### PR TITLE
v0.2.0.dev — tokens discriminados, contexto ativo e média/turno

### DIFF
--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -133,7 +133,10 @@ claude_dashboard/
 - [ ] View `now` com `rich.Live`
 - [ ] Entrypoint CLI
 
-### v0.2 — Agregações históricas
+### v0.2 — Enriquecimento da view 'now' e agregações históricas
+- [x] Tokens discriminados na tabela (total / in·out / cache r·w / turno)
+- [x] Coluna `Ctx` com tokens do contexto ativo (último turno assistant)
+- [x] `SessionStats.last_usage`, `active_context_tokens`, `tokens_per_turn`
 - [ ] View `today`
 - [ ] View `tools`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.1.0.dev0"
+version = "0.2.0.dev0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.2.0.dev0"

--- a/src/claude_dash/aggregator.py
+++ b/src/claude_dash/aggregator.py
@@ -37,6 +37,9 @@ def _apply_entry(entry: dict, stats: SessionStats) -> None:
         model = normalize_model(raw) if raw != "unknown" else raw
         stats.usage_by_model.setdefault(model, Usage())
         stats.usage_by_model[model] += u
+        # last_usage = snapshot do turno mais recente (não acumulado);
+        # útil para inferir o tamanho atual do contexto ativo.
+        stats.last_usage = u
 
     for tool_name in iter_tool_uses(entry):
         stats.tools[tool_name] = stats.tools.get(tool_name, 0) + 1

--- a/src/claude_dash/cache.py
+++ b/src/claude_dash/cache.py
@@ -78,6 +78,8 @@ def deserialize_stats(d: dict) -> SessionStats:
         for model, u_dict in (d.get("usage_by_model") or {}).items()
     }
     transcript_path = d.get("transcript_path")
+    last_usage_dict = d.get("last_usage")
+    last_usage = Usage(**last_usage_dict) if last_usage_dict else None
     return SessionStats(
         session_id=d["session_id"],
         cwd=Path(d.get("cwd") or ""),
@@ -92,6 +94,7 @@ def deserialize_stats(d: dict) -> SessionStats:
         messages_user=int(d.get("messages_user") or 0),
         messages_assistant=int(d.get("messages_assistant") or 0),
         subagents=int(d.get("subagents") or 0),
+        last_usage=last_usage,
     )
 
 

--- a/src/claude_dash/models.py
+++ b/src/claude_dash/models.py
@@ -71,6 +71,11 @@ class SessionStats:
     messages_user: int = 0
     messages_assistant: int = 0
     subagents: int = 0                    # número de transcripts filhos
+    # Snapshot do `message.usage` da ÚLTIMA entrada assistant vista.
+    # Aproxima o "contexto ativo" da sessão agora — o que o harness do
+    # Claude Code envia como input na próxima chamada (input_tokens +
+    # cache_read_input_tokens) é o tamanho real do contexto em uso.
+    last_usage: Usage | None = None
 
     @property
     def total_usage(self) -> Usage:
@@ -88,3 +93,26 @@ class SessionStats:
             self.usage_by_model.items(),
             key=lambda kv: kv[1].output_tokens,
         )[0]
+
+    @property
+    def active_context_tokens(self) -> int:
+        """Tamanho aproximado do contexto ativo: input + cache_read do último turno.
+
+        O harness envia, a cada chamada, `input_tokens` novos + todos os
+        tokens de `cache_read` (reaproveitados). Esse somatório
+        representa o tamanho efetivo do prompt que o modelo recebe —
+        ou seja, o contexto em uso. Entradas de cache_creation contam
+        como parte do prompt quando escritas, mas como leitura em
+        turnos seguintes; usar cache_read+input cobre o caso estável.
+        """
+        if self.last_usage is None:
+            return 0
+        return self.last_usage.input_tokens + self.last_usage.cache_read
+
+    @property
+    def tokens_per_turn(self) -> float:
+        """Output médio por mensagem assistant (0 se não houver msgs)."""
+        if self.messages_assistant == 0:
+            return 0.0
+        total_out = sum(u.output_tokens for u in self.usage_by_model.values())
+        return total_out / self.messages_assistant

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -73,6 +73,31 @@ def _tools_summary(s: SessionStats, top_n: int = 4) -> str:
     return " ".join(f"{name}:{count}" for name, count in top)
 
 
