### PR TITLE
v0.5 — view 'session <sid>' com drill-down completo

### DIFF
--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -148,6 +148,13 @@ claude_dashboard/
 - [x] `aggregator.collect_tool_usage_since` (subagents atribuídos ao parent)
 - [x] Sparkline ASCII por tool + histograma agregado por hora
 
+### v0.5 — Drill-down por sessão
+- [x] View `session <sid>` com prefix matching
+- [x] `Turn` dataclass (index, timestamp, model, usage, tools_called)
+- [x] `aggregator.extract_turns` — um Turn por entrada assistant com usage
+- [x] Timeline tail (últimos 20 turnos com custo estimado por turno)
+- [x] Painel de subagentes com custo individual
+
 ### v0.3 — Drill-down
 - [ ] View `session <sid>`
 - [ ] Timeline de turnos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.4.0.dev0"
+version = "0.5.0.dev0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.4.0.dev0"
+__version__ = "0.5.0.dev0"

--- a/src/claude_dash/aggregator.py
+++ b/src/claude_dash/aggregator.py
@@ -238,10 +238,12 @@ def extract_turns(ref: TranscriptRef) -> list[Turn]:
     `tools_called` do turno são os `tool_use` encontrados no mesmo
     `message.content[]`. Turnos sem timestamp herdam o timestamp da
     entry imediatamente anterior que tinha um (fallback para ordenar
-    sem perder informação).
+    sem perder informação). Se nenhum timestamp foi visto antes do
+    primeiro turno, o `timestamp_ms` fica 0 e a view exibe "—" em vez
+    do epoch 1970 — isso é tratado em `_timeline` e `_header`.
     """
     turns: list[Turn] = []
-    last_ts = 0
+    last_ts: int | None = None
     for _offset, entry in iter_entries(ref.path):
         ts = extract_timestamp_ms(entry)
         if ts is not None:
@@ -257,10 +259,13 @@ def extract_turns(ref: TranscriptRef) -> list[Turn]:
         model_raw = extract_model(entry) or "unknown"
         tools = list(iter_tool_uses(entry))
 
+        # Se não há ts nem last_ts, salva 0 — o display checa e exibe "—"
+        effective_ts = ts if ts is not None else (last_ts if last_ts is not None else 0)
+
         turns.append(
             Turn(
                 index=len(turns),
-                timestamp_ms=ts if ts is not None else last_ts,
+                timestamp_ms=effective_ts,
                 model=model_raw,
                 usage=u,
                 tools_called=tools,

--- a/src/claude_dash/aggregator.py
+++ b/src/claude_dash/aggregator.py
@@ -10,7 +10,7 @@ from claude_dash.discover import (
     discover_live_sessions,
     discover_transcripts,
 )
-from claude_dash.models import SessionStats, ToolUsageStats, Usage
+from claude_dash.models import SessionStats, ToolUsageStats, Turn, Usage
 from claude_dash.parser import (
     extract_model,
     extract_timestamp_ms,
@@ -229,6 +229,45 @@ def collect_sessions_since(since_ms: int) -> list[SessionStats]:
 
     out.sort(key=lambda s: s.last_activity_ms, reverse=True)
     return out
+
+
+def extract_turns(ref: TranscriptRef) -> list[Turn]:
+    """Extrai a lista de turnos assistant de um transcript.
+
+    Um turno = uma entrada assistant com `message.usage` presente. Os
+    `tools_called` do turno são os `tool_use` encontrados no mesmo
+    `message.content[]`. Turnos sem timestamp herdam o timestamp da
+    entry imediatamente anterior que tinha um (fallback para ordenar
+    sem perder informação).
+    """
+    turns: list[Turn] = []
+    last_ts = 0
+    for _offset, entry in iter_entries(ref.path):
+        ts = extract_timestamp_ms(entry)
+        if ts is not None:
+            last_ts = ts
+
+        if entry.get("type") != "assistant":
+            continue
+
+        u = extract_usage(entry)
+        if u is None:
+            continue
+
+        model_raw = extract_model(entry) or "unknown"
+        tools = list(iter_tool_uses(entry))
+
+        turns.append(
+            Turn(
+                index=len(turns),
+                timestamp_ms=ts if ts is not None else last_ts,
+                model=model_raw,
+                usage=u,
+                tools_called=tools,
+            )
+        )
+
+    return turns
 
 
 def collect_tool_usage_since(since_ms: int) -> dict[str, ToolUsageStats]:

--- a/src/claude_dash/cli.py
+++ b/src/claude_dash/cli.py
@@ -38,8 +38,9 @@ def main(argv: list[str] | None = None) -> int:
 
         return run_tools()
     if args.command == "session":
-        print(f"TODO: view 'session' para sid={args.sid!r} (v0.3)")
-        return 0
+        from claude_dash.views.session import run as run_session
+
+        return run_session(args.sid)
     return 2  # pragma: no cover
 
 

--- a/src/claude_dash/models.py
+++ b/src/claude_dash/models.py
@@ -55,6 +55,29 @@ class ToolStat:
 
 
 @dataclass(slots=True)
+class Turn:
+    """Um turno assistant numa sessão — unidade natural para drill-down.
+
+    Diferente de `SessionStats` (agregado) ou `ToolUsageStats`
+    (cross-session), um `Turn` representa *uma* resposta do modelo:
+    tokens consumidos nessa resposta específica e tools que ela
+    disparou. A ordem dentro da sessão é dada por `index` (0-based).
+    """
+
+    index: int
+    timestamp_ms: int
+    model: str
+    usage: Usage
+    tools_called: list[str] = field(default_factory=list)
+
+    @property
+    def cost_estimate_key(self) -> str:
+        """Chave normalizada do modelo para lookup em PRICING."""
+        from claude_dash.pricing import normalize_model
+        return normalize_model(self.model)
+
+
+@dataclass(slots=True)
 class ToolUsageStats:
     """Estatísticas globais de uso de uma ferramenta numa janela temporal.
 

