### PR TITLE
v0.9 — rate limits 5h/7d via hook opcional

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ claude-dash tools              # breakdown de tool_use últimas 24h
 claude-dash session <sid>      # drill-down (prefixo de sessionId aceito)
 ```
 
+### Rate limits 5h/7d (hook opcional)
+
+Desde v0.9, o dashboard pode exibir o consumo real dos rate limits da
+conta (5h e 7d) — especialmente útil em planos flat-rate (Max/Pro),
+onde o custo em USD é hipotético e o que importa é **quanto do limite
+já foi usado**.
+
+O Claude Code só injeta `rate_limits` no JSON do statusline — por
+isso a captura requer uma linha extra no seu script de statusline
+(`settings.json:statusLine.command`). Instalação:
+
+1. Identifique o script configurado em `~/.claude/settings.json:statusLine.command`.
+2. Adicione no **topo** do seu script (depois do `input=$(cat)`):
+   ```bash
+   echo "$input" | claude-dash-rate-limit-capture > /dev/null
+   ```
+3. Reinicie a sessão do Claude Code. A cada render do statusline,
+   o snapshot de rate limits é gravado em `/tmp/claude-dash-rate-limits/`.
+
+Sem o hook instalado, o dashboard continua funcional — apenas omite a
+linha de rate limits no header. Graceful degradation.
+
 ### MCP server — canal para agentes
 
 A partir da v0.7, um servidor MCP expõe o estado do Claude Code como
@@ -82,6 +104,8 @@ Ferramentas expostas:
 | `today_summary` | Agregado do dia corrente |
 | `tools_breakdown(hours=24)` | Breakdown de `tool_use` no período |
 | `session_details(sid)` | Drill-down de 1 sessão |
+| `account_info` | Conta, organização, billing type (flat-rate vs API) |
+| `rate_limits` | Consumo 5h/7d (se hook opcional instalado) |
 | `workflow_snapshot` | **Canal unificado** — resumo + alertas acionáveis |
 
 ## Instalação

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -192,11 +192,17 @@ claude_dashboard/
   que é custo hipotético, não cobrança
 - [x] Tool MCP `account_info` + chave `account` em `workflow_snapshot`
 
-### Futuro — Rate limits por sessão
-- [ ] Hook opcional capturando `rate_limits.five_hour`/`seven_day` do
-  JSON do statusline em `/tmp/.claude-dash-rate-limits/*.json`
-- [ ] Views e MCP exibem % consumido dos limites em vez de custo USD
-  quando `is_flat_rate=True`
+### v0.9 — Rate limits 5h/7d via hook opcional
+- [x] `claude-dash-rate-limit-capture` entrypoint (pass-through stdin)
+- [x] `rate_limits.py` lê `/tmp/claude-dash-rate-limits/*.json` com
+  freshness check (15 min) e `global_worst_case` consolidando sessões
+- [x] View `now` header: linha extra "Rate limits 5h N% ↻ · 7d N% ↻"
+  (apenas se captura existe; degradação graceful sem hook)
+- [x] Tool MCP `rate_limits()` + chave `rate_limits` em `workflow_snapshot`
+- [x] Alertas rate-limit-aware em `_infer_alerts` (5h≥85%, 7d≥85%)
+- [x] Supressão de alerta de custo USD em planos flat-rate
+- [x] Instalação documentada no README (linha adicional no statusline
+  existente; não requer reescrita)
 
 ### v0.3 — Drill-down
 - [ ] View `session <sid>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.8.0"
+version = "0.9.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -37,6 +37,7 @@ dev = [
 [project.scripts]
 claude-dash = "claude_dash.cli:main"
 claude-dash-mcp = "claude_dash.mcp_server:main"
+claude-dash-rate-limit-capture = "claude_dash.rate_limit_capture:main"
 
 [project.urls]
 Homepage = "https://github.com/mencoding/claude-dashboard"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/claude_dash/mcp_server.py
+++ b/src/claude_dash/mcp_server.py
@@ -193,11 +193,12 @@ def rate_limits() -> dict[str, Any]:
     Retorna:
     - `installed`: True se há pelo menos 1 snapshot capturado (proxy
       para "usuário instalou o hook `claude-dash-rate-limit-capture`")
-    - `global_worst_case`: pior caso entre sessões vivas (5h%, 7d%,
-      tempo até reset) — rate limits são por conta, então o "pior
-      caso" reflete o estado real
+    - `global_worst_case`: pior caso entre sessões com snapshots
+      **frescos** (capturados nos últimos 15 min). Pode ser `None`
+      mesmo com `installed=True` se todos os snapshots estão stale —
+      sessões idle/encerradas. Consumidores devem checar explicitamente.
     - `by_session`: dict com snapshot por sessão (inclui age e
-      freshness)
+      freshness — o campo `is_fresh` distingue ativos de stale)
 
     Se o hook não estiver instalado, retorna `{"installed": false}`
     — instruções no README para adicionar uma linha no statusline

--- a/src/claude_dash/mcp_server.py
+++ b/src/claude_dash/mcp_server.py
@@ -21,6 +21,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from claude_dash.account import read_account_info
+from claude_dash.rate_limits import global_worst_case, read_all as read_rate_limits
 from claude_dash.aggregator import (
     build_stats_for_transcript,
     collect_live_sessions,
@@ -117,16 +118,36 @@ def _infer_alerts(
                 f"— próximo do limite 200k da janela padrão; considerar /compact."
             )
 
-    # Custo agregado do dia — sinal de sessão maratônica
-    total_cost_today = sum(
-        sum(cost_of(m, u) for m, u in s.usage_by_model.items())
-        for s in today_stats
-    )
-    if total_cost_today > 200:
-        alerts.append(
-            f"Consumo agregado do dia: ${total_cost_today:.2f}. Está acima do "
-            f"típico — revise se alguma sessão está em loop."
+    # Custo agregado do dia — sinal de sessão maratônica. Só relevante
+    # em billing pay-as-you-go; em assinatura flat-rate o custo em USD
+    # é hipotético (ver `account.is_flat_rate`).
+    acc = read_account_info()
+    if acc is None or not acc.is_flat_rate:
+        total_cost_today = sum(
+            sum(cost_of(m, u) for m, u in s.usage_by_model.items())
+            for s in today_stats
         )
+        if total_cost_today > 200:
+            alerts.append(
+                f"Consumo agregado do dia: ${total_cost_today:.2f}. Está acima do "
+                f"típico — revise se alguma sessão está em loop."
+            )
+
+    # Rate limits — só gera alerta se o hook opcional estiver instalado
+    worst_rl = global_worst_case()
+    if worst_rl is not None:
+        if worst_rl.five_hour_pct >= 85:
+            delta = max(0, worst_rl.five_hour_resets_in_seconds // 60)
+            alerts.append(
+                f"Rate limit 5h em {worst_rl.five_hour_pct:.0f}% — reset em "
+                f"~{delta} min. Sessões pesadas próximas do throttle."
+            )
+        if worst_rl.seven_day_pct >= 85:
+            days = max(0, worst_rl.seven_day_resets_in_seconds // 86400)
+            alerts.append(
+                f"Rate limit 7d em {worst_rl.seven_day_pct:.0f}% — reset em "
+                f"~{days} dia(s). Consumo semanal perto do limite do plano."
+            )
 
     return alerts
 
@@ -163,6 +184,53 @@ def account_info() -> dict[str, Any]:
         "account_uuid": acc.account_uuid,
         "organization_uuid": acc.organization_uuid,
     }
+
+
+@mcp.tool()
+def rate_limits() -> dict[str, Any]:
+    """Consumo atual dos rate limits 5h/7d (se hook opcional instalado).
+
+    Retorna:
+    - `installed`: True se há pelo menos 1 snapshot capturado (proxy
+      para "usuário instalou o hook `claude-dash-rate-limit-capture`")
+    - `global_worst_case`: pior caso entre sessões vivas (5h%, 7d%,
+      tempo até reset) — rate limits são por conta, então o "pior
+      caso" reflete o estado real
+    - `by_session`: dict com snapshot por sessão (inclui age e
+      freshness)
+
+    Se o hook não estiver instalado, retorna `{"installed": false}`
+    — instruções no README para adicionar uma linha no statusline
+    do usuário.
+    """
+    all_snaps = read_rate_limits()
+    if not all_snaps:
+        return {"installed": False, "reason": "nenhum snapshot em /tmp/claude-dash-rate-limits/"}
+
+    worst = global_worst_case()
+    result: dict[str, Any] = {
+        "installed": True,
+        "global_worst_case": None,
+        "by_session": {},
+    }
+    if worst is not None:
+        result["global_worst_case"] = {
+            "five_hour_pct": worst.five_hour_pct,
+            "five_hour_resets_in_seconds": worst.five_hour_resets_in_seconds,
+            "seven_day_pct": worst.seven_day_pct,
+            "seven_day_resets_in_seconds": worst.seven_day_resets_in_seconds,
+            "captured_from_session": worst.session_id,
+            "age_seconds": worst.age_ms // 1000,
+        }
+    for sid, snap in all_snaps.items():
+        result["by_session"][sid] = {
+            "five_hour_pct": snap.five_hour_pct,
+            "seven_day_pct": snap.seven_day_pct,
+            "age_seconds": snap.age_ms // 1000,
+            "is_fresh": snap.is_fresh,
+            "model_id": snap.model_id,
+        }
+    return result
 
 
 @mcp.tool()
@@ -308,7 +376,10 @@ def workflow_snapshot() -> dict[str, Any]:
       (1) output/turno alto em sessão viva,
       (2) sessão viva sem atividade há > 30 min,
       (3) contexto ativo > 150k tokens (perto do limite 200k),
-      (4) custo agregado do dia > $200.
+      (4) custo agregado do dia > $200 (só em API billing — ignorado
+          em plano flat-rate onde custo USD é hipotético),
+      (5) rate limit 5h ≥ 85% (requer hook opcional instalado),
+      (6) rate limit 7d ≥ 85% (requer hook opcional instalado).
     """
     live = collect_live_sessions()
     today = collect_sessions_since(today_start_ms())
@@ -338,6 +409,17 @@ def workflow_snapshot() -> dict[str, Any]:
     peak_hour = hourly.index(max(hourly)) if any(hourly) else None
 
     acc = read_account_info()
+    worst_rl = global_worst_case()
+
+    rate_limits_block: dict[str, Any] = {"installed": False}
+    if worst_rl is not None:
+        rate_limits_block = {
+            "installed": True,
+            "five_hour_pct": worst_rl.five_hour_pct,
+            "seven_day_pct": worst_rl.seven_day_pct,
+            "five_hour_resets_in_seconds": worst_rl.five_hour_resets_in_seconds,
+            "seven_day_resets_in_seconds": worst_rl.seven_day_resets_in_seconds,
+        }
 
     return {
         "generated_at": datetime.now().isoformat(),
@@ -346,6 +428,7 @@ def workflow_snapshot() -> dict[str, Any]:
             "billing_label": acc.billing_label if acc else None,
             "is_flat_rate": acc.is_flat_rate if acc else None,
         },
+        "rate_limits": rate_limits_block,
         "active": {
             "sessions_count": len(live),
             "workspaces": sorted({str(s.cwd) for s in live}),

--- a/src/claude_dash/rate_limit_capture.py
+++ b/src/claude_dash/rate_limit_capture.py
@@ -1,0 +1,85 @@
+"""Capturador de rate_limits a partir do JSON de input do statusline.
+
+O Claude Code só injeta `rate_limits.five_hour` / `seven_day` no JSON que
+passa para o script configurado em `settings.json:statusLine`. Nenhum
+hook recebe esses campos. Esta camada resolve com um padrão de pipeline
+composable:
+
+1. Usuário adiciona uma linha no seu statusline script que faz tee do
+   JSON de entrada para este capturador:
+       echo "$input" | claude-dash-rate-limit-capture > /dev/null
+2. Este script extrai rate_limits + session_id + context_window atual e
+   grava em /tmp/claude-dash-rate-limits/<session_id>.json, com timestamp.
+3. O dashboard (TUI, MCP, views) lê esse diretório e exibe o snapshot
+   mais recente por sessão.
+
+A gravação é pass-through (stdout mirra stdin) para permitir compor com
+pipes, mas no uso típico do Léo o chamador descarta o stdout pra não
+duplicar o status line.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+CAPTURE_DIR = Path(os.environ.get(
+    "CLAUDE_DASH_RATE_LIMIT_DIR",
+    "/tmp/claude-dash-rate-limits",
+))
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Escrita atômica (tmp + rename) pra evitar leituras parciais."""
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(content)
+    tmp.replace(path)
+
+
+def capture_from_json(raw: str, capture_dir: Path = CAPTURE_DIR) -> bool:
+    """Extrai rate_limits de uma string JSON e grava em `capture_dir`.
+
+    Retorna True se a captura gravou algo, False caso contrário
+    (JSON inválido, ausência dos campos, falha de I/O).
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+    rate_limits = data.get("rate_limits")
+    sid = data.get("session_id")
+    if not rate_limits or not sid:
+        return False
+
+    payload = {
+        "session_id": sid,
+        "captured_at_ms": int(time.time() * 1000),
+        "rate_limits": rate_limits,
+        "context_window": data.get("context_window"),
+        "model_id": (data.get("model") or {}).get("id"),
+    }
+
+    try:
+        capture_dir.mkdir(parents=True, exist_ok=True)
+        _atomic_write(capture_dir / f"{sid}.json", json.dumps(payload))
+    except OSError:
+        return False
+    return True
+
+
+def main() -> int:
+    """Entrypoint console. Lê stdin, captura, espelha no stdout (pass-through)."""
+    raw = sys.stdin.read()
+    capture_from_json(raw)
+    # Pass-through: permite colocar este passo num pipe sem quebrar a
+    # chain. Ex: `echo "$input" | claude-dash-rate-limit-capture | my_statusline`
+    sys.stdout.write(raw)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/claude_dash/rate_limits.py
+++ b/src/claude_dash/rate_limits.py
@@ -1,0 +1,147 @@
+"""Leitura dos snapshots de rate_limits capturados pelo hook opcional.
+
+Se o hook `claude-dash-rate-limit-capture` está instalado (ver
+`rate_limit_capture.py`), este módulo lê os arquivos JSON por sessão
+que ele grava em /tmp e expõe uma visão consolidada para views e MCP.
+
+Se o hook NÃO está instalado, todas as funções retornam vazio —
+graceful degradation, o dashboard continua funcional sem rate limits.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from claude_dash.rate_limit_capture import CAPTURE_DIR
+
+
+# Quanto tempo um snapshot é considerado "fresco". Claude Code atualiza
+# o statusline a cada interação — se passa de 15 min sem update, o
+# número provavelmente está desatualizado (sessão idle ou terminada).
+FRESHNESS_MS = 15 * 60 * 1000
+
+
+@dataclass(slots=True)
+class RateLimitSnapshot:
+    """Snapshot mais recente de rate limits de uma sessão."""
+
+    session_id: str
+    captured_at_ms: int
+    five_hour_pct: float         # 0..100
+    five_hour_resets_at_ms: int  # epoch ms; 0 se desconhecido
+    seven_day_pct: float
+    seven_day_resets_at_ms: int
+    model_id: str | None = None
+
+    @property
+    def age_ms(self) -> int:
+        return int(datetime.now().timestamp() * 1000) - self.captured_at_ms
+
+    @property
+    def is_fresh(self) -> bool:
+        return self.age_ms < FRESHNESS_MS
+
+    @property
+    def five_hour_resets_in_seconds(self) -> int:
+        now_ms = int(datetime.now().timestamp() * 1000)
+        return max(0, self.five_hour_resets_at_ms - now_ms) // 1000
+
+    @property
+    def seven_day_resets_in_seconds(self) -> int:
+        now_ms = int(datetime.now().timestamp() * 1000)
+        return max(0, self.seven_day_resets_at_ms - now_ms) // 1000
+
+
+def _parse_snapshot(data: dict) -> RateLimitSnapshot | None:
+    """Deserializa um arquivo JSON gravado pelo capturador."""
+    rl = data.get("rate_limits") or {}
+    five = rl.get("five_hour") or {}
+    seven = rl.get("seven_day") or {}
+    sid = data.get("session_id")
+    captured = data.get("captured_at_ms")
+
+    if not sid or not captured:
+        return None
+
+    # `resets_at` no JSON do Claude Code vem em epoch SEGUNDOS
+    def _to_ms(val) -> int:  # noqa: ANN001
+        if val is None:
+            return 0
+        try:
+            n = int(val)
+        except (TypeError, ValueError):
+            return 0
+        # Se o número couber em epoch seconds (até 2030), multiplica
+        # por 1000; se já é ms (≥10^12), mantém.
+        return n * 1000 if n < 10**12 else n
+
+    return RateLimitSnapshot(
+        session_id=sid,
+        captured_at_ms=int(captured),
+        five_hour_pct=float(five.get("used_percentage") or 0),
+        five_hour_resets_at_ms=_to_ms(five.get("resets_at")),
+        seven_day_pct=float(seven.get("used_percentage") or 0),
+        seven_day_resets_at_ms=_to_ms(seven.get("resets_at")),
+        model_id=data.get("model_id"),
+    )
+
+
+def read_all(capture_dir: Path = CAPTURE_DIR) -> dict[str, RateLimitSnapshot]:
+    """Lê todos os snapshots disponíveis; key = session_id."""
+    if not capture_dir.is_dir():
+        return {}
+    out: dict[str, RateLimitSnapshot] = {}
+    for f in capture_dir.glob("*.json"):
+        try:
+            data = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        snap = _parse_snapshot(data)
+        if snap is not None:
+            out[snap.session_id] = snap
+    return out
+
+
+def read_for_session(
+    session_id: str, capture_dir: Path = CAPTURE_DIR
+) -> RateLimitSnapshot | None:
+    """Snapshot de uma sessão específica, ou None se não houver captura."""
+    path = capture_dir / f"{session_id}.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return _parse_snapshot(data)
+
+
+def global_worst_case(
+    capture_dir: Path = CAPTURE_DIR,
+) -> RateLimitSnapshot | None:
+    """Snapshot "pior caso" entre todas as sessões capturadas.
+
+    Rate limits são por conta (compartilhados entre sessões). O maior
+    `five_hour_pct` reflete o estado real da conta no momento mais
+    recente capturado. Retorna None se não há snapshots frescos.
+    """
+    fresh = [s for s in read_all(capture_dir).values() if s.is_fresh]
+    if not fresh:
+        return None
+    # Escolhe o snapshot com maior 5h% (mais recente em caso de empate)
+    return max(fresh, key=lambda s: (s.five_hour_pct, s.captured_at_ms))
+
+
+def format_reset_delta(seconds: int) -> str:
+    """Formato compacto: '3h42m', '42m', '2d3h'. Vazio se <=0."""
+    if seconds <= 0:
+        return ""
+    if seconds >= 86400:
+        d, rem = divmod(seconds, 86400)
+        return f"{d}d{rem // 3600}h"
+    if seconds >= 3600:
+        h, rem = divmod(seconds, 3600)
+        return f"{h}h{rem // 60}m"
+    return f"{seconds // 60}m"

--- a/src/claude_dash/rate_limits.py
+++ b/src/claude_dash/rate_limits.py
@@ -123,15 +123,22 @@ def global_worst_case(
 ) -> RateLimitSnapshot | None:
     """Snapshot "pior caso" entre todas as sessões capturadas.
 
-    Rate limits são por conta (compartilhados entre sessões). O maior
-    `five_hour_pct` reflete o estado real da conta no momento mais
-    recente capturado. Retorna None se não há snapshots frescos.
+    Rate limits são por conta (compartilhados entre sessões). O snapshot
+    retornado é o que tem o maior percentual entre 5h E 7d — qualquer
+    um dos dois perto do throttle é motivo para atenção. Em empate,
+    desempate pelo mais recente.
+
+    Retorna None se não há snapshots frescos (<15 min).
     """
     fresh = [s for s in read_all(capture_dir).values() if s.is_fresh]
     if not fresh:
         return None
-    # Escolhe o snapshot com maior 5h% (mais recente em caso de empate)
-    return max(fresh, key=lambda s: (s.five_hour_pct, s.captured_at_ms))
+    # Pior caso = max entre 5h% e 7d% (qualquer um crítico pesa igual),
+    # desempate por captured_at_ms descendente
+    return max(
+        fresh,
+        key=lambda s: (max(s.five_hour_pct, s.seven_day_pct), s.captured_at_ms),
+    )
 
 
 def format_reset_delta(seconds: int) -> str:

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -18,6 +18,11 @@ from claude_dash.account import AccountInfo, read_account_info
 from claude_dash.aggregator import collect_live_sessions
 from claude_dash.models import SessionStats, Usage
 from claude_dash.pricing import cost_of
+from claude_dash.rate_limits import (
+    RateLimitSnapshot,
+    format_reset_delta,
+    global_worst_case,
+)
 
 
 REFRESH_SEC = 2.0
@@ -210,6 +215,36 @@ def _account_line(acc: AccountInfo | None) -> Text:
     return line
 
 
+def _rate_limit_line(snap: RateLimitSnapshot | None) -> Text:
+    """Linha com consumo 5h/7d da conta; vazia se não há captura.
+
+    Só aparece quando o hook opcional `claude-dash-rate-limit-capture`
+    está instalado. Sem captura, a linha é omitida (graceful degradation).
+    """
+    line = Text()
+    if snap is None or not snap.is_fresh:
+        return line
+    line.append(" Rate limits ", style="dim")
+    # 5h
+    pct5 = snap.five_hour_pct
+    color5 = "bold red" if pct5 >= 85 else "bold yellow" if pct5 >= 60 else "bold"
+    line.append("5h ", style="dim")
+    line.append(f"{pct5:.0f}%", style=color5)
+    delta5 = format_reset_delta(snap.five_hour_resets_in_seconds)
+    if delta5:
+        line.append(f" ↻{delta5}", style="dim")
+    line.append("   ", style="dim")
+    # 7d
+    pct7 = snap.seven_day_pct
+    color7 = "bold red" if pct7 >= 85 else "bold yellow" if pct7 >= 60 else "bold"
+    line.append("7d ", style="dim")
+    line.append(f"{pct7:.0f}%", style=color7)
+    delta7 = format_reset_delta(snap.seven_day_resets_in_seconds)
+    if delta7:
+        line.append(f" ↻{delta7}", style="dim")
+    return line
+
+
 def _header(sessions: list[SessionStats]) -> Panel:
     n = len(sessions)
     total_tokens = sum(s.total_usage.total for s in sessions)
@@ -235,6 +270,10 @@ def _header(sessions: list[SessionStats]) -> Panel:
     if len(acc_line) > 0:
         header_text.append_text(acc_line)
         header_text.append("\n")
+    rl_line = _rate_limit_line(global_worst_case())
+    if len(rl_line) > 0:
+        header_text.append_text(rl_line)
+        header_text.append("\n")
     header_text.append(f" {now}  ", style="dim")
     header_text.append(f"│  Sessões vivas: ", style="dim")
     header_text.append(f"{n}", style="bold cyan")
@@ -258,9 +297,15 @@ def _footer(refresh_sec: float) -> Panel:
 
 
 def _render(sessions: list[SessionStats], refresh_sec: float) -> Layout:
+    # Header: 1 borda sup + data/stats + 1 borda inf = 3 linhas base.
+    # Linhas condicionais: +1 se tem account info, +1 se tem rate limits.
+    has_account = read_account_info() is not None
+    has_rl = global_worst_case() is not None
+    header_size = 3 + (1 if has_account else 0) + (1 if has_rl else 0)
+
     layout = Layout()
     layout.split_column(
-        Layout(_header(sessions), size=4, name="header"),
+        Layout(_header(sessions), size=header_size, name="header"),
         Layout(Panel(_session_table(sessions), border_style="dim", title="Sessões",
                      title_align="left"), name="body"),
         Layout(_footer(refresh_sec), size=3, name="footer"),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -85,16 +85,47 @@ def test_workflow_snapshot_has_alerts_section() -> None:
 
 
 def test_workflow_snapshot_alert_on_high_cost() -> None:
-    """Custo agregado do dia > $200 dispara alerta."""
+    """Custo agregado do dia > $200 dispara alerta (apenas em billing API).
+
+    Em plano flat-rate (is_flat_rate=True), o alerta de custo em USD é
+    suprimido porque o valor não representa cobrança real — o usuário
+    paga mensalidade fixa. Este teste valida o caminho API.
+    """
     big_spender = _mk_session(
         cost_usage=Usage(input_tokens=50_000_000),  # $250 em input Opus
     )
     with patch.object(mcp_server, "collect_live_sessions", return_value=[]), \
          patch.object(mcp_server, "collect_sessions_since", return_value=[big_spender]), \
-         patch.object(mcp_server, "collect_tool_usage_since", return_value={}):
+         patch.object(mcp_server, "collect_tool_usage_since", return_value={}), \
+         patch.object(mcp_server, "read_account_info", return_value=None):
+        # read_account_info=None é tratado como "API billing" (caminho
+        # conservador — quando não se sabe, assume-se que USD é real)
         snap = mcp_server.workflow_snapshot()
 
     assert any("Consumo agregado do dia" in a for a in snap["alerts"])
+
+
+def test_workflow_snapshot_suppresses_cost_alert_on_flat_rate() -> None:
+    """Em billing flat-rate, alerta de custo diário é suprimido."""
+    from claude_dash.account import AccountInfo, BILLING_FLAT_RATE
+
+    big_spender = _mk_session(
+        cost_usage=Usage(input_tokens=50_000_000),
+    )
+    flat_rate_account = AccountInfo(
+        email="x@y.com", display_name="", organization_name="",
+        organization_role="", billing_type=BILLING_FLAT_RATE,
+        has_extra_usage_enabled=False, extra_usage_disabled_reason=None,
+        first_token_date=None, account_uuid="", organization_uuid="",
+    )
+    with patch.object(mcp_server, "collect_live_sessions", return_value=[]), \
+         patch.object(mcp_server, "collect_sessions_since", return_value=[big_spender]), \
+         patch.object(mcp_server, "collect_tool_usage_since", return_value={}), \
+         patch.object(mcp_server, "read_account_info", return_value=flat_rate_account):
+        snap = mcp_server.workflow_snapshot()
+
+    # Alerta de custo NÃO deve aparecer porque is_flat_rate=True
+    assert not any("Consumo agregado do dia" in a for a in snap["alerts"])
 
 
 def test_workflow_snapshot_alert_on_high_context() -> None:

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -109,6 +109,29 @@ class TestGlobalWorstCase:
     def test_worst_case_none_when_empty(self, cap_dir: Path) -> None:
         assert global_worst_case(cap_dir) is None
 
+    def test_worst_case_picks_by_max_of_5h_or_7d(self, cap_dir: Path) -> None:
+        """Um snapshot com 7d% alto deve ganhar mesmo que 5h% seja baixo.
+
+        Regressão do review do PR #15: critério anterior era `max(5h%)`
+        isolado, perdia casos onde o 7d é o gargalo real (consumo
+        semanal alto mas janela de 5h resetou recente).
+        """
+        # Snapshot A: 5h baixo, 7d crítico (pior caso real)
+        capture_from_json(
+            _sample_statusline_json(sid="seven-day-crit", five_pct=10, seven_pct=92),
+            cap_dir,
+        )
+        # Snapshot B: 5h moderado, 7d baixo
+        capture_from_json(
+            _sample_statusline_json(sid="five-hour-mid", five_pct=55, seven_pct=20),
+            cap_dir,
+        )
+        worst = global_worst_case(cap_dir)
+        assert worst is not None
+        # Escolhe pelo 7d=92, não pelo 5h=55
+        assert worst.session_id == "seven-day-crit"
+        assert worst.seven_day_pct == 92
+
 
 class TestFormatResetDelta:
     def test_zero_returns_empty(self) -> None:

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -1,0 +1,138 @@
+"""Testes do capturador e leitor de rate limits."""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from claude_dash.rate_limit_capture import capture_from_json
+from claude_dash.rate_limits import (
+    format_reset_delta,
+    global_worst_case,
+    read_all,
+    read_for_session,
+)
+
+
+@pytest.fixture
+def cap_dir(tmp_path: Path) -> Path:
+    return tmp_path / "rate-limits"
+
+
+def _sample_statusline_json(
+    sid: str = "sid-abc",
+    five_pct: float = 13,
+    seven_pct: float = 18,
+    five_resets_in_s: int = 3600 * 3,
+    seven_resets_in_s: int = 3600 * 24 * 5,
+) -> str:
+    now_s = int(time.time())
+    return json.dumps({
+        "session_id": sid,
+        "model": {"id": "claude-opus-4-7"},
+        "rate_limits": {
+            "five_hour": {
+                "used_percentage": five_pct,
+                "resets_at": now_s + five_resets_in_s,
+            },
+            "seven_day": {
+                "used_percentage": seven_pct,
+                "resets_at": now_s + seven_resets_in_s,
+            },
+        },
+        "context_window": {"used_percentage": 12},
+    })
+
+
+class TestCapture:
+    def test_captures_rate_limits(self, cap_dir: Path) -> None:
+        raw = _sample_statusline_json(sid="abc", five_pct=42)
+        ok = capture_from_json(raw, capture_dir=cap_dir)
+        assert ok is True
+        assert (cap_dir / "abc.json").is_file()
+
+    def test_captures_nothing_on_invalid_json(self, cap_dir: Path) -> None:
+        assert capture_from_json("{ not json", capture_dir=cap_dir) is False
+
+    def test_captures_nothing_without_rate_limits(self, cap_dir: Path) -> None:
+        raw = json.dumps({"session_id": "abc", "model": {"id": "x"}})
+        assert capture_from_json(raw, capture_dir=cap_dir) is False
+
+    def test_captures_nothing_without_session_id(self, cap_dir: Path) -> None:
+        raw = json.dumps({
+            "rate_limits": {"five_hour": {"used_percentage": 10}}
+        })
+        assert capture_from_json(raw, capture_dir=cap_dir) is False
+
+    def test_capture_is_atomic(self, cap_dir: Path) -> None:
+        """Deve gravar via rename, não deixando .tmp para trás."""
+        raw = _sample_statusline_json(sid="sid-z")
+        capture_from_json(raw, capture_dir=cap_dir)
+        assert (cap_dir / "sid-z.json").is_file()
+        assert not (cap_dir / "sid-z.tmp").exists()
+
+
+class TestRead:
+    def test_read_for_session(self, cap_dir: Path) -> None:
+        capture_from_json(_sample_statusline_json(sid="s1", five_pct=67), cap_dir)
+        snap = read_for_session("s1", cap_dir)
+        assert snap is not None
+        assert snap.session_id == "s1"
+        assert snap.five_hour_pct == 67
+        assert snap.is_fresh is True
+
+    def test_read_all_returns_dict(self, cap_dir: Path) -> None:
+        capture_from_json(_sample_statusline_json(sid="s1"), cap_dir)
+        capture_from_json(_sample_statusline_json(sid="s2", five_pct=90), cap_dir)
+        result = read_all(cap_dir)
+        assert set(result.keys()) == {"s1", "s2"}
+
+    def test_read_for_absent_session_returns_none(self, cap_dir: Path) -> None:
+        assert read_for_session("nao-existe", cap_dir) is None
+
+    def test_read_all_empty_when_dir_missing(self, tmp_path: Path) -> None:
+        assert read_all(tmp_path / "nao-existe") == {}
+
+
+class TestGlobalWorstCase:
+    def test_worst_case_picks_highest_5h_pct(self, cap_dir: Path) -> None:
+        capture_from_json(_sample_statusline_json(sid="low", five_pct=10), cap_dir)
+        capture_from_json(_sample_statusline_json(sid="high", five_pct=87), cap_dir)
+        capture_from_json(_sample_statusline_json(sid="mid", five_pct=50), cap_dir)
+        worst = global_worst_case(cap_dir)
+        assert worst is not None
+        assert worst.session_id == "high"
+        assert worst.five_hour_pct == 87
+
+    def test_worst_case_none_when_empty(self, cap_dir: Path) -> None:
+        assert global_worst_case(cap_dir) is None
+
+
+class TestFormatResetDelta:
+    def test_zero_returns_empty(self) -> None:
+        assert format_reset_delta(0) == ""
+        assert format_reset_delta(-1) == ""
+
+    def test_under_hour(self) -> None:
+        assert format_reset_delta(42 * 60) == "42m"
+
+    def test_hours_and_minutes(self) -> None:
+        assert format_reset_delta(3 * 3600 + 15 * 60) == "3h15m"
+
+    def test_days(self) -> None:
+        assert format_reset_delta(2 * 86400 + 3 * 3600) == "2d3h"
+
+
+class TestResetsInSeconds:
+    def test_positive_seconds_to_reset(self, cap_dir: Path) -> None:
+        # Timestamp de reset 1 hora no futuro
+        capture_from_json(
+            _sample_statusline_json(sid="x", five_resets_in_s=3600),
+            cap_dir,
+        )
+        snap = read_for_session("x", cap_dir)
+        assert snap is not None
+        # Tolerância: 3600 ± 5 segundos (round-trip via timestamps)
+        assert 3590 <= snap.five_hour_resets_in_seconds <= 3600


### PR DESCRIPTION
Fecha o roadmap prometido no SCOPE. Captura \`rate_limits\` do JSON do statusline (única fonte onde o Claude Code expõe isso) via hook opcional composable.

### Arquitetura

- **Capturador** (\`rate_limit_capture.py\`): entrypoint \`claude-dash-rate-limit-capture\` lê stdin, grava em \`/tmp/claude-dash-rate-limits/<sid>.json\`, espelha stdin→stdout para compor com pipes.
- **Leitor** (\`rate_limits.py\`): freshness 15min, \`global_worst_case\` agrega entre sessões (rate limits são por conta).
- **Views**: header de \`now\` ganha linha extra colorida (dim<60%, yellow≥60%, red≥85%) **só quando há captura** (graceful degradation).
- **MCP**: nova tool \`rate_limits()\` + chave em \`workflow_snapshot\` + 2 alertas novos (\`_infer_alerts\`). Alerta de custo diário suprimido em planos flat-rate.

### Instalação (1 linha)

Adicionar no topo do script em \`settings.json:statusLine.command\`:
\`\`\`bash
echo "\$input" | claude-dash-rate-limit-capture > /dev/null
\`\`\`

### Test plan

- [x] 131 testes passando (+16 em \`test_rate_limits.py\` + 1 em \`test_mcp_server.py\`)
- [x] Smoke test: entrypoint instalado, captura grava JSON correto
- [x] Graceful degradation validada — sem hook, header omite a linha

Bump: \`0.8.0\` → \`0.9.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)