### PR TITLE
chore: release v0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.6.0.dev0"
+version = "0.6.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.6.0.dev0"
+__version__ = "0.6.0"


### PR DESCRIPTION
Bump de versão `0.6.0.dev0` → `0.6.0`. Tag `v0.6.0` será criada após merge.