### PR TITLE
v0.5.0 — polish pré-release: pricing oficial, cores, nit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.5.0.dev0"
+version = "0.5.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.5.0.dev0"
+__version__ = "0.5.0"

--- a/src/claude_dash/pricing.py
+++ b/src/claude_dash/pricing.py
@@ -1,8 +1,17 @@
 """Tabela de preços e cálculo de custo estimado.
 
-Valores em USD por milhão de tokens. Atualizado em 2026-04-21 contra
-os preços públicos Anthropic. **Validação pendente contra a página
-oficial** — ver TODO abaixo.
+Valores em USD por milhão de tokens. Validado em 2026-04-21 contra
+https://claude.com/pricing e
+https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+
+Invariantes documentados pela Anthropic (consistentes entre modelos):
+- Output = 5× Input
+- Cache read = 0.1× Input
+- Cache write 5m = 1.25× Input
+- Cache write 1h = 2× Input
+
+Se a Anthropic alterar preços, basta ajustar `input_usd_per_m`; os
+demais campos são derivados dessa base.
 """
 from __future__ import annotations
 
@@ -35,31 +44,21 @@ class Price:
 # Tabela hard-coded. A chave deve bater com o valor `.message.model` do
 # transcript (ex: "claude-opus-4-7", "claude-sonnet-4-6"). Sufixos como
 # "[1m]" (1M context) são removidos via `normalize_model`.
-#
-# TODO(v0.4): cruzar com endpoint /v1/models da Anthropic ao iniciar o
-# dashboard e logar discrepâncias.
+def _price_from_input(input_per_m: float) -> Price:
+    """Constrói Price aplicando os multiplicadores oficiais Anthropic."""
+    return Price(
+        input_usd_per_m=input_per_m,
+        output_usd_per_m=input_per_m * 5.0,         # 5× input
+        cache_read_usd_per_m=input_per_m * 0.1,     # 0.1× input
+        cache_write_5m_usd_per_m=input_per_m * 1.25,  # 1.25× input
+        cache_write_1h_usd_per_m=input_per_m * 2.0,   # 2× input
+    )
+
+
 PRICING: dict[str, Price] = {
-    "claude-opus-4-7": Price(
-        input_usd_per_m=15.00,
-        output_usd_per_m=75.00,
-        cache_read_usd_per_m=1.50,
-        cache_write_1h_usd_per_m=18.75,
-        cache_write_5m_usd_per_m=18.75,
-    ),
-    "claude-sonnet-4-6": Price(
-        input_usd_per_m=3.00,
-        output_usd_per_m=15.00,
-        cache_read_usd_per_m=0.30,
-        cache_write_1h_usd_per_m=3.75,
-        cache_write_5m_usd_per_m=3.75,
-    ),
-    "claude-haiku-4-5": Price(
-        input_usd_per_m=1.00,
-        output_usd_per_m=5.00,
-        cache_read_usd_per_m=0.10,
-        cache_write_1h_usd_per_m=1.25,
-        cache_write_5m_usd_per_m=1.25,
-    ),
+    "claude-opus-4-7": _price_from_input(5.00),
+    "claude-sonnet-4-6": _price_from_input(3.00),
+    "claude-haiku-4-5": _price_from_input(1.00),
 }
 
 

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -69,8 +69,8 @@ def _total_cost(s: SessionStats) -> float:
 def colored_cost(usd: float, thresholds: tuple[float, float] = (10.0, 50.0)) -> str:
     """Formata custo em USD com cor por faixa.
 
-    Padrão: verde/dim abaixo de thresholds[0], amarelo entre, vermelho
-    acima de thresholds[1]. Argumentos:
+    Padrão: dim abaixo de thresholds[0], amarelo entre, vermelho acima
+    de thresholds[1]. Argumentos:
         thresholds[0]: limite para cor amarela ("atenção")
         thresholds[1]: limite para cor vermelha ("custo alto")
     Usado no display de sessões agregadas (`now`/`today`).
@@ -88,8 +88,9 @@ def colored_cost(usd: float, thresholds: tuple[float, float] = (10.0, 50.0)) -> 
 def colored_turn_cost(usd: float) -> str:
     """Versão com thresholds menores, apropriados para custo de um turno.
 