--- a/src/claude_dash/views/session.py
+++ b/src/claude_dash/views/session.py
@@ -188,7 +188,8 @@ def _subagents_panel(session_id: str) -> Panel | None:
     table.add_column("Subagent ID", width=20)
     table.add_column("Tokens", justify="right", width=10)
     table.add_column("Custo", justify="right", width=9)
-    table.add_column("Msgs", justify="right", width=6)
+    # Formato u/a (user/assistant) alinhado com o resto do dashboard
+    table.add_column("Msgs (u/a)", justify="right", width=10)
     table.add_column("Tools", overflow="fold")
 
     for sub in subs:
@@ -203,7 +204,7 @@ def _subagents_panel(session_id: str) -> Panel | None:
             sub.session_id,
             _fmt_tokens(sub_stats.total_usage.total),
             f"${cost:,.2f}",
-            str(sub_stats.messages_assistant),
+            f"{sub_stats.messages_user}/{sub_stats.messages_assistant}",
             tools_str,
         )
 

--- a/src/claude_dash/views/session.py
+++ b/src/claude_dash/views/session.py
@@ -1,0 +1,241 @@
+"""View 'session <sid>' — drill-down de uma sessão específica.
+
+Aceita prefixo de sessionId (se único). Mostra:
+- Identificação e estado
+- Resumo agregado (herda de SessionStats)
+- Timeline dos últimos N turnos com tokens e tools por turno
+- Subagentes disparados com custos individuais
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from claude_dash.aggregator import (
+    build_stats_for_transcript,
+    extract_turns,
+)
+from claude_dash.discover import (
+    discover_live_sessions,
+    find_transcript_for_session,
+    subagents_of,
+)
+from claude_dash.models import SessionStats, Turn
+from claude_dash.pricing import cost_of
+from claude_dash.views.now import (
+    _fmt_duration,
+    _fmt_short_cwd,
+    _fmt_tokens,
+    _total_cost,
+)
+
+
+DEFAULT_TIMELINE_TAIL = 20  # últimos N turnos na timeline
+
+
+def _header(stats: SessionStats) -> Panel:
+    now_ms = int(datetime.now().timestamp() * 1000)
+    age_ms = now_ms - stats.started_at_ms if stats.started_at_ms else 0
+
+    state = "[green]viva[/green]" if stats.alive else "[red]morta[/red]"
+    pid_str = str(stats.pid) if stats.pid else "—"
+
+    started = (
+        datetime.fromtimestamp(stats.started_at_ms / 1000).strftime("%Y-%m-%d %H:%M:%S")
+        if stats.started_at_ms
+        else "—"
+    )
+    last_act = (
+        datetime.fromtimestamp(stats.last_activity_ms / 1000).strftime("%Y-%m-%d %H:%M:%S")
+        if stats.last_activity_ms
+        else "—"
+    )
+
+    h = Text()
+    h.append(f" SID    {stats.session_id}\n", style="bold cyan")
+    h.append(f" CWD    {stats.cwd}\n", style="dim")
+    h.append(" Estado ", style="dim")
+    h.append(f"{state}", style="")
+    h.append("  |  PID ", style="dim")
+    h.append(f"{pid_str}", style="bold")
+    h.append("  |  Versão Claude Code ", style="dim")
+    h.append(f"{stats.version or '—'}\n", style="")
+    h.append(" Iniciada ", style="dim")
+    h.append(f"{started}", style="")
+    h.append(f" ({_fmt_duration(age_ms) if age_ms else '—'} atrás)\n", style="dim")
+    h.append(" Última atividade ", style="dim")
+    h.append(f"{last_act}", style="")
+
+    return Panel(h, border_style="cyan", title="claude-dash session", title_align="left")
+
+
+def _overview(stats: SessionStats) -> Panel:
+    total = stats.total_usage
+    cost = _total_cost(stats)
+
+    lines = Text()
+    lines.append("Totais (cumulativos da sessão):\n", style="bold")
+    lines.append(f"  Tokens     ", style="dim")
+    lines.append(f"{_fmt_tokens(total.total)}", style="bold")
+    lines.append(f"    (in {_fmt_tokens(total.input_tokens)} · ", style="dim")
+    lines.append(f"out {_fmt_tokens(total.output_tokens)} · ", style="dim")
+    lines.append(f"cache r {_fmt_tokens(total.cache_read)} · ", style="dim")
+    lines.append(f"w {_fmt_tokens(total.cache_creation_1h + total.cache_creation_5m)})\n", style="dim")
+    lines.append(f"  Custo      ", style="dim")
+    lines.append(f"${cost:,.2f}\n", style="bold yellow")
+    lines.append(f"  Mensagens  ", style="dim")
+    lines.append(f"{stats.messages_user} user / {stats.messages_assistant} assistant\n", style="bold")
+    lines.append(f"  Subagents  ", style="dim")
+    lines.append(f"{stats.subagents}\n", style="bold")
+
+    # Modelos usados
+    if stats.usage_by_model:
+        lines.append(" Modelos    ", style="dim")
+        for i, (model, u) in enumerate(
+            sorted(stats.usage_by_model.items(), key=lambda kv: -kv[1].output_tokens)
+        ):
+            short = model.replace("claude-", "")
+            if i > 0:
+                lines.append(", ", style="dim")
+            lines.append(f"{short}", style="cyan")
+            lines.append(f" ({_fmt_tokens(u.total)})", style="dim")
+        lines.append("\n")
+
+    # Tools usados
+    if stats.tools:
+        lines.append(" Tools      ", style="dim")
+        top = sorted(stats.tools.items(), key=lambda kv: -kv[1])[:8]
+        for i, (name, count) in enumerate(top):
+            if i > 0:
+                lines.append(" ", style="dim")
+            lines.append(f"{name}:{count}", style="dim")
+
+    return Panel(lines, title="Resumo", title_align="left", border_style="dim")
+
+
+def _timeline(turns: list[Turn], tail: int = DEFAULT_TIMELINE_TAIL) -> Panel:
+    if not turns:
+        return Panel(
+            Text("Nenhum turno assistant com usage encontrado.", style="dim"),
+            title="Timeline",
+            title_align="left",
+            border_style="dim",
+        )
+
+    shown = turns[-tail:]
+    omitted = len(turns) - len(shown)
+
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        border_style="dim",
+        expand=True,
+        padding=(0, 1),
+    )
+    table.add_column("#", justify="right", width=5)
+    table.add_column("Hora", width=10)
+    table.add_column("Modelo", width=14)
+    table.add_column("In", justify="right", width=8)
+    table.add_column("Out", justify="right", width=8)
+    table.add_column("Cache r", justify="right", width=9)
+    table.add_column("Custo", justify="right", width=9)
+    table.add_column("Tools disparados", overflow="fold")
+
+    for t in shown:
+        time_str = (
+            datetime.fromtimestamp(t.timestamp_ms / 1000).strftime("%H:%M:%S")
+            if t.timestamp_ms
+            else "—"
+        )
+        short_model = t.model.replace("claude-", "")
+        cost = cost_of(t.model, t.usage)
+        tools_str = (
+            " ".join(t.tools_called) if t.tools_called else "[dim]—[/dim]"
+        )
+        table.add_row(
+            str(t.index + 1),
+            time_str,
+            short_model,
+            _fmt_tokens(t.usage.input_tokens),
+            _fmt_tokens(t.usage.output_tokens),
+            _fmt_tokens(t.usage.cache_read),
+            f"${cost:,.4f}" if cost < 1 else f"${cost:,.2f}",
+            tools_str,
+        )
+
+    title = f"Timeline — últimos {len(shown)} de {len(turns)} turnos"
+    if omitted > 0:
+        title += f" (+{omitted} anteriores)"
+    return Panel(table, title=title, title_align="left", border_style="dim")
+
+
+def _subagents_panel(session_id: str) -> Panel | None:
+    subs = subagents_of(session_id)
+    if not subs:
+        return None
+
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        border_style="dim",
+        expand=True,
+        padding=(0, 1),
+    )
+    table.add_column("Subagent ID", width=20)
+    table.add_column("Tokens", justify="right", width=10)
+    table.add_column("Custo", justify="right", width=9)
+    table.add_column("Msgs", justify="right", width=6)
+    table.add_column("Tools", overflow="fold")
+
+    for sub in subs:
+        try:
+            sub_stats = build_stats_for_transcript(sub)
+        except OSError:
+            continue
+        cost = sum(cost_of(m, u) for m, u in sub_stats.usage_by_model.items())
+        top_tools = sorted(sub_stats.tools.items(), key=lambda kv: -kv[1])[:3]
+        tools_str = " ".join(f"{n}:{c}" for n, c in top_tools) if top_tools else "—"
+        table.add_row(
+            sub.session_id,
+            _fmt_tokens(sub_stats.total_usage.total),
+            f"${cost:,.2f}",
+            str(sub_stats.messages_assistant),
+            tools_str,
+        )
+
+    return Panel(table, title=f"Subagentes ({len(subs)})", title_align="left", border_style="dim")
+
+
+def run(sid: str) -> int:
+    console = Console()
+
+    ref = find_transcript_for_session(sid)
+    if ref is None:
+        console.print(
+            f"[red]Não encontrei transcript para SID '[bold]{sid}[/bold]' "
+            f"(pode ser prefixo ambíguo ou inexistente).[/red]"
+        )
+        return 1
+
+    # Busca info viva (se houver)
+    live_by_sid = {ls.session_id: ls for ls in discover_live_sessions()}
+    live = live_by_sid.get(ref.session_id)
+
+    stats = build_stats_for_transcript(ref, live=live)
+    stats.subagents = len(subagents_of(ref.session_id))
+
+    turns = extract_turns(ref)
+
+    console.print(_header(stats))
+    console.print(_overview(stats))
+    console.print(_timeline(turns))
+
+    sub_panel = _subagents_panel(ref.session_id)
+    if sub_panel is not None:
+        console.print(sub_panel)
+
+    return 0

--- a/tests/test_session_view.py
+++ b/tests/test_session_view.py
@@ -1,0 +1,91 @@
+"""Testes de extract_turns e helpers da view session."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_dash.aggregator import extract_turns
+from claude_dash.discover import TranscriptRef
+from claude_dash.models import Turn, Usage
+
+
+def _make_ref(tmp: Path, entries: list[dict]) -> TranscriptRef:
+    p = tmp / "t.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    return TranscriptRef(session_id="test", path=p, workspace="-ws",
+                         mtime_ms=int(p.stat().st_mtime * 1000))
+
+
+def test_extract_turns_one_per_assistant_with_usage(tmp_path: Path) -> None:
+    entries = [
+        {"type": "user", "timestamp": "2026-04-21T10:00:00Z"},
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:05Z",
+         "message": {"model": "claude-opus-4-7",
+                     "usage": {"input_tokens": 100, "output_tokens": 50},
+                     "content": [
+                         {"type": "tool_use", "id": "1", "name": "Bash", "input": {}},
+                     ]}},
+        {"type": "user", "timestamp": "2026-04-21T10:01:00Z"},
+        {"type": "assistant", "timestamp": "2026-04-21T10:01:10Z",
+         "message": {"model": "claude-opus-4-7",
+                     "usage": {"input_tokens": 200, "output_tokens": 80},
+                     "content": [{"type": "text", "text": "done"}]}},
+    ]
+    turns = extract_turns(_make_ref(tmp_path, entries))
+    assert len(turns) == 2
+    assert turns[0].index == 0
+    assert turns[0].usage.input_tokens == 100
+    assert turns[0].usage.output_tokens == 50
+    assert turns[0].tools_called == ["Bash"]
+    assert turns[1].index == 1
+    assert turns[1].usage.input_tokens == 200
+    assert turns[1].tools_called == []
+
+
+def test_extract_turns_skips_assistant_without_usage(tmp_path: Path) -> None:
+    """Turnos sem usage (ex: placeholder messages) não viram Turn."""
+    entries = [
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:00Z",
+         "message": {"model": "m",  # sem usage
+                     "content": [{"type": "text", "text": "hi"}]}},
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:10Z",
+         "message": {"model": "m",
+                     "usage": {"input_tokens": 5}}},
+    ]
+    turns = extract_turns(_make_ref(tmp_path, entries))
+    assert len(turns) == 1
+    assert turns[0].usage.input_tokens == 5
+
+
+def test_extract_turns_fallback_timestamp(tmp_path: Path) -> None:
+    """Turnos sem timestamp herdam o da entry anterior que tinha."""
+    entries = [
+        {"type": "user", "timestamp": "2026-04-21T10:00:00Z"},
+        {"type": "assistant",  # sem timestamp
+         "message": {"model": "m",
+                     "usage": {"input_tokens": 10}}},
+    ]
+    turns = extract_turns(_make_ref(tmp_path, entries))
+    assert len(turns) == 1
+    # Herdou timestamp do user anterior (10:00 UTC)
+    assert turns[0].timestamp_ms == 1776765600000
+
+
+def test_turn_cost_estimate_key_normalizes(tmp_path: Path) -> None:
+    """A chave de custo do Turn deve remover sufixos [1m] etc."""
+    t = Turn(index=0, timestamp_ms=0, model="claude-opus-4-7[1m]",
+             usage=Usage(), tools_called=[])
+    assert t.cost_estimate_key == "claude-opus-4-7"
+
+
+def test_extract_turns_preserves_raw_model(tmp_path: Path) -> None:
+    """Turn.model mantém a string raw (com sufixo) — a normalização é feita
+    na propriedade cost_estimate_key. Isso preserva info para display."""
+    entries = [
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:00Z",
+         "message": {"model": "claude-opus-4-7[1m]",
+                     "usage": {"input_tokens": 1}}},
+    ]
+    turns = extract_turns(_make_ref(tmp_path, entries))
+    assert turns[0].model == "claude-opus-4-7[1m]"
+    assert turns[0].cost_estimate_key == "claude-opus-4-7"

--- a/tests/test_session_view.py
+++ b/tests/test_session_view.py
@@ -89,3 +89,18 @@ def test_extract_turns_preserves_raw_model(tmp_path: Path) -> None:
     turns = extract_turns(_make_ref(tmp_path, entries))
     assert turns[0].model == "claude-opus-4-7[1m]"
     assert turns[0].cost_estimate_key == "claude-opus-4-7"
+
+
+def test_extract_turns_no_timestamps_keeps_zero(tmp_path: Path) -> None:
+    """Se nenhum timestamp foi visto antes do primeiro turno, timestamp_ms=0.
+
+    A view é responsável por exibir '—' em vez de epoch 1970 — aqui
+    validamos que o aggregator não inventa um timestamp falso.
+    """
+    entries = [
+        {"type": "assistant",  # sem timestamp, sem user anterior
+         "message": {"model": "m", "usage": {"input_tokens": 1}}},
+    ]
+    turns = extract_turns(_make_ref(tmp_path, entries))
+    assert len(turns) == 1
+    assert turns[0].timestamp_ms == 0  # cai no fallback final


### PR DESCRIPTION
## Summary

Subcomando \`claude-dash session <sid>\` (prefixo aceito) — drill-down completo de 1 sessão: header com estado, resumo com breakdown de tokens/tools/modelos, **timeline dos últimos 20 turnos** com custo estimado por turno e tools disparados, painel de subagentes com custo individual.

Modelagem:
- \`Turn\` dataclass (index, timestamp_ms, model, usage, tools_called)
- \`aggregator.extract_turns(ref)\` — um \`Turn\` por entrada assistant com usage; fallback de timestamp
- \`Turn.cost_estimate_key\` property (lookup canônico em PRICING, preservando raw model para display)

Bump: \`0.4.0.dev0\` → \`0.5.0.dev0\`.

Com esta release, todos os 4 subcomandos planejados estão implementados (\`now\`, \`today\`, \`tools\`, \`session\`).

## Test plan

- [x] 80 testes passando (+5 em \`test_session_view.py\`)
- [x] Smoke test real contra a sessão atual: 448 turnos, 47 subagents (incluindo os agents de code-review desta própria conversa)
- [x] Prefix matching de SID validado

🤖 Generated with [Claude Code](https://claude.com/claude-code)