### PR TITLE
fix: rate limits visuais + separação billing vs créditos extras — v0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.9.0"
+version = "0.9.1"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/src/claude_dash/account.py
+++ b/src/claude_dash/account.py
@@ -55,17 +55,52 @@ class AccountInfo:
 
     @property
     def billing_label(self) -> str:
-        """String curta para exibição (ex: 'Assinatura', 'API (pay-as-you-go)')."""
+        """Label do **tipo de cobrança** (Stripe / API / Enterprise).
+
+        Nota importante: o Claude Code **não expõe o nome do plano**
+        (Pro, Max, Team, etc) em `~/.claude.json`. Esse dado só viria
+        via call autenticada à API da Anthropic. Aqui retornamos o
+        tipo de cobrança, que é o dado disponível localmente.
+        """
         if self.billing_type == BILLING_FLAT_RATE:
-            # O nome exato do plano (Max/Pro) não está no JSON local;
-            # ficamos com "Assinatura" como label neutro. Se o Léo
-            # quiser diferenciar depois, podemos buscar via API.
-            return "Assinatura"
+            return "Assinatura (Stripe)"
         if self.billing_type == BILLING_API:
             return "API (pay-as-you-go)"
         if self.billing_type == BILLING_ENTERPRISE:
             return "Enterprise"