-    A escala por-turno é 2 ordens de grandeza menor que por-sessão:
-    $0.50/turno já é alto, $1.00/turno é caso de investigação.
+    Thresholds: ($0.50, $1.00) vs. ($10, $50) da sessão — cerca de
+    20× e 50× mais baixos, refletindo que um único turno raramente
+    aproxima do custo cumulativo de uma sessão de horas.
     """
     return colored_cost(usd, thresholds=(0.5, 1.0))
 

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -66,6 +66,34 @@ def _total_cost(s: SessionStats) -> float:
     return sum(cost_of(model, u) for model, u in s.usage_by_model.items())
 
 
+def colored_cost(usd: float, thresholds: tuple[float, float] = (10.0, 50.0)) -> str:
+    """Formata custo em USD com cor por faixa.
+
+    Padrão: verde/dim abaixo de thresholds[0], amarelo entre, vermelho
+    acima de thresholds[1]. Argumentos:
+        thresholds[0]: limite para cor amarela ("atenção")
+        thresholds[1]: limite para cor vermelha ("custo alto")
+    Usado no display de sessões agregadas (`now`/`today`).
+    """
+    if usd >= thresholds[1]:
+        style = "bold red"
+    elif usd >= thresholds[0]:
+        style = "bold yellow"
+    else:
+        style = "dim"
+    fmt = f"${usd:,.4f}" if usd < 1 else f"${usd:,.2f}"
+    return f"[{style}]{fmt}[/{style}]"
+
+
+def colored_turn_cost(usd: float) -> str:
+    """Versão com thresholds menores, apropriados para custo de um turno.
+
+    A escala por-turno é 2 ordens de grandeza menor que por-sessão:
+    $0.50/turno já é alto, $1.00/turno é caso de investigação.
+    """
+    return colored_cost(usd, thresholds=(0.5, 1.0))
+
+
 def _tools_summary(s: SessionStats, top_n: int = 4) -> str:
     if not s.tools:
         return "-"
@@ -141,7 +169,7 @@ def _session_table(sessions: list[SessionStats]) -> Table:
             dom_short,
             _tokens_breakdown(s),
             _context_cell(s),
-            f"${cost:,.2f}",
+            colored_cost(cost),
             msgs,
             str(s.subagents),
             _tools_summary(s),

--- a/src/claude_dash/views/session.py
+++ b/src/claude_dash/views/session.py
@@ -31,6 +31,8 @@ from claude_dash.views.now import (
     _fmt_short_cwd,
     _fmt_tokens,
     _total_cost,
+    colored_cost,
+    colored_turn_cost,
 )
 
 
@@ -86,7 +88,7 @@ def _overview(stats: SessionStats) -> Panel:
     lines.append(f"cache r {_fmt_tokens(total.cache_read)} · ", style="dim")
     lines.append(f"w {_fmt_tokens(total.cache_creation_1h + total.cache_creation_5m)})\n", style="dim")
     lines.append(f"  Custo      ", style="dim")
-    lines.append(f"${cost:,.2f}\n", style="bold yellow")
+    lines.append_text(Text.from_markup(f"{colored_cost(cost)}\n"))
     lines.append(f"  Mensagens  ", style="dim")
     lines.append(f"{stats.messages_user} user / {stats.messages_assistant} assistant\n", style="bold")
     lines.append(f"  Subagents  ", style="dim")
@@ -163,7 +165,7 @@ def _timeline(turns: list[Turn], tail: int = DEFAULT_TIMELINE_TAIL) -> Panel:
             _fmt_tokens(t.usage.input_tokens),
             _fmt_tokens(t.usage.output_tokens),
             _fmt_tokens(t.usage.cache_read),
-            f"${cost:,.4f}" if cost < 1 else f"${cost:,.2f}",
+            colored_turn_cost(cost),
             tools_str,
         )
 
@@ -203,7 +205,7 @@ def _subagents_panel(session_id: str) -> Panel | None:
         table.add_row(
             sub.session_id,
             _fmt_tokens(sub_stats.total_usage.total),
-            f"${cost:,.2f}",
+            colored_cost(cost, thresholds=(1.0, 5.0)),  # escala menor para subagents
             f"{sub_stats.messages_user}/{sub_stats.messages_assistant}",
             tools_str,
         )

--- a/src/claude_dash/views/today.py
+++ b/src/claude_dash/views/today.py
@@ -23,6 +23,7 @@ from claude_dash.views.now import (
     _short_sid,
     _tools_summary,
     _total_cost,
+    colored_cost,
 )
 
 
@@ -102,7 +103,7 @@ def _session_table(sessions: list[SessionStats]) -> Panel:
             last_activity,
             dom_short,
             _fmt_tokens(total),
-            f"${cost:,.2f}",
+            colored_cost(cost),
             msgs,
             str(s.subagents),
             _tools_summary(s),

--- a/src/claude_dash/views/tools.py
+++ b/src/claude_dash/views/tools.py
@@ -26,11 +26,11 @@ def window_start_ms(window: timedelta = DEFAULT_WINDOW) -> int:
 
 
 def _histogram_bar(hist: list[int], width: int = 24) -> str:
-    """ASCII sparkline de 24 horas usando blocos Unicode."""
+    """Sparkline de 24 horas usando Unicode block elements."""
     if not any(hist):
         return " " * width
     max_val = max(hist)
-    # 8 níveis de intensidade ASCII (Unicode block elements)
+    # 8 níveis de intensidade não-brancos (U+2581..U+2588) + espaço para zero
     blocks = " ▁▂▃▄▅▆▇█"
     return "".join(
         blocks[min(len(blocks) - 1, int((v / max_val) * (len(blocks) - 1) + 0.5))]

--- a/tests/test_colored_cost.py
+++ b/tests/test_colored_cost.py
@@ -1,0 +1,49 @@
+"""Testes do helper colored_cost (faixas de cor por custo)."""
+from __future__ import annotations
+
+from claude_dash.views.now import colored_cost, colored_turn_cost
+
+
+class TestColoredCost:
+    def test_below_first_threshold_is_dim(self) -> None:
+        out = colored_cost(0.5)
+        assert "dim" in out
+        assert "yellow" not in out
+        assert "red" not in out
+
+    def test_between_thresholds_is_yellow(self) -> None:
+        out = colored_cost(20.0)  # default thresholds (10, 50)
+        assert "yellow" in out
+        assert "red" not in out
+
+    def test_above_second_threshold_is_red(self) -> None:
+        out = colored_cost(75.0)
+        assert "red" in out
+
+    def test_custom_thresholds(self) -> None:
+        # Custo baixo com thresholds pequenos fica amarelo
+        out = colored_cost(2.0, thresholds=(1.0, 5.0))
+        assert "yellow" in out
+
+    def test_format_under_1_usd_uses_4_decimals(self) -> None:
+        out = colored_cost(0.1234)
+        assert "$0.1234" in out
+
+    def test_format_over_1_usd_uses_2_decimals(self) -> None:
+        out = colored_cost(12.3456)
+        assert "$12.35" in out
+
+
+class TestColoredTurnCost:
+    def test_turn_scale_is_tighter(self) -> None:
+        # $0.75 por turno: yellow (acima de $0.50)
+        out = colored_turn_cost(0.75)
+        assert "yellow" in out
+
+    def test_turn_above_1_usd_is_red(self) -> None:
+        out = colored_turn_cost(1.5)
+        assert "red" in out
+
+    def test_cheap_turn_is_dim(self) -> None:
+        out = colored_turn_cost(0.001)
+        assert "dim" in out

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -26,20 +26,29 @@ class TestCostOf:
         assert cost_of("model-inexistente", Usage(input_tokens=1_000_000)) == 0.0
 
     def test_opus_1m_input_tokens(self) -> None:
-        # 1M input tokens @ $15/M = $15
-        assert cost_of("claude-opus-4-7", Usage(input_tokens=1_000_000)) == pytest.approx(15.0)
+        # 1M input tokens @ $5/M = $5
+        assert cost_of("claude-opus-4-7", Usage(input_tokens=1_000_000)) == pytest.approx(5.0)
 
     def test_opus_1m_output_tokens(self) -> None:
-        # 1M output tokens @ $75/M = $75
-        assert cost_of("claude-opus-4-7", Usage(output_tokens=1_000_000)) == pytest.approx(75.0)
+        # 1M output tokens @ $25/M = $25 (5× input)
+        assert cost_of("claude-opus-4-7", Usage(output_tokens=1_000_000)) == pytest.approx(25.0)
 
     def test_opus_1m_cache_read(self) -> None:
-        # 1M cache read @ $1.50/M = $1.50
-        assert cost_of("claude-opus-4-7", Usage(cache_read=1_000_000)) == pytest.approx(1.5)
+        # 1M cache read @ $0.50/M = $0.50 (0.1× input)
+        assert cost_of("claude-opus-4-7", Usage(cache_read=1_000_000)) == pytest.approx(0.5)
+
+    def test_opus_cache_write_1h_vs_5m(self) -> None:
+        # 1h cache write deve ser ~1.6× mais caro que 5m cache write
+        # (invariantes: 5m = 1.25× input, 1h = 2× input)
+        c_5m = cost_of("claude-opus-4-7", Usage(cache_creation_5m=1_000_000))
+        c_1h = cost_of("claude-opus-4-7", Usage(cache_creation_1h=1_000_000))
+        assert c_5m == pytest.approx(6.25)
+        assert c_1h == pytest.approx(10.0)
+        assert c_1h == pytest.approx(c_5m * 1.6)
 
     def test_bracket_suffix_resolves_to_opus_pricing(self) -> None:
         # Tokens do transcript vêm como "claude-opus-4-7[1m]" — precisa casar
-        assert cost_of("claude-opus-4-7[1m]", Usage(input_tokens=1_000_000)) == pytest.approx(15.0)
+        assert cost_of("claude-opus-4-7[1m]", Usage(input_tokens=1_000_000)) == pytest.approx(5.0)
 
     def test_sonnet_cheaper_than_opus(self) -> None:
         u = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
@@ -56,9 +65,35 @@ class TestCostOf:
             cache_creation_1h=200_000,
             cache_read=800_000,
         )
-        # Opus: 100k*15 + 50k*75 + 200k*18.75 + 800k*1.5 all over 1M
-        expected = (100_000 * 15 + 50_000 * 75 + 200_000 * 18.75 + 800_000 * 1.5) / 1_000_000
+        # Opus (preços 2026-04): 100k*5 + 50k*25 + 200k*10 + 800k*0.5 all over 1M
+        expected = (100_000 * 5 + 50_000 * 25 + 200_000 * 10 + 800_000 * 0.5) / 1_000_000
         assert cost_of("claude-opus-4-7", u) == pytest.approx(expected)
+
+
+class TestPricingInvariants:
+    """Valida que a tabela segue os multiplicadores oficiais Anthropic."""
+
+    def test_output_is_5x_input(self) -> None:
+        for model, price in PRICING.items():
+            assert price.output_usd_per_m == pytest.approx(price.input_usd_per_m * 5), model
+
+    def test_cache_read_is_0_1x_input(self) -> None:
+        for model, price in PRICING.items():
+            assert price.cache_read_usd_per_m == pytest.approx(
+                price.input_usd_per_m * 0.1
+            ), model
+
+    def test_cache_write_5m_is_1_25x_input(self) -> None:
+        for model, price in PRICING.items():
+            assert price.cache_write_5m_usd_per_m == pytest.approx(
+                price.input_usd_per_m * 1.25
+            ), model
+
+    def test_cache_write_1h_is_2x_input(self) -> None:
+        for model, price in PRICING.items():
+            assert price.cache_write_1h_usd_per_m == pytest.approx(
+                price.input_usd_per_m * 2.0
+            ), model
 
 
 class TestUsage:


### PR DESCRIPTION
## Summary

Polish final antes da tag **v0.5.0** (primeira release estável).

### Commits
1. \`f732b60\` \`fix(pricing)\` — validação contra [claude.com/pricing](https://claude.com/pricing) e [prompt-caching docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching):
   - **Opus 4.7 caiu 3×** (input \$15→\$5, output \$75→\$25, cache read \$1.50→\$0.50)
   - Cache write 1h ≠ 5m (1h = 2× input, 5m = 1.25× input; antes estavam iguais para todos os modelos)
   - Refactor \`_price_from_input()\` aplica multiplicadores oficiais automaticamente
   - +5 testes de invariantes (\`TestPricingInvariants\`)
2. \`db8344b\` \`polish\` — faixas de cor por custo + nit ASCII→Unicode:
   - \`colored_cost(usd, thresholds)\` helper: dim < yellow < red
   - Aplicado em \`now\`, \`today\`, \`session\` (escalas distintas por contexto)
   - Nit score-15 do PR #4 resolvido (docstring do \`_histogram_bar\`)
3. \`56c1849\` \`chore\` — bump \`0.5.0.dev0\` → \`0.5.0\`

### Impacto nos dados

Custos históricos exibidos nos PRs anteriores superestimaram Opus em ~3×. Com a tabela correta, \`today\` passou de ~\$610 para ~\$367.

### Test plan

- [x] 95 testes passando (+9 novos)
- [x] Smoke test real: cores distribuem atenção corretamente (\$136 em vermelho, \$48 amarelo)

Após merge: tag \`v0.5.0\` criada no commit de merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)