+def _tokens_breakdown(s: SessionStats) -> str:
+    """Célula multi-linha: total (bold) + in/out + cache r/w + /turno.
+
+    Usa markup Rich para colorir: total em branco forte, breakdown em dim.
+    """
+    total = s.total_usage
+    per_turn = s.tokens_per_turn
+    # Soma por tipo (agregando todos os modelos da sessão + subagentes)
+    lines = [
+        f"[bold]{_fmt_tokens(total.total)}[/bold]",
+        f"[dim]in {_fmt_tokens(total.input_tokens)} / out {_fmt_tokens(total.output_tokens)}[/dim]",
+        f"[dim]cache r {_fmt_tokens(total.cache_read)} / w {_fmt_tokens(total.cache_creation_1h + total.cache_creation_5m)}[/dim]",
+        f"[dim]/turno {_fmt_tokens(int(per_turn))}[/dim]",
+    ]
+    return "\n".join(lines)
+
+
+def _context_cell(s: SessionStats) -> str:
+    """Tokens em uso no contexto ativo (último turno assistant)."""
+    ctx = s.active_context_tokens
+    if ctx == 0:
+        return "—"
+    return _fmt_tokens(ctx)
+
+
 def _session_table(sessions: list[SessionStats]) -> Table:
     table = Table(
         title=None,
@@ -86,16 +111,17 @@ def _session_table(sessions: list[SessionStats]) -> Table:
     table.add_column("SID", width=10)
     table.add_column("CWD", overflow="ellipsis")
     table.add_column("Idade", justify="right", width=8)
-    table.add_column("Modelo", width=16)
-    table.add_column("Tokens", justify="right", width=10)
+    table.add_column("Modelo", width=14)
+    table.add_column("Tokens (total / in·out / cache r·w / turno)",
+                     justify="right", width=22)
+    table.add_column("Ctx", justify="right", width=7)
     table.add_column("Custo", justify="right", width=9)
     table.add_column("Msgs", justify="right", width=10)
-    table.add_column("Subagts", justify="right", width=7)
+    table.add_column("Sub", justify="right", width=4)
     table.add_column("Tools (top 4)", overflow="fold")
 
     now_ms = int(time.time() * 1000)
     for s in sessions:
-        total_tokens = s.total_usage.total
         cost = _total_cost(s)
         age_ms = now_ms - s.started_at_ms if s.started_at_ms else 0
 
@@ -113,11 +139,13 @@ def _session_table(sessions: list[SessionStats]) -> Table:
             _fmt_short_cwd(s.cwd),
             _fmt_duration(age_ms) if age_ms else "—",
             dom_short,
-            _fmt_tokens(total_tokens),
+            _tokens_breakdown(s),
+            _context_cell(s),
             f"${cost:,.2f}",
             msgs,
             str(s.subagents),
             _tools_summary(s),
+            end_section=True,  # linha divisória entre sessões
         )
     return table
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -245,3 +245,76 @@ def test_collect_live_sessions_single_scan(
     result = aggregator.collect_live_sessions(use_cache=False)
     assert result == []
     assert scan_count["n"] == 1
+
+
+def test_last_usage_tracks_most_recent_assistant(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """last_usage deve ser snapshot da última assistant entry — não acumulado."""
+    entries = [
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 10, "cache_read_input_tokens": 100}}},
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 20, "cache_read_input_tokens": 5000}}},
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 3, "cache_read_input_tokens": 7777}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    assert stats.last_usage is not None
+    # Snapshot do último turno (não soma dos três)
+    assert stats.last_usage.input_tokens == 3
+    assert stats.last_usage.cache_read == 7777
+    # Contexto ativo = input + cache_read do último turno
+    assert stats.active_context_tokens == 3 + 7777
+
+
+def test_last_usage_is_none_without_assistant(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """Sem entrada assistant, last_usage fica None e context=0."""
+    entries = [{"type": "user"}, {"type": "system"}]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    assert stats.last_usage is None
+    assert stats.active_context_tokens == 0
+
+
+def test_tokens_per_turn(tmp_path: Path, isolated_cache: Path) -> None:
+    """tokens_per_turn = total_output / messages_assistant."""
+    entries = [
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"output_tokens": 100}}},
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"output_tokens": 400}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    # (100 + 400) / 2 = 250
+    assert stats.tokens_per_turn == 250.0
+
+
+def test_tokens_per_turn_zero_when_no_assistant(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    entries = [{"type": "user"}]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    assert stats.tokens_per_turn == 0.0
+
+
+def test_last_usage_survives_cache_roundtrip(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """Após save+load do cache, last_usage deve ser preservado."""
+    entries = [
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 42, "cache_read_input_tokens": 999}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    build_stats_for_transcript(ref, use_cache=True)
+    # Segunda chamada: carrega do cache
+    stats2 = build_stats_for_transcript(ref, use_cache=True)
+    assert stats2.last_usage is not None
+    assert stats2.last_usage.input_tokens == 42
+    assert stats2.last_usage.cache_read == 999


### PR DESCRIPTION
## Summary

Enriquecimento da view \`now\` com 3 informações adicionais por sessão:

1. **Discriminação de tokens** — total + in/out + cache r/w + /turno
2. **Contexto ativo** (coluna \`Ctx\`) — tokens em uso no último turno
3. **Média por turno** — output médio por mensagem assistant

Modelagem:
- \`SessionStats.last_usage\` (snapshot do último \`message.usage\`, não acumulado)
- Propriedades \`active_context_tokens\` e \`tokens_per_turn\`
- Cache serializa/deserializa \`last_usage\` no round-trip

Version bump: \`0.1.0.dev0\` → \`0.2.0.dev0\` (MINOR, compatível).

## Test plan

- [x] 60 testes passando (+5 novos)
- [x] Render real contra 3 sessões vivas — novo layout cabe em terminal 170 cols
- [x] Cache round-trip preserva \`last_usage\`
- [ ] Validar em terminal mais estreito (≤120 cols) — talvez \`Tokens\` precise ser mais compacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)