### PR TITLE
fix(tui): ListView da aba Session não recebia foco — v0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.7.0"
+version = "0.7.1"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -123,7 +123,10 @@ class DashboardApp(App):
                 yield Static(id="tools-content", expand=True)
             with TabPane("Session (4)", id="tab-session"):
                 with Vertical():
-                    yield Label("Selecione uma sessão (↑/↓, Enter):", id="session-hint")
+                    yield Label(
+                        "↑/↓ navega  •  Enter abre o drill-down da sessão selecionada",
+                        id="session-hint",
+                    )
                     yield ListView(id="session-list")
                     yield Static(id="session-detail")
         yield Footer()
@@ -143,6 +146,25 @@ class DashboardApp(App):
         self._refresh_session_list()
         # Auto-refresh só da Now (demais via `r` manual)
         self.set_interval(NOW_REFRESH_SEC, self._refresh_now)
+
+    def on_tabbed_content_tab_activated(
+        self, event: TabbedContent.TabActivated
+    ) -> None:
+        """Foca o widget interativo da aba ao ativá-la.
+
+        Sem isso, o ListView da aba Session não recebe eventos de
+        teclado mesmo quando visível — Enter/Space caem nas bindings
+        globais da App e o Selected nunca dispara. Resultado: usuário
+        vê os itens navegáveis por seta mas não consegue selecionar.
+        """
+        if event.pane.id == "tab-session":
+            try:
+                list_view = self.query_one("#session-list", ListView)
+                if len(list_view.children) > 0 and list_view.index is None:
+                    list_view.index = 0
+                list_view.focus()
+            except Exception:  # noqa: BLE001
+                pass
 
     # ----- Actions -------------------------------------------------------
 
@@ -239,6 +261,12 @@ class DashboardApp(App):
 
         for sid, label in entries:
             list_view.append(SessionListItem(sid=sid, label=label))
+
+        # Garante que há um item "current" desde o primeiro render —
+        # sem isso, Enter num ListView recém-populado não dispara
+        # Selected porque não há índice focado.
+        if list_view.index is None:
+            list_view.index = 0
 
     def _render_session_detail(self, sid: str) -> None:
         """Chamado quando o usuário seleciona um SID na lista."""

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -74,14 +74,15 @@ def test_session_tab_enter_triggers_drill_down() -> None:
     """Regressão: pressionar Enter num SessionListItem deve chamar
     _render_session_detail com o sid correto.
 
-    Bug anterior (v0.6.0): atributo `.data` em ListItem não persistia
-    confiavelmente, então on_list_view_selected recebia None e o
-    drill-down silenciosamente não acontecia. Subclassando ListItem
-    em SessionListItem, o atributo `.sid` fica tipado e estável.
+    Fluxo simulado é o REAL do usuário (sem focus() explícito): troca
+    pra aba Session com tecla 4 e pressiona Enter. O bug original era
+    `.data` não persistir em ListItem; o bug secundário (v0.7.0) é que
+    a ListView não recebia foco automaticamente ao ativar a aba, então
+    Enter caía nas bindings globais. Fix: hook em on_tabbed_content_tab_activated
+    que chama list_view.focus() ao ativar a aba Session.
     """
     async def run():
         app = DashboardApp()
-        # Substitui _render_session_detail por spy
         called_with: list[str] = []
 
         def spy(sid: str) -> None:
@@ -90,12 +91,11 @@ def test_session_tab_enter_triggers_drill_down() -> None:
         async with app.run_test() as pilot:
             await pilot.pause(0.5)
             app._render_session_detail = spy  # type: ignore[method-assign]
-            # Ir pra aba Session
-            await pilot.press("4")
-            await pilot.pause(0.2)
 
-            # Garante que a lista tem pelo menos 1 item (ou o teste
-            # é inerte — depende do filesystem real do ambiente de teste)
+            # Troca pra aba Session — deve focar ListView automaticamente
+            await pilot.press("4")
+            await pilot.pause(0.3)
+
             from claude_dash.views.tui import SessionListItem
             from textual.widgets import ListView
 
@@ -104,10 +104,11 @@ def test_session_tab_enter_triggers_drill_down() -> None:
             if not session_items:
                 return  # Ambiente sem transcripts → nada a testar
 
-            # Foca na ListView e simula Enter no primeiro item
-            list_view.focus()
-            list_view.index = 0
-            await pilot.pause(0.1)
+            # Nenhum focus() explícito aqui — deve estar focado pelo hook
+            assert list_view.has_focus, "ListView não foi focado automaticamente ao ativar a aba"
+            # Primeiro item deve estar highlighted desde o populate
+            assert list_view.index == 0
+
             await pilot.press("enter")
             await pilot.pause(0.2)
 


### PR DESCRIPTION
Bug reportado: mesmo após o fix de PR #9, Enter/Space na aba Session continuava não selecionando.

**Causa raiz:** ao ativar a aba, o foco de teclado permanecia no \`TabbedContent\` — o \`ListView\` não recebia eventos, então \`Selected\` nunca disparava. Setas funcionavam porque o TabbedContent as propaga, mas Enter/Space caíam nas bindings globais da App.

**Fix em 3 camadas:**
1. \`on_tabbed_content_tab_activated\` foca \`#session-list\` ao ativar a aba Session
2. \`_refresh_session_list\` define \`index=0\` após popular (sem isso, Enter num ListView sem item highlighted não dispara Selected)
3. Label/hint reescrito pra ficar claro que Enter abre drill-down

**Teste reescrito:** \`test_session_tab_enter_triggers_drill_down\` agora simula o flow REAL do usuário (sem \`list_view.focus()\` explícito). O anterior passava mesmo com o bug porque chamava focus manualmente.

**Bump:** \`0.7.0\` → \`0.7.1\` (PATCH).

**Test plan:**
- [x] 107 testes passando
- [x] Novo assert \`has_focus\` após press('4')