-        return f"Desconhecido ({self.billing_type})"
+        return f"Billing desconhecido ({self.billing_type})"
+
+    @property
+    def extra_usage_label(self) -> str:
+        """Status do pay-as-you-go adicional (créditos extras).
+
+        Retorna uma descrição compacta combinando capability
+        (`has_extra_usage_enabled`) com o runtime status
+        (`extra_usage_disabled_reason`). Estes são dois campos
+        ortogonais:
+        - capability = conta está inscrita no programa pay-as-you-go
+        - runtime reason = motivo pelo qual NÃO está disponível agora
+          (ex: sem saldo, bloqueio temporário)
+
+        Exemplos de retorno:
+            'habilitado, sem créditos no momento'
+            'habilitado, disponível'
+            'desabilitado'
+        """
+        if not self.has_extra_usage_enabled:
+            return "desabilitado"
+        if self.extra_usage_disabled_reason:
+            # Traduz códigos comuns para PT-BR
+            reason = {
+                "out_of_credits": "sem créditos no momento",
+                "billing_issue": "problema de cobrança",
+                "exceeded_limit": "limite de gastos excedido",
+            }.get(
+                self.extra_usage_disabled_reason,
+                self.extra_usage_disabled_reason,
+            )
+            return f"habilitado, {reason}"
+        return "habilitado, disponível"
 
 
 def read_account_info(

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -199,50 +199,81 @@ def _cost_label(acc: AccountInfo | None) -> str:
 
 
 def _account_line(acc: AccountInfo | None) -> Text:
-    """Linha curta com info de conta; vazio se não encontrado."""
+    """Linha de info da conta, organizada em 3 campos semânticos:
+    email · billing type · status dos créditos extras.
+
+    Antes os 3 campos apareciam misturados ("Assinatura (extra usage
+    desabilitado: out_of_credits)"), dando a impressão de que "extra
+    usage desabilitado" era o status do plano. Agora separados com
+    nomes dos campos, cada um é claramente identificável.
+    """
     line = Text()
     if acc is None:
         return line
     line.append(" Conta ", style="dim")
     line.append(f"{acc.email}", style="bold")
-    line.append(" · ", style="dim")
+    line.append("  ·  Billing: ", style="dim")
     line.append(f"{acc.billing_label}", style="bold cyan")
-    if acc.has_extra_usage_enabled and acc.extra_usage_disabled_reason:
-        line.append(
-            f" (extra usage desabilitado: {acc.extra_usage_disabled_reason})",
-            style="dim yellow",
-        )
+    line.append("  ·  Créditos extras: ", style="dim")
+    # Cor do status de créditos: verde=disponível, amarelo=sem créditos,
+    # dim=desabilitado.
+    label = acc.extra_usage_label
+    if "disponível" in label:
+        style = "bold green"
+    elif "sem créditos" in label or "bloqueado" in label:
+        style = "bold yellow"
+    else:
+        style = "dim"
+    line.append(label, style=style)
     return line
 
 
-def _rate_limit_line(snap: RateLimitSnapshot | None) -> Text:
-    """Linha com consumo 5h/7d da conta; vazia se não há captura.
+def _rate_limit_bar(pct: float, width: int = 14) -> str:
+    """Barra ASCII estilo progresso, proporcional ao percentual.
 
-    Só aparece quando o hook opcional `claude-dash-rate-limit-capture`
-    está instalado. Sem captura, a linha é omitida (graceful degradation).
+    Exemplo para pct=42, width=14:
+        '[█████░░░░░░░░]'
     """
-    line = Text()
+    pct = max(0.0, min(100.0, pct))
+    filled = int(round(pct / 100 * width))
+    empty = width - filled
+    return "[" + "█" * filled + "░" * empty + "]"
+
+
+def _rate_limit_block(snap: RateLimitSnapshot | None) -> Text:
+    """Bloco de 2 linhas exibindo consumo 5h e 7d da conta.
+
+    Layout (cada janela em uma linha):
+        Janela 5h  [██░░░░░░░░░░░░]  13%   reseta em 3h48m
+        Janela 7d  [███░░░░░░░░░░░]  18%   reseta em 6d 1h
+
+    Vazio se não há captura fresca (graceful degradation).
+    """
+    out = Text()
     if snap is None or not snap.is_fresh:
-        return line
-    line.append(" Rate limits ", style="dim")
-    # 5h
-    pct5 = snap.five_hour_pct
-    color5 = "bold red" if pct5 >= 85 else "bold yellow" if pct5 >= 60 else "bold"
-    line.append("5h ", style="dim")
-    line.append(f"{pct5:.0f}%", style=color5)
-    delta5 = format_reset_delta(snap.five_hour_resets_in_seconds)
-    if delta5:
-        line.append(f" ↻{delta5}", style="dim")
-    line.append("   ", style="dim")
-    # 7d
-    pct7 = snap.seven_day_pct
-    color7 = "bold red" if pct7 >= 85 else "bold yellow" if pct7 >= 60 else "bold"
-    line.append("7d ", style="dim")
-    line.append(f"{pct7:.0f}%", style=color7)
-    delta7 = format_reset_delta(snap.seven_day_resets_in_seconds)
-    if delta7:
-        line.append(f" ↻{delta7}", style="dim")
-    return line
+        return out
+
+    for label, pct, resets_in_s in (
+        ("Janela 5h", snap.five_hour_pct, snap.five_hour_resets_in_seconds),
+        ("Janela 7d", snap.seven_day_pct, snap.seven_day_resets_in_seconds),
+    ):
+        color = (
+            "bold red" if pct >= 85
+            else "bold yellow" if pct >= 60
+            else "bold green"
+        )
+        out.append(f" {label}  ", style="dim")
+        out.append(_rate_limit_bar(pct), style=color)
+        out.append(f"  {pct:5.1f}%", style=color)
+        delta = format_reset_delta(resets_in_s)
+        if delta:
+            out.append(f"   reseta em {delta}", style="dim")
+        out.append("\n")
+
+    # Remove o último \n para não adicionar linha vazia no header
+    if out.plain.endswith("\n"):
+        out = out[:-1]
+    return out
 
 
 def _header(sessions: list[SessionStats]) -> Panel:
@@ -270,9 +301,9 @@ def _header(sessions: list[SessionStats]) -> Panel:
     if len(acc_line) > 0:
         header_text.append_text(acc_line)
         header_text.append("\n")
-    rl_line = _rate_limit_line(global_worst_case())
-    if len(rl_line) > 0:
-        header_text.append_text(rl_line)
+    rl_block = _rate_limit_block(global_worst_case())
+    if len(rl_block) > 0:
+        header_text.append_text(rl_block)
         header_text.append("\n")
     header_text.append(f" {now}  ", style="dim")
     header_text.append(f"│  Sessões vivas: ", style="dim")
@@ -298,10 +329,11 @@ def _footer(refresh_sec: float) -> Panel:
 
 def _render(sessions: list[SessionStats], refresh_sec: float) -> Layout:
     # Header: 1 borda sup + data/stats + 1 borda inf = 3 linhas base.
-    # Linhas condicionais: +1 se tem account info, +1 se tem rate limits.
+    # Linhas condicionais: +1 se tem account info, +2 se tem rate limits
+    # (bloco renderiza 2 linhas — uma para 5h, outra para 7d).
     has_account = read_account_info() is not None
     has_rl = global_worst_case() is not None
-    header_size = 3 + (1 if has_account else 0) + (1 if has_rl else 0)
+    header_size = 3 + (1 if has_account else 0) + (2 if has_rl else 0)
 
     layout = Layout()
     layout.split_column(

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -52,7 +52,8 @@ def test_is_flat_rate_true_for_stripe_subscription() -> None:
         first_token_date=None, account_uuid="", organization_uuid="",
     )
     assert acc.is_flat_rate is True
-    assert acc.billing_label == "Assinatura"
+    # billing_label agora indica tipo de cobrança (Stripe), não o plano
+    assert acc.billing_label == "Assinatura (Stripe)"
 
 
 def test_is_flat_rate_false_for_api() -> None:
@@ -64,6 +65,51 @@ def test_is_flat_rate_false_for_api() -> None:
     )
     assert acc.is_flat_rate is False
     assert "API" in acc.billing_label
+
+
+def test_extra_usage_label_disabled() -> None:
+    acc = AccountInfo(
+        email="", display_name="", organization_name="",
+        organization_role="", billing_type=BILLING_FLAT_RATE,
+        has_extra_usage_enabled=False, extra_usage_disabled_reason=None,
+        first_token_date=None, account_uuid="", organization_uuid="",
+    )
+    assert acc.extra_usage_label == "desabilitado"
+
+
+def test_extra_usage_label_out_of_credits() -> None:
+    acc = AccountInfo(
+        email="", display_name="", organization_name="",
+        organization_role="", billing_type=BILLING_FLAT_RATE,
+        has_extra_usage_enabled=True,
+        extra_usage_disabled_reason="out_of_credits",
+        first_token_date=None, account_uuid="", organization_uuid="",
+    )
+    label = acc.extra_usage_label
+    assert "habilitado" in label
+    assert "sem créditos" in label
+
+
+def test_extra_usage_label_available() -> None:
+    acc = AccountInfo(
+        email="", display_name="", organization_name="",
+        organization_role="", billing_type=BILLING_FLAT_RATE,
+        has_extra_usage_enabled=True, extra_usage_disabled_reason=None,
+        first_token_date=None, account_uuid="", organization_uuid="",
+    )
+    assert acc.extra_usage_label == "habilitado, disponível"
+
+
+def test_extra_usage_label_unknown_reason_passthrough() -> None:
+    """Reason desconhecido é exibido literalmente (não quebra display)."""
+    acc = AccountInfo(
+        email="", display_name="", organization_name="",
+        organization_role="", billing_type=BILLING_FLAT_RATE,
+        has_extra_usage_enabled=True,
+        extra_usage_disabled_reason="new_unknown_reason_2028",
+        first_token_date=None, account_uuid="", organization_uuid="",
+    )
+    assert "new_unknown_reason_2028" in acc.extra_usage_label
 
 
 def test_read_returns_none_when_file_missing(tmp_path: Path) -> None:

--- a/tests/test_rate_limit_display.py
+++ b/tests/test_rate_limit_display.py
@@ -1,0 +1,83 @@
+"""Testes do layout de exibição de rate limits (bars + texto)."""
+from __future__ import annotations
+
+from claude_dash.rate_limits import RateLimitSnapshot
+from claude_dash.views.now import _rate_limit_bar, _rate_limit_block
+
+
+class TestRateLimitBar:
+    def test_zero_pct_is_all_empty(self) -> None:
+        bar = _rate_limit_bar(0, width=10)
+        assert bar == "[" + "░" * 10 + "]"
+
+    def test_full_pct_is_all_filled(self) -> None:
+        bar = _rate_limit_bar(100, width=10)
+        assert bar == "[" + "█" * 10 + "]"
+
+    def test_half_pct(self) -> None:
+        bar = _rate_limit_bar(50, width=10)
+        assert bar.count("█") == 5
+        assert bar.count("░") == 5
+
+    def test_clamps_over_100(self) -> None:
+        bar = _rate_limit_bar(150, width=10)
+        assert bar.count("█") == 10
+
+    def test_clamps_negative(self) -> None:
+        bar = _rate_limit_bar(-5, width=10)
+        assert bar.count("█") == 0
+        assert bar.count("░") == 10
+
+
+class TestRateLimitBlock:
+    def test_empty_when_snap_is_none(self) -> None:
+        block = _rate_limit_block(None)
+        assert block.plain == ""
+
+    def test_empty_when_stale(self) -> None:
+        old_snap = RateLimitSnapshot(
+            session_id="x",
+            captured_at_ms=1,  # epoch antigo
+            five_hour_pct=42,
+            five_hour_resets_at_ms=0,
+            seven_day_pct=18,
+            seven_day_resets_at_ms=0,
+        )
+        block = _rate_limit_block(old_snap)
+        assert block.plain == ""
+
+    def test_renders_two_lines_when_fresh(self) -> None:
+        import time
+        now_ms = int(time.time() * 1000)
+        snap = RateLimitSnapshot(
+            session_id="x",
+            captured_at_ms=now_ms,
+            five_hour_pct=42,
+            five_hour_resets_at_ms=now_ms + 3600_000,
+            seven_day_pct=18,
+            seven_day_resets_at_ms=now_ms + 86400_000 * 6,
+        )
+        block = _rate_limit_block(snap)
+        rendered = block.plain
+        assert "Janela 5h" in rendered
+        assert "Janela 7d" in rendered
+        assert "42.0%" in rendered
+        assert "18.0%" in rendered
+        # Uma quebra de linha separando as duas janelas
+        assert rendered.count("\n") == 1
+
+    def test_includes_reset_time(self) -> None:
+        import time
+        now_ms = int(time.time() * 1000)
+        snap = RateLimitSnapshot(
+            session_id="x",
+            captured_at_ms=now_ms,
+            five_hour_pct=50,
+            five_hour_resets_at_ms=now_ms + 3600_000 + 15 * 60_000,  # 1h15m
+            seven_day_pct=20,
+            seven_day_resets_at_ms=now_ms + 86400_000 * 3,
+        )
+        block = _rate_limit_block(snap).plain
+        assert "reseta em" in block
+        assert "1h15m" in block
+        assert "3d0h" in block


### PR DESCRIPTION
Feedback do usuário: rate limit difícil de entender, billing misturado com extra usage parecia que o plano estava desabilitado.

**Esclarecimento**: ~/.claude.json não tem o nome do tier (Pro/Max) — só `billingType`. Renomeado para deixar claro que é **tipo de cobrança**, não plano.

Mudanças:
- `billing_label` e `extra_usage_label` são campos ortogonais
- `_account_line` renderiza 3 campos separados: Conta · Billing · Créditos extras
- Rate limit vira bloco de 2 linhas com barras ASCII: `Janela 5h [█████████░░░░░] 67.0% reseta em 1h29m`

145 testes (+11). Bump `0.9.0` → `0.9.1`.