### PR TITLE
fix(tui): Enter na aba Session não disparava drill-down

### DIFF
--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -26,6 +26,19 @@ from textual.widgets import (
     TabPane,
 )
 
+
+class SessionListItem(ListItem):
+    """ListItem que carrega o sessionId como atributo tipado.
+
+    Subclassar é mais robusto que atribuir `.data` depois de criado:
+    evita depender de Textual preservar atributos arbitrários entre
+    versões e dá type-safety no event handler.
+    """
+
+    def __init__(self, sid: str, label: str) -> None:
+        super().__init__(Label(label))
+        self.sid = sid
+
 from claude_dash.aggregator import (
     build_stats_for_transcript,
     collect_live_sessions,
@@ -225,9 +238,7 @@ class DashboardApp(App):
             return
 
         for sid, label in entries:
-            item = ListItem(Label(label))
-            item.data = sid  # type: ignore[attr-defined]
-            list_view.append(item)
+            list_view.append(SessionListItem(sid=sid, label=label))
 
     def _render_session_detail(self, sid: str) -> None:
         """Chamado quando o usuário seleciona um SID na lista."""
@@ -266,9 +277,9 @@ class DashboardApp(App):
     # ----- Event handlers ------------------------------------------------
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
-        sid = getattr(event.item, "data", None)
-        if isinstance(sid, str):
-            self._render_session_detail(sid)
+        # Usuário pressionou Enter (ou clicou) numa linha da lista
+        if isinstance(event.item, SessionListItem):
+            self._render_session_detail(event.item.sid)
 
 
 def run() -> int:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -70,6 +70,53 @@ def test_refresh_binding_does_not_crash() -> None:
     _run(run())
 
 
+def test_session_tab_enter_triggers_drill_down() -> None:
+    """Regressão: pressionar Enter num SessionListItem deve chamar
+    _render_session_detail com o sid correto.
+
+    Bug anterior (v0.6.0): atributo `.data` em ListItem não persistia
+    confiavelmente, então on_list_view_selected recebia None e o
+    drill-down silenciosamente não acontecia. Subclassando ListItem
+    em SessionListItem, o atributo `.sid` fica tipado e estável.
+    """
+    async def run():
+        app = DashboardApp()
+        # Substitui _render_session_detail por spy
+        called_with: list[str] = []
+
+        def spy(sid: str) -> None:
+            called_with.append(sid)
+
+        async with app.run_test() as pilot:
+            await pilot.pause(0.5)
+            app._render_session_detail = spy  # type: ignore[method-assign]
+            # Ir pra aba Session
+            await pilot.press("4")
+            await pilot.pause(0.2)
+
+            # Garante que a lista tem pelo menos 1 item (ou o teste
+            # é inerte — depende do filesystem real do ambiente de teste)
+            from claude_dash.views.tui import SessionListItem
+            from textual.widgets import ListView
+
+            list_view = app.query_one("#session-list", ListView)
+            session_items = [c for c in list_view.children if isinstance(c, SessionListItem)]
+            if not session_items:
+                return  # Ambiente sem transcripts → nada a testar
+
+            # Foca na ListView e simula Enter no primeiro item
+            list_view.focus()
+            list_view.index = 0
+            await pilot.pause(0.1)
+            await pilot.press("enter")
+            await pilot.pause(0.2)
+
+            assert len(called_with) == 1, "drill-down não foi disparado por Enter"
+            assert called_with[0] == session_items[0].sid
+
+    _run(run())
+
+
 def test_all_tab_contents_mount_without_error() -> None:
     """Valida que os Static de conteúdo de cada aba existem após on_mount.
 


### PR DESCRIPTION
Bug reportado pelo usuário: navegação com setas funcionava, mas Enter não selecionava.

**Causa:** \`item.data = sid\` atribuía atributo arbitrário em \`ListItem\`, não confiável em textual 8.x — event handler recebia None e ignorava silenciosamente.

**Fix:** \`SessionListItem(ListItem)\` com \`sid\` tipado como atributo próprio. Event handler agora confere \`isinstance(event.item, SessionListItem)\` e acessa \`.sid\` direto.

**Test plan:**
- [x] Regressão em \`test_session_tab_enter_triggers_drill_down\` — spy em \`_render_session_detail\` valida que Enter dispara com sid correto
- [x] 100 testes passando (+1)

Será base para v0.6.1 ou entra junto com a feature MCP como v0.7.