### PR TITLE
v0.8 — Info de conta + billing awareness

### DIFF
--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -177,6 +177,26 @@ claude_dashboard/
   gera **alertas** acionáveis (custo alto, contexto próximo do
   limite, sessões sem atividade)
 - [x] Integração com Claude Code via `~/.claude/settings.json`
+- [x] **v0.7.1**: fix foco ListView na aba Session
+- [x] **v0.7.2**: fix CSS — drill-down estava invisível
+- [x] **v0.7.3**: remove ●/○ ambíguo, usa texto colorido
+
+### v0.8 — Info de conta e distinção por billing
+- [x] `account.py`: lê `~/.claude.json` extraindo email, organização,
+  billing type (`stripe_subscription` = assinatura flat-rate;
+  `api` = pay-as-you-go)
+- [x] `AccountInfo.is_flat_rate` e `billing_label` para agentes
+  decidirem se custo USD é significativo
+- [x] Header de `now`/`today` passa a mostrar conta + billing; label
+  do custo vira "Custo (ref. API)" em plano flat-rate para sinalizar
+  que é custo hipotético, não cobrança
+- [x] Tool MCP `account_info` + chave `account` em `workflow_snapshot`
+
+### Futuro — Rate limits por sessão
+- [ ] Hook opcional capturando `rate_limits.five_hour`/`seven_day` do
+  JSON do statusline em `/tmp/.claude-dash-rate-limits/*.json`
+- [ ] Views e MCP exibem % consumido dos limites em vez de custo USD
+  quando `is_flat_rate=True`
 
 ### v0.3 — Drill-down
 - [ ] View `session <sid>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.7.3"
+version = "0.8.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.7.3"
+__version__ = "0.8.0"

--- a/src/claude_dash/account.py
+++ b/src/claude_dash/account.py
@@ -55,7 +55,7 @@ class AccountInfo:
 
     @property
     def billing_label(self) -> str:
-        """String curta para exibição (ex: 'Max/flat', 'API', ...)."""
+        """String curta para exibição (ex: 'Assinatura', 'API (pay-as-you-go)')."""
         if self.billing_type == BILLING_FLAT_RATE:
             # O nome exato do plano (Max/Pro) não está no JSON local;
             # ficamos com "Assinatura" como label neutro. Se o Léo
@@ -71,7 +71,15 @@ class AccountInfo:
 def read_account_info(
     path: Path = DEFAULT_CLAUDE_JSON,
 ) -> AccountInfo | None:
-    """Lê ~/.claude.json e extrai info de conta; retorna None se ausente."""
+    """Lê ~/.claude.json e extrai info de conta.
+
+    Retorna None em três cenários (tratados silenciosamente, sem raise):
+    1. arquivo ausente no path indicado
+    2. JSON inválido (parse error) ou erro de leitura (OSError)
+    3. arquivo existe e parseia mas não tem o bloco `oauthAccount`
+
+    Callers devem checar `is None` antes de acessar campos.
+    """
     if not path.is_file():
         return None
     try:

--- a/src/claude_dash/account.py
+++ b/src/claude_dash/account.py
@@ -1,0 +1,97 @@
+"""Lê informação da conta/assinatura Anthropic a partir de ~/.claude.json.
+
+O Claude Code armazena dados de OAuth e estado de billing local. Esta
+camada expõe isso como `AccountInfo` tipado, permitindo que as views
+diferenciem usuários em **plano flat-rate** (assinatura Max/Pro onde
+o "custo em USD" é desinformação — o real consumo é % do rate limit
+5h/7d) de usuários em **API billing** pay-as-you-go (onde USD
+estimado é a métrica correta).
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_CLAUDE_JSON = Path(os.environ.get("CLAUDE_JSON", Path.home() / ".claude.json"))
+
+
+# Valores observados no campo `billingType` do oauthAccount.
+# A enum não é exaustiva — outros valores devem ser tratados como
+# "desconhecido" (fallback para API billing, mais conservador do
+# ponto de vista de exibição de custo).
+BILLING_FLAT_RATE = "stripe_subscription"  # plano Max/Pro/similar
+BILLING_API = "api"                        # pay-as-you-go
+BILLING_ENTERPRISE = "enterprise"          # não observado, mas plausível
+
+
+@dataclass(slots=True)
+class AccountInfo:
+    """Snapshot da conta/assinatura do usuário no Claude Code."""
+
+    email: str
+    display_name: str
+    organization_name: str
+    organization_role: str              # "admin", "member", etc
+    billing_type: str                   # valor raw do campo
+    has_extra_usage_enabled: bool       # pay-as-you-go além do flat rate?
+    extra_usage_disabled_reason: str | None
+    first_token_date: str | None        # primeira vez que usou
+    account_uuid: str
+    organization_uuid: str
+
+    @property
+    def is_flat_rate(self) -> bool:
+        """True se a conta é de assinatura flat-rate (Max, Pro, etc).
+
+        Nesses planos, o "custo em USD por tokens" estimado pela
+        tabela de preços da API NÃO representa o custo real do
+        usuário — o usuário paga uma mensalidade fixa. A métrica
+        relevante é o % consumido dos rate limits 5h/7d.
+        """
+        return self.billing_type == BILLING_FLAT_RATE
+
+    @property
+    def billing_label(self) -> str:
+        """String curta para exibição (ex: 'Max/flat', 'API', ...)."""
+        if self.billing_type == BILLING_FLAT_RATE:
+            # O nome exato do plano (Max/Pro) não está no JSON local;
+            # ficamos com "Assinatura" como label neutro. Se o Léo
+            # quiser diferenciar depois, podemos buscar via API.
+            return "Assinatura"
+        if self.billing_type == BILLING_API:
+            return "API (pay-as-you-go)"
+        if self.billing_type == BILLING_ENTERPRISE:
+            return "Enterprise"
+        return f"Desconhecido ({self.billing_type})"
+
+
+def read_account_info(
+    path: Path = DEFAULT_CLAUDE_JSON,
+) -> AccountInfo | None:
+    """Lê ~/.claude.json e extrai info de conta; retorna None se ausente."""
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    oauth = data.get("oauthAccount") or {}
+    if not oauth:
+        return None
+
+    return AccountInfo(
+        email=oauth.get("emailAddress") or "",
+        display_name=oauth.get("displayName") or "",
+        organization_name=oauth.get("organizationName") or "",
+        organization_role=oauth.get("organizationRole") or "",
+        billing_type=oauth.get("billingType") or "",
+        has_extra_usage_enabled=bool(oauth.get("hasExtraUsageEnabled", False)),
+        extra_usage_disabled_reason=data.get("cachedExtraUsageDisabledReason"),
+        first_token_date=data.get("claudeCodeFirstTokenDate"),
+        account_uuid=oauth.get("accountUuid") or "",
+        organization_uuid=oauth.get("organizationUuid") or "",
+    )

--- a/src/claude_dash/mcp_server.py
+++ b/src/claude_dash/mcp_server.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
+from claude_dash.account import read_account_info
 from claude_dash.aggregator import (
     build_stats_for_transcript,
     collect_live_sessions,
@@ -131,6 +132,37 @@ def _infer_alerts(
 
 
 # --- ferramentas expostas ------------------------------------------------
+
+
+@mcp.tool()
+def account_info() -> dict[str, Any]:
+    """Info da conta/assinatura do usuário no Claude Code.
+
+    Retorna email, organização, billing type ("stripe_subscription"
+    para planos Max/Pro flat-rate; "api" para pay-as-you-go),
+    flag `is_flat_rate` (útil para agentes decidirem se custo em
+    USD faz sentido), status de extra usage (pay-as-you-go adicional).
+
+    Lida de ~/.claude.json (campos oauthAccount, cachedExtraUsageDisabledReason).
+    Retorna `{"error": ...}` se não houver arquivo ou parse falhar.
+    """
+    acc = read_account_info()
+    if acc is None:
+        return {"error": "~/.claude.json ausente ou sem oauthAccount"}
+    return {
+        "email": acc.email,
+        "display_name": acc.display_name,
+        "organization_name": acc.organization_name,
+        "organization_role": acc.organization_role,
+        "billing_type": acc.billing_type,
+        "billing_label": acc.billing_label,
+        "is_flat_rate": acc.is_flat_rate,
+        "has_extra_usage_enabled": acc.has_extra_usage_enabled,
+        "extra_usage_disabled_reason": acc.extra_usage_disabled_reason,
+        "first_token_date": acc.first_token_date,
+        "account_uuid": acc.account_uuid,
+        "organization_uuid": acc.organization_uuid,
+    }
 
 
 @mcp.tool()
@@ -276,7 +308,7 @@ def workflow_snapshot() -> dict[str, Any]:
       (1) output/turno alto em sessão viva,
       (2) sessão viva sem atividade há > 30 min,
       (3) contexto ativo > 150k tokens (perto do limite 200k),
-      (4) custo agregado do dia > \$200.
+      (4) custo agregado do dia > $200.
     """
     live = collect_live_sessions()
     today = collect_sessions_since(today_start_ms())
@@ -305,8 +337,15 @@ def workflow_snapshot() -> dict[str, Any]:
             hourly[h] += count
     peak_hour = hourly.index(max(hourly)) if any(hourly) else None
 
+    acc = read_account_info()
+
     return {
         "generated_at": datetime.now().isoformat(),
+        "account": {
+            "email": acc.email if acc else None,
+            "billing_label": acc.billing_label if acc else None,
+            "is_flat_rate": acc.is_flat_rate if acc else None,
+        },
         "active": {
             "sessions_count": len(live),
             "workspaces": sorted({str(s.cwd) for s in live}),

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -14,6 +14,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from claude_dash.account import AccountInfo, read_account_info
 from claude_dash.aggregator import collect_live_sessions
 from claude_dash.models import SessionStats, Usage
 from claude_dash.pricing import cost_of
@@ -179,10 +180,41 @@ def _session_table(sessions: list[SessionStats]) -> Table:
     return table
 
 
+def _cost_label(acc: AccountInfo | None) -> str:
+    """Rótulo adequado ao plano de billing do usuário.
+
+    Em assinatura flat-rate (Max/Pro), 'Custo estimado' em USD é
+    desinformação — o usuário paga mensalidade fixa. O dashboard
+    sinaliza isso com o rótulo 'Custo (ref. API)' para deixar claro
+    que é custo hipotético, não cobrança efetiva.
+    """
+    if acc is not None and acc.is_flat_rate:
+        return "Custo (ref. API)"
+    return "Custo estimado"
+
+
+def _account_line(acc: AccountInfo | None) -> Text:
+    """Linha curta com info de conta; vazio se não encontrado."""
+    line = Text()
+    if acc is None:
+        return line
+    line.append(" Conta ", style="dim")
+    line.append(f"{acc.email}", style="bold")
+    line.append(" · ", style="dim")
+    line.append(f"{acc.billing_label}", style="bold cyan")
+    if acc.has_extra_usage_enabled and acc.extra_usage_disabled_reason:
+        line.append(
+            f" (extra usage desabilitado: {acc.extra_usage_disabled_reason})",
+            style="dim yellow",
+        )
+    return line
+
+
 def _header(sessions: list[SessionStats]) -> Panel:
     n = len(sessions)
     total_tokens = sum(s.total_usage.total for s in sessions)
     total_cost = sum(_total_cost(s) for s in sessions)
+    acc = read_account_info()
 
     total_usage = Usage()
     tool_totals: dict[str, int] = {}
@@ -199,12 +231,16 @@ def _header(sessions: list[SessionStats]) -> Panel:
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     header_text = Text()
+    acc_line = _account_line(acc)
+    if len(acc_line) > 0:
+        header_text.append_text(acc_line)
+        header_text.append("\n")
     header_text.append(f" {now}  ", style="dim")
     header_text.append(f"│  Sessões vivas: ", style="dim")
     header_text.append(f"{n}", style="bold cyan")
     header_text.append(f"  │  Tokens agregados: ", style="dim")
     header_text.append(f"{_fmt_tokens(total_tokens)}", style="bold")
-    header_text.append(f"  │  Custo estimado: ", style="dim")
+    header_text.append(f"  │  {_cost_label(acc)}: ", style="dim")
     header_text.append(f"${total_cost:,.2f}", style="bold yellow")
     header_text.append(f"  │  Cache hit: ", style="dim")
     header_text.append(f"{cache_hit_pct:.1f}%", style="bold green")
@@ -224,7 +260,7 @@ def _footer(refresh_sec: float) -> Panel:
 def _render(sessions: list[SessionStats], refresh_sec: float) -> Layout:
     layout = Layout()
     layout.split_column(
-        Layout(_header(sessions), size=3, name="header"),
+        Layout(_header(sessions), size=4, name="header"),
         Layout(Panel(_session_table(sessions), border_style="dim", title="Sessões",
                      title_align="left"), name="body"),
         Layout(_footer(refresh_sec), size=3, name="footer"),

--- a/src/claude_dash/views/today.py
+++ b/src/claude_dash/views/today.py
@@ -16,7 +16,10 @@ from rich.text import Text
 from claude_dash.aggregator import collect_sessions_since
 from claude_dash.models import SessionStats
 from claude_dash.pricing import cost_of
+from claude_dash.account import read_account_info
 from claude_dash.views.now import (
+    _account_line,
+    _cost_label,
     _fmt_duration,
     _fmt_short_cwd,
     _fmt_tokens,
@@ -41,19 +44,23 @@ def _header(sessions: list[SessionStats], since_ms: int) -> Panel:
     total_msgs_asst = sum(s.messages_assistant for s in sessions)
     alive = sum(1 for s in sessions if s.alive)
     dead = len(sessions) - alive
+    acc = read_account_info()
 
     since_str = datetime.fromtimestamp(since_ms / 1000).strftime("%Y-%m-%d %H:%M")
     now_str = datetime.now().strftime("%H:%M:%S")
 
-    # Layout em 2 linhas para caber em terminais ~80 cols
     header = Text()
+    acc_line = _account_line(acc)
+    if len(acc_line) > 0:
+        header.append_text(acc_line)
+        header.append("\n")
     header.append(f" {since_str}  →  {now_str}   ", style="dim")
     header.append(f"{len(sessions)}", style="bold cyan")
     header.append(" sessões   ", style="dim")
     header.append(f"[{alive} vivas · {dead} mortas]\n", style="dim")
     header.append(f" Tokens ", style="dim")
     header.append(f"{_fmt_tokens(total_tokens)}", style="bold")
-    header.append("   Custo ", style="dim")
+    header.append(f"   {_cost_label(acc)} ", style="dim")
     header.append(f"${total_cost:,.2f}", style="bold yellow")
     header.append("   Mensagens ", style="dim")
     header.append(f"{total_msgs_user}u/{total_msgs_asst}a", style="bold")

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,94 @@
+"""Testes de leitura de info da conta (~/.claude.json)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_dash.account import (
+    BILLING_API,
+    BILLING_FLAT_RATE,
+    AccountInfo,
+    read_account_info,
+)
+
+
+def _write_claude_json(tmp_path: Path, data: dict) -> Path:
+    path = tmp_path / "claude.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_read_account_info_from_oauth_block(tmp_path: Path) -> None:
+    path = _write_claude_json(tmp_path, {
+        "oauthAccount": {
+            "accountUuid": "uuid-a",
+            "emailAddress": "leo@example.com",
+            "organizationUuid": "uuid-b",
+            "hasExtraUsageEnabled": True,
+            "billingType": BILLING_FLAT_RATE,
+            "displayName": "Leo",
+            "organizationRole": "admin",
+            "organizationName": "Leo's Org",
+        },
+        "cachedExtraUsageDisabledReason": "out_of_credits",
+        "claudeCodeFirstTokenDate": "2026-03-01",
+    })
+    acc = read_account_info(path)
+    assert acc is not None
+    assert acc.email == "leo@example.com"
+    assert acc.display_name == "Leo"
+    assert acc.organization_role == "admin"
+    assert acc.billing_type == BILLING_FLAT_RATE
+    assert acc.has_extra_usage_enabled is True
+    assert acc.extra_usage_disabled_reason == "out_of_credits"
+    assert acc.first_token_date == "2026-03-01"
+
+
+def test_is_flat_rate_true_for_stripe_subscription() -> None:
+    acc = AccountInfo(
+        email="", display_name="", organization_name="",
+        organization_role="", billing_type=BILLING_FLAT_RATE,
+        has_extra_usage_enabled=False, extra_usage_disabled_reason=None,
+        first_token_date=None, account_uuid="", organization_uuid="",
+    )
+    assert acc.is_flat_rate is True
+    assert acc.billing_label == "Assinatura"
+
+
+def test_is_flat_rate_false_for_api() -> None:
+    acc = AccountInfo(
+        email="", display_name="", organization_name="",
+        organization_role="", billing_type=BILLING_API,
+        has_extra_usage_enabled=False, extra_usage_disabled_reason=None,
+        first_token_date=None, account_uuid="", organization_uuid="",
+    )
+    assert acc.is_flat_rate is False
+    assert "API" in acc.billing_label
+
+
+def test_read_returns_none_when_file_missing(tmp_path: Path) -> None:
+    assert read_account_info(tmp_path / "inexistente.json") is None
+
+
+def test_read_returns_none_when_no_oauth_block(tmp_path: Path) -> None:
+    path = _write_claude_json(tmp_path, {"outraChave": 123})
+    assert read_account_info(path) is None
+
+
+def test_read_returns_none_on_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{ not json")
+    assert read_account_info(path) is None
+
+
+def test_unknown_billing_label_includes_raw(tmp_path: Path) -> None:
+    path = _write_claude_json(tmp_path, {
+        "oauthAccount": {
+            "emailAddress": "x@y.com",
+            "billingType": "some_new_tier_2028",
+        },
+    })
+    acc = read_account_info(path)
+    assert acc is not None
+    assert acc.is_flat_rate is False
+    assert "some_new_tier_2028" in acc.billing_label


### PR DESCRIPTION
## Summary

Pedido do usuário: *"eu assino o plano Max. É possível ler qual a conta sendo utilizada e a assinatura?"* — o **custo estimado em USD** via tabela de preços API é desinformação para planos flat-rate (Max, Pro). O dashboard agora distingue billing types e adapta labels.

### Implementação

- **\`account.py\`** — \`AccountInfo\` dataclass lendo \`~/.claude.json\` (bloco \`oauthAccount\`)
  - \`is_flat_rate\` detecta assinatura (\`billing_type == stripe_subscription\`)
  - \`billing_label\` gera string humanizada (\`Assinatura\`/\`API (pay-as-you-go)\`/etc)
- **Views** — header de \`now\`/\`today\` passa a mostrar:
  \`\`\`
  Conta leonardo.menzani@gmail.com · Assinatura (extra usage desabilitado: out_of_credits)
  \`\`\`
  Label do custo adapta-se: \`Custo estimado\` → \`Custo (ref. API)\` em flat-rate, sinalizando que é hipotético e não cobrança efetiva.
- **MCP** — nova tool \`account_info()\` + chave \`"account"\` em \`workflow_snapshot\` para agentes consultarem billing type e decidirem se custos USD são relevantes.

### Test plan

- [x] 114 testes passando (+7 em \`test_account.py\`)
- [x] Smoke test real: account_info retorna email, billing_type correto (\`stripe_subscription\`), is_flat_rate=True
- [x] Header renderizado com info de conta (linha extra acima dos totais)

Bump: \`0.7.3\` → \`0.8.0\`.

### Futuro (v0.9)

Rate limits 5h/7d via hook opcional no \`~/.claude/settings.json\`, exibindo % consumido em vez de USD quando billing=flat-rate. Fora do escopo desta PR para manter incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)