### PR TITLE
v0.3 — view 'today' com filtragem exata por timestamp

### DIFF
--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -133,12 +133,15 @@ claude_dashboard/
 - [ ] View `now` com `rich.Live`
 - [ ] Entrypoint CLI
 
-### v0.2 — Enriquecimento da view 'now' e agregações históricas
+### v0.2 — Enriquecimento da view 'now'
 - [x] Tokens discriminados na tabela (total / in·out / cache r·w / turno)
 - [x] Coluna `Ctx` com tokens do contexto ativo (último turno assistant)
 - [x] `SessionStats.last_usage`, `active_context_tokens`, `tokens_per_turn`
-- [ ] View `today`
-- [ ] View `tools`
+
+### v0.3 — Agregações históricas
+- [x] View `today` (dia corrente, filtragem **exata** por timestamp das entries)
+- [x] `aggregator.aggregate_transcript_since` / `collect_sessions_since`
+- [ ] View `tools` (últimas 24h)
 
 ### v0.3 — Drill-down
 - [ ] View `session <sid>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.2.0.dev0"
+version = "0.3.0.dev0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.2.0.dev0"
+__version__ = "0.3.0.dev0"

--- a/src/claude_dash/aggregator.py
+++ b/src/claude_dash/aggregator.py
@@ -201,18 +201,27 @@ def collect_sessions_since(since_ms: int) -> list[SessionStats]:
         ls = live_by_sid.get(ref.session_id)
         stats = aggregate_transcript_since(ref, since_ms, live=ls)
 
-        subs_in_window = [
+        # Pre-filtra por mtime (barato) para evitar abrir arquivos
+        # claramente fora da janela — mas só conta como subagente "ativo"
+        # aquele que realmente contribuiu no período (messages ou usage),
+        # para não inflar stats.subagents em casos onde mtime foi mexido
+        # sem appends novos (touch, fs repair, etc).
+        subs_candidates = [
             s for s in subs_by_parent.get(ref.session_id, [])
             if s.mtime_ms >= since_ms
         ]
-        stats.subagents = len(subs_in_window)
-        for sub_ref in subs_in_window:
+        active_subagents = 0
+        for sub_ref in subs_candidates:
             sub_stats = aggregate_transcript_since(sub_ref, since_ms)
+            if sub_stats.messages_assistant == 0 and sub_stats.total_usage.total == 0:
+                continue
+            active_subagents += 1
             for model, usage in sub_stats.usage_by_model.items():
                 stats.usage_by_model.setdefault(model, Usage())
                 stats.usage_by_model[model] += usage
             for tool_name, count in sub_stats.tools.items():
                 stats.tools[tool_name] = stats.tools.get(tool_name, 0) + count
+        stats.subagents = active_subagents
 
         # Só retorna sessões com atividade real na janela
         if stats.total_usage.total > 0 or stats.tools or stats.messages_assistant:

--- a/src/claude_dash/aggregator.py
+++ b/src/claude_dash/aggregator.py
@@ -128,6 +128,100 @@ def build_stats_for_transcript(
     return stats
 
 
+def aggregate_transcript_since(
+    ref: TranscriptRef,
+    since_ms: int,
+    live: LiveSession | None = None,
+) -> SessionStats:
+    """Agrega um transcript contando APENAS entries com timestamp >= since_ms.
+
+    Bypassa o cache porque este sempre guarda totais acumulados desde
+    o início da sessão. Para janelas de tempo (ex: "hoje"), precisamos
+    re-parsear do zero filtrando por `timestamp`. Entradas sem campo
+    `timestamp` (ex: `system`, `attachment`) não são contadas — isso é
+    intencional: usage/tools só vêm de assistant/user, que têm
+    timestamp.
+    """
+    stats = SessionStats(
+        session_id=ref.session_id,
+        cwd=live.cwd if live else Path(),
+        started_at_ms=live.started_at_ms if live else 0,
+        transcript_path=ref.path,
+    )
+
+    if live is not None:
+        stats.pid = live.pid
+        stats.alive = live.alive
+        stats.cwd = live.cwd
+        stats.version = live.version
+        if not stats.started_at_ms:
+            stats.started_at_ms = live.started_at_ms
+
+    for _offset, entry in iter_entries(ref.path):
+        ts = extract_timestamp_ms(entry)
+        # Descarta entries sem timestamp OU antes da janela
+        if ts is None or ts < since_ms:
+            continue
+        _apply_entry(entry, stats)
+
+    if not stats.last_activity_ms:
+        stats.last_activity_ms = ref.mtime_ms
+
+    return stats
+
+
+def collect_sessions_since(since_ms: int) -> list[SessionStats]:
+    """Coleta SessionStats de sessões com atividade desde `since_ms`.
+
+    Diferente de `collect_live_sessions`:
+    - Inclui sessões mortas (desde que o transcript tenha atividade no
+      período)
+    - Totais são restritos ao período (exact), não cumulativos
+    - Ordenação por última atividade (mais recente primeiro)
+
+    Subagentes são agregados apenas se também tiveram atividade no
+    período.
+    """
+    live = discover_live_sessions()
+    all_transcripts = discover_transcripts()
+    live_by_sid = {ls.session_id: ls for ls in live}
+
+    main_candidates = [
+        t for t in all_transcripts
+        if not t.is_subagent and t.mtime_ms >= since_ms
+    ]
+
+    subs_by_parent: dict[str, list[TranscriptRef]] = {}
+    for t in all_transcripts:
+        if t.is_subagent and t.parent_session_id:
+            subs_by_parent.setdefault(t.parent_session_id, []).append(t)
+
+    out: list[SessionStats] = []
+    for ref in main_candidates:
+        ls = live_by_sid.get(ref.session_id)
+        stats = aggregate_transcript_since(ref, since_ms, live=ls)
+
+        subs_in_window = [
+            s for s in subs_by_parent.get(ref.session_id, [])
+            if s.mtime_ms >= since_ms
+        ]
+        stats.subagents = len(subs_in_window)
+        for sub_ref in subs_in_window:
+            sub_stats = aggregate_transcript_since(sub_ref, since_ms)
+            for model, usage in sub_stats.usage_by_model.items():
+                stats.usage_by_model.setdefault(model, Usage())
+                stats.usage_by_model[model] += usage
+            for tool_name, count in sub_stats.tools.items():
+                stats.tools[tool_name] = stats.tools.get(tool_name, 0) + count
+
+        # Só retorna sessões com atividade real na janela
+        if stats.total_usage.total > 0 or stats.tools or stats.messages_assistant:
+            out.append(stats)
+
+    out.sort(key=lambda s: s.last_activity_ms, reverse=True)
+    return out
+
+
 def collect_live_sessions(use_cache: bool = True) -> list[SessionStats]:
     """Coleta SessionStats de todas as sessões atualmente vivas.
 

--- a/src/claude_dash/cli.py
+++ b/src/claude_dash/cli.py
@@ -30,8 +30,9 @@ def main(argv: list[str] | None = None) -> int:
 
         return run_now()
     if args.command == "today":
-        print("TODO: view 'today' — agregado do dia (v0.2)")
-        return 0
+        from claude_dash.views.today import run as run_today
+
+        return run_today()
     if args.command == "tools":
         print("TODO: view 'tools' — breakdown de tool_use (v0.2)")
         return 0

--- a/src/claude_dash/views/today.py
+++ b/src/claude_dash/views/today.py
@@ -1,0 +1,165 @@
+"""View 'today' — agregado do dia corrente desde 00:00 local.
+
+Render estático (um único print), diferente do `now` que é Live.
+Os totais exibidos são **exatos da janela** — entradas do transcript
+anteriores a 00:00 são ignoradas.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from claude_dash.aggregator import collect_sessions_since
+from claude_dash.models import SessionStats
+from claude_dash.pricing import cost_of
+from claude_dash.views.now import (
+    _fmt_duration,
+    _fmt_short_cwd,
+    _fmt_tokens,
+    _short_sid,
+    _tools_summary,
+    _total_cost,
+)
+
+
+def today_start_ms() -> int:
+    """Epoch ms do início do dia corrente no timezone local."""
+    now = datetime.now()
+    start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    return int(start.timestamp() * 1000)
+
+
+def _header(sessions: list[SessionStats], since_ms: int) -> Panel:
+    total_tokens = sum(s.total_usage.total for s in sessions)
+    total_cost = sum(_total_cost(s) for s in sessions)
+    total_msgs_user = sum(s.messages_user for s in sessions)
+    total_msgs_asst = sum(s.messages_assistant for s in sessions)
+    alive = sum(1 for s in sessions if s.alive)
+    dead = len(sessions) - alive
+
+    since_str = datetime.fromtimestamp(since_ms / 1000).strftime("%Y-%m-%d %H:%M")
+    now_str = datetime.now().strftime("%H:%M:%S")
+
+    # Layout em 2 linhas para caber em terminais ~80 cols
+    header = Text()
+    header.append(f" {since_str}  →  {now_str}   ", style="dim")
+    header.append(f"{len(sessions)}", style="bold cyan")
+    header.append(" sessões   ", style="dim")
+    header.append(f"[{alive} vivas · {dead} mortas]\n", style="dim")
+    header.append(f" Tokens ", style="dim")
+    header.append(f"{_fmt_tokens(total_tokens)}", style="bold")
+    header.append("   Custo ", style="dim")
+    header.append(f"${total_cost:,.2f}", style="bold yellow")
+    header.append("   Mensagens ", style="dim")
+    header.append(f"{total_msgs_user}u/{total_msgs_asst}a", style="bold")
+
+    return Panel(header, border_style="cyan", title="claude-dash today", title_align="left")
+
+
+def _session_table(sessions: list[SessionStats]) -> Panel:
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        border_style="dim",
+        expand=True,
+        padding=(0, 1),
+    )
+    table.add_column("SID", width=10)
+    table.add_column("CWD", overflow="ellipsis")
+    table.add_column("Estado", width=7, justify="center")
+    table.add_column("Última atividade", width=18)
+    table.add_column("Modelo", width=14)
+    table.add_column("Tokens", justify="right", width=10)
+    table.add_column("Custo", justify="right", width=9)
+    table.add_column("Msgs", justify="right", width=10)
+    table.add_column("Sub", justify="right", width=4)
+    table.add_column("Tools (top 4)", overflow="fold")
+
+    for s in sessions:
+        total = s.total_usage.total
+        cost = _total_cost(s)
+
+        state = "[green]viva[/green]" if s.alive else "[red]morta[/red]"
+        dom_model = s.dominant_model or "—"
+        dom_short = dom_model.replace("claude-", "") if dom_model != "—" else dom_model
+
+        last_activity = (
+            datetime.fromtimestamp(s.last_activity_ms / 1000).strftime("%H:%M:%S")
+            if s.last_activity_ms
+            else "—"
+        )
+
+        msgs = f"{s.messages_user}u/{s.messages_assistant}a"
+
+        table.add_row(
+            _short_sid(s.session_id),
+            _fmt_short_cwd(s.cwd),
+            state,
+            last_activity,
+            dom_short,
+            _fmt_tokens(total),
+            f"${cost:,.2f}",
+            msgs,
+            str(s.subagents),
+            _tools_summary(s),
+        )
+
+    if len(sessions) == 0:
+        return Panel(
+            Text("Nenhuma sessão com atividade hoje ainda.", style="dim"),
+            title="Sessões",
+            title_align="left",
+            border_style="dim",
+        )
+
+    return Panel(table, title="Sessões", title_align="left", border_style="dim")
+
+
+def _tools_aggregate(sessions: list[SessionStats], top_n: int = 10) -> Panel:
+    totals: dict[str, int] = {}
+    for s in sessions:
+        for name, count in s.tools.items():
+            totals[name] = totals.get(name, 0) + count
+
+    if not totals:
+        return Panel(
+            Text("Nenhum tool usado.", style="dim"),
+            title="Tools (todas as sessões)",
+            title_align="left",
+            border_style="dim",
+        )
+
+    top = sorted(totals.items(), key=lambda kv: -kv[1])[:top_n]
+    total_calls = sum(count for _, count in top)
+
+    lines = []
+    for name, count in top:
+        pct = 100 * count / total_calls if total_calls else 0
+        lines.append(f"  [bold cyan]{name:<16}[/bold cyan] [bold]{count:>4}[/bold]  [dim]({pct:4.1f}%)[/dim]")
+
+    content = "\n".join(lines)
+    if len(totals) > top_n:
+        content += f"\n[dim]  … e mais {len(totals) - top_n} tool(s) com menor uso[/dim]"
+
+    return Panel(
+        content,
+        title=f"Top {min(top_n, len(totals))} tools",
+        title_align="left",
+        border_style="dim",
+    )
+
+
+def run() -> int:
+    """Imprime snapshot estático do dia corrente. Retorna exit code."""
+    console = Console()
+    since_ms = today_start_ms()
+    sessions = collect_sessions_since(since_ms)
+
+    console.print(_header(sessions, since_ms))
+    console.print(_session_table(sessions))
+    console.print(_tools_aggregate(sessions))
+    return 0

--- a/src/claude_dash/views/today.py
+++ b/src/claude_dash/views/today.py
@@ -134,7 +134,11 @@ def _tools_aggregate(sessions: list[SessionStats], top_n: int = 10) -> Panel:
         )
 
     top = sorted(totals.items(), key=lambda kv: -kv[1])[:top_n]
-    total_calls = sum(count for _, count in top)
+    # Denominador é a soma de TODOS os tools, não só os exibidos — assim
+    # as porcentagens refletem share real, e a tail (tools fora do top N)
+    # "some" em forma de pct não-mostrados que fazem a soma visível
+    # ficar abaixo de 100% quando existe cauda.
+    total_calls = sum(totals.values())
 
     lines = []
     for name, count in top:

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -359,6 +359,63 @@ def test_since_excludes_untimed_entries(
     assert stats.messages_assistant == 0
 
 
+def test_collect_sessions_since_counts_only_active_subagents(
+    tmp_path: Path, isolated_cache: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Subagent com mtime dentro da janela mas entries todas pré-cutoff
+    não deve inflar stats.subagents."""
+    from claude_dash import aggregator
+    from claude_dash.aggregator import collect_sessions_since
+    from claude_dash.discover import TranscriptRef
+
+    cutoff = 1776758400000  # 2026-04-21 00:00 UTC
+
+    # Parent: entrada válida na janela
+    parent_entries = [
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 1}}},
+    ]
+    parent_file = tmp_path / "parent.jsonl"
+    parent_file.write_text("\n".join(json.dumps(e) for e in parent_entries) + "\n")
+
+    # Subagent 1: ATIVO — entry na janela
+    sub_active_entries = [
+        {"type": "assistant", "timestamp": "2026-04-21T11:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 100}}},
+    ]
+    sub_active_file = tmp_path / "sub_active.jsonl"
+    sub_active_file.write_text("\n".join(json.dumps(e) for e in sub_active_entries) + "\n")
+
+    # Subagent 2: FANTASMA — mtime recente mas entry pré-cutoff
+    sub_ghost_entries = [
+        {"type": "assistant", "timestamp": "2026-04-20T15:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 999}}},
+    ]
+    sub_ghost_file = tmp_path / "sub_ghost.jsonl"
+    sub_ghost_file.write_text("\n".join(json.dumps(e) for e in sub_ghost_entries) + "\n")
+
+    now_ms = int(parent_file.stat().st_mtime * 1000)
+    refs = [
+        TranscriptRef(session_id="parent", path=parent_file, workspace="-ws",
+                      mtime_ms=now_ms),
+        TranscriptRef(session_id="sub_active", path=sub_active_file,
+                      workspace="-ws", mtime_ms=now_ms,
+                      is_subagent=True, parent_session_id="parent"),
+        TranscriptRef(session_id="sub_ghost", path=sub_ghost_file,
+                      workspace="-ws", mtime_ms=now_ms,  # mtime recente
+                      is_subagent=True, parent_session_id="parent"),
+    ]
+
+    monkeypatch.setattr(aggregator, "discover_live_sessions", lambda: [])
+    monkeypatch.setattr(aggregator, "discover_transcripts", lambda: refs)
+
+    result = collect_sessions_since(cutoff)
+    assert len(result) == 1
+    # Apenas o sub_active deve contar — o ghost teve mtime dentro da
+    # janela mas nenhuma entry nela
+    assert result[0].subagents == 1
+
+
 def test_collect_sessions_since_filters_by_mtime(
     tmp_path: Path, isolated_cache: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -318,3 +318,84 @@ def test_last_usage_survives_cache_roundtrip(
     assert stats2.last_usage is not None
     assert stats2.last_usage.input_tokens == 42
     assert stats2.last_usage.cache_read == 999
+
+
+# --- aggregate_transcript_since -----------------------------------------
+
+
+def test_since_filters_before_cutoff(tmp_path: Path, isolated_cache: Path) -> None:
+    """Entradas com timestamp < since_ms são descartadas."""
+    from claude_dash.aggregator import aggregate_transcript_since
+
+    entries = [
+        {"type": "assistant", "timestamp": "2026-04-20T10:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 111}}},
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 222}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    # Cutoff = 2026-04-21 00:00 UTC
+    cutoff = 1776758400000
+    stats = aggregate_transcript_since(ref, since_ms=cutoff)
+    # Só a entrada de 21/04 conta
+    assert stats.usage_by_model["m"].input_tokens == 222
+    assert stats.messages_assistant == 1
+
+
+def test_since_excludes_untimed_entries(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """Entradas sem `timestamp` não contam (conservador — sem data não dá
+    pra afirmar que estão na janela)."""
+    from claude_dash.aggregator import aggregate_transcript_since
+
+    entries = [
+        {"type": "assistant",  # sem timestamp
+         "message": {"model": "m", "usage": {"input_tokens": 10}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    stats = aggregate_transcript_since(ref, since_ms=0)
+    assert stats.usage_by_model == {}
+    assert stats.messages_assistant == 0
+
+
+def test_collect_sessions_since_filters_by_mtime(
+    tmp_path: Path, isolated_cache: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """collect_sessions_since ignora transcripts com mtime antes da janela."""
+    from claude_dash import aggregator
+    from claude_dash.aggregator import collect_sessions_since
+    from claude_dash.discover import TranscriptRef
+
+    # Transcripts sintéticos: um antigo (mtime pequeno) e um novo
+    old_entries = [
+        {"type": "assistant", "timestamp": "2026-04-20T10:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 1}}},
+    ]
+    new_entries = [
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 999}}},
+    ]
+
+    old_file = tmp_path / "old.jsonl"
+    new_file = tmp_path / "new.jsonl"
+    old_file.write_text("\n".join(json.dumps(e) for e in old_entries) + "\n")
+    new_file.write_text("\n".join(json.dumps(e) for e in new_entries) + "\n")
+    # Força mtime antigo no old_file
+    os.utime(old_file, (1700000000, 1700000000))
+
+    refs = [
+        TranscriptRef(session_id="old", path=old_file, workspace="-ws",
+                      mtime_ms=int(old_file.stat().st_mtime * 1000)),
+        TranscriptRef(session_id="new", path=new_file, workspace="-ws",
+                      mtime_ms=int(new_file.stat().st_mtime * 1000)),
+    ]
+
+    monkeypatch.setattr(aggregator, "discover_live_sessions", lambda: [])
+    monkeypatch.setattr(aggregator, "discover_transcripts", lambda: refs)
+
+    cutoff = 1776758400000  # 2026-04-21 00:00 UTC
+    result = collect_sessions_since(cutoff)
+    sids = [s.session_id for s in result]
+    assert "new" in sids
+    assert "old" not in sids

--- a/tests/test_today.py
+++ b/tests/test_today.py
@@ -1,0 +1,58 @@
+"""Testes da view 'today' — foco em helpers puros (sem TTY)."""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from claude_dash.models import SessionStats, Usage
+from claude_dash.views.today import _tools_aggregate
+
+
+def _stats_with_tools(tools: dict[str, int]) -> SessionStats:
+    return SessionStats(
+        session_id="x",
+        cwd="/x",  # type: ignore[arg-type]
+        started_at_ms=0,
+        tools=tools,
+    )
+
+
+def test_tools_percentages_use_full_total_not_top_slice() -> None:
+    """Com mais tools que top_n, os % exibidos devem refletir share do TOTAL,
+    não share do top-N (regressão do achado #1 do review do PR #3)."""
+    # 12 tools — top 10 serão exibidos, 2 ficam na cauda
+    tools = {f"T{i:02d}": 100 - i for i in range(12)}
+    sessions = [_stats_with_tools(tools)]
+
+    panel = _tools_aggregate(sessions, top_n=10)
+    # `panel.renderable` aqui é uma string com markup Rich. Remove tags
+    # entre colchetes para checar o conteúdo literal.
+    raw = str(panel.renderable)
+    stripped = re.sub(r"\[/?[^\]]*\]", "", raw)
+
+    # T00 tem 100 calls; total_calls deve ser sum(100..89) = 1134
+    # % correto ≈ 8.8, NÃO ~10.47 (bug do top-N-denominator)
+    match = re.search(r"T00\s+100\s+\(\s*([\d.]+)%\)", stripped)
+    assert match is not None, f"T00 não encontrado no render: {stripped[:500]}"
+    pct = float(match.group(1))
+    assert 8.5 < pct < 9.2, f"T00 pct={pct}; esperado ~8.8, não ~10.47"
+
+
+def test_tools_percentages_sum_to_100_when_no_tail() -> None:
+    """Sem cauda (tools <= top_n), os % do top N somam 100."""
+    tools = {"A": 60, "B": 30, "C": 10}
+    sessions = [_stats_with_tools(tools)]
+
+    panel = _tools_aggregate(sessions, top_n=10)
+    stripped = re.sub(r"\[/?[^\]]*\]", "", str(panel.renderable))
+
+    pcts = [float(m.group(1)) for m in re.finditer(r"\(\s*([\d.]+)%\)", stripped)]
+    assert len(pcts) == 3
+    assert sum(pcts) == pytest.approx(100.0, abs=0.1)
+
+
+def test_tools_empty_returns_fallback_panel() -> None:
+    sessions = [_stats_with_tools({})]
+    panel = _tools_aggregate(sessions)
+    assert "Nenhum tool usado" in str(panel.renderable)


### PR DESCRIPTION
## Summary

Novo subcomando \`claude-dash today\` — snapshot estático do dia corrente (00:00 local → agora) com filtragem **exata**: totais refletem apenas entries com \`timestamp\` na janela, não o cumulativo da sessão.

Infra reutilizável:
- \`aggregator.aggregate_transcript_since(ref, since_ms, live=None)\` — re-parseia filtrando por entry timestamp; bypassa cache (que é cumulativo)
- \`aggregator.collect_sessions_since(since_ms)\` — varre todos os transcripts (vivos e mortos), filtra por mtime + entry timestamp

View:
- Header 2-linhas: janela, contagem vivas/mortas, tokens, custo, msgs
- Tabela por sessão: Estado (viva/morta), última atividade, modelo, tokens/custo do período
- Bottom: top 10 tools com porcentagens

Bump: \`0.2.0.dev0\` → \`0.3.0.dev0\`.

## Test plan

- [x] 66 testes passando (+3 para \`aggregate_transcript_since\`)
- [x] Smoke test real: 5 sessões detectadas hoje (3 vivas, 2 mortas de madrugada que o \`now\` não mostrava)
- [x] Filtragem correta confirmada: entries com timestamp pré-cutoff descartadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)