### PR TITLE
fix(tui): drill-down da aba Session estava invisível por CSS — v0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.7.1"
+version = "0.7.2"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -89,15 +89,23 @@ class DashboardApp(App):
     TabPane {
         padding: 0 1;
     }
-    ListView {
-        border: solid $primary;
-        height: 100%;
-    }
     ListView > ListItem {
         padding: 0 1;
     }
+    /* Aba Session: lista limitada a 40% da altura, detail toma o resto.
+       O 'ListView { height: 100% }' anterior absorvia toda a altura e
+       deixava o drill-down invisível. */
+    #session-list {
+        border: solid $primary;
+        height: 40%;
+    }
     #session-detail {
         height: 1fr;
+        border: solid $primary;
+        overflow-y: auto;
+    }
+    #session-hint {
+        margin: 0 0 1 0;
     }
     """
 


### PR DESCRIPTION
CSS global `ListView { height: 100% }` absorvia toda a altura do TabPane, escondendo o `#session-detail`. Removida regra global, `#session-list` limitado a 40%, `#session-detail` pega o resto com scroll. Bump `0.7.1` → `0.7.2`. 107 testes passando.