### PR TITLE
v0.10 — detecta plano real (Max/Pro) via credentials.json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.9.1"
+version = "0.10.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"

--- a/src/claude_dash/account.py
+++ b/src/claude_dash/account.py
@@ -87,11 +87,15 @@ class AccountInfo:
             'Max 5×'   (subscription=max, tier=default_claude_max_5x)
             'Max 20×'  (subscription=max, tier=default_claude_max_20x)
             'Pro'      (subscription=pro)
-            '—'        (credentials inacessível — fallback seguro)
+            '—'        (qualquer caso em que subscription_type está vazio)
 
-        Se os campos não estão disponíveis (arquivo sem permissão,
-        ausente ou sem bloco claudeAiOauth), retorna '—' e o caller
-        pode optar por `billing_label` como alternativa.
+        O '—' cobre quatro situações reais, indistinguíveis do caller:
+        (1) credentials.json inacessível (permissão/ausente),
+        (2) JSON parseável mas sem bloco `claudeAiOauth`,
+        (3) bloco existe mas `subscriptionType` é null/string vazia,
+        (4) JSON manualmente corrompido (claudeAiOauth não é dict).
+        Em qualquer um, o caller pode exibir `billing_label` como
+        fallback.
         """
         if not self.subscription_type:
             return "—"
@@ -140,9 +144,9 @@ def _read_credentials(
 ) -> tuple[str, str]:
     """Lê subscriptionType e rateLimitTier de ~/.claude/.credentials.json.
 
-    Retorna ('', '') se arquivo inacessível (permissão negada,
-    ausente, JSON inválido ou sem bloco claudeAiOauth). Os campos
-    ficam vazios e `plan_label` cai em '—'.
+    Retorna ('', '') se o arquivo não estiver acessível ou se o JSON
+    não tiver o bloco `claudeAiOauth` no formato esperado. Erros
+    silenciosos — o display cai em fallback via `plan_label`.
 
     Importante: `.credentials.json` tem permissão 0600 por design
     (contém refresh tokens). Este módulo só **lê** os campos
@@ -152,9 +156,14 @@ def _read_credentials(
         return "", ""
     try:
         data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError, PermissionError):
+    except (OSError, json.JSONDecodeError):
+        # PermissionError é subclasse de OSError — sem menção explícita.
         return "", ""
-    oauth = data.get("claudeAiOauth") or {}
+    oauth = data.get("claudeAiOauth")
+    # Proteção contra JSON manualmente corrompido (claudeAiOauth pode
+    # vir como lista/int/null caso alguém tenha editado o arquivo).
+    if not isinstance(oauth, dict):
+        return "", ""
     return (
         str(oauth.get("subscriptionType") or ""),
         str(oauth.get("rateLimitTier") or ""),

--- a/src/claude_dash/account.py
+++ b/src/claude_dash/account.py
@@ -11,11 +11,16 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
 
 DEFAULT_CLAUDE_JSON = Path(os.environ.get("CLAUDE_JSON", Path.home() / ".claude.json"))
+DEFAULT_CREDENTIALS_JSON = Path(os.environ.get(
+    "CLAUDE_CREDENTIALS",
+    Path.home() / ".claude" / ".credentials.json",
+))
 
 
 # Valores observados no campo `billingType` do oauthAccount.
@@ -41,6 +46,10 @@ class AccountInfo:
     first_token_date: str | None        # primeira vez que usou
     account_uuid: str
     organization_uuid: str
+    # Campos lidos de ~/.claude/.credentials.json (claudeAiOauth). Vazios
+    # se arquivo não acessível (permissão) ou sem bloco claudeAiOauth.
+    subscription_type: str = ""         # ex: "max", "pro", "team"
+    rate_limit_tier: str = ""           # ex: "default_claude_max_5x"
 
     @property
     def is_flat_rate(self) -> bool:
@@ -57,10 +66,9 @@ class AccountInfo:
     def billing_label(self) -> str:
         """Label do **tipo de cobrança** (Stripe / API / Enterprise).
 
-        Nota importante: o Claude Code **não expõe o nome do plano**
-        (Pro, Max, Team, etc) em `~/.claude.json`. Esse dado só viria
-        via call autenticada à API da Anthropic. Aqui retornamos o
-        tipo de cobrança, que é o dado disponível localmente.
+        Nota: este é o *tipo de cobrança* (como o usuário paga).
+        O **nome do plano** (Pro, Max, Team) vem de `plan_label`,
+        lido de `~/.claude/.credentials.json:claudeAiOauth`.
         """
         if self.billing_type == BILLING_FLAT_RATE:
             return "Assinatura (Stripe)"
@@ -69,6 +77,30 @@ class AccountInfo:
         if self.billing_type == BILLING_ENTERPRISE:
             return "Enterprise"
         return f"Billing desconhecido ({self.billing_type})"
+
+    @property
+    def plan_label(self) -> str:
+        """Nome amigável do plano, combinando `subscription_type` +
+        variante detectada em `rate_limit_tier`.
+
+        Exemplos de retorno:
+            'Max 5×'   (subscription=max, tier=default_claude_max_5x)
+            'Max 20×'  (subscription=max, tier=default_claude_max_20x)
+            'Pro'      (subscription=pro)
+            '—'        (credentials inacessível — fallback seguro)
+
+        Se os campos não estão disponíveis (arquivo sem permissão,
+        ausente ou sem bloco claudeAiOauth), retorna '—' e o caller
+        pode optar por `billing_label` como alternativa.
+        """
+        if not self.subscription_type:
+            return "—"
+        name = self.subscription_type.capitalize()  # "max" → "Max"
+        # Detecta variante numérica no tier (ex: 5x, 20x)
+        match = re.search(r"_(\d+)x$", self.rate_limit_tier or "")
+        if match:
+            return f"{name} {match.group(1)}×"
+        return name
 
     @property
     def extra_usage_label(self) -> str:
@@ -103,17 +135,46 @@ class AccountInfo:
         return "habilitado, disponível"
 
 
+def _read_credentials(
+    path: Path = DEFAULT_CREDENTIALS_JSON,
+) -> tuple[str, str]:
+    """Lê subscriptionType e rateLimitTier de ~/.claude/.credentials.json.
+
+    Retorna ('', '') se arquivo inacessível (permissão negada,
+    ausente, JSON inválido ou sem bloco claudeAiOauth). Os campos
+    ficam vazios e `plan_label` cai em '—'.
+
+    Importante: `.credentials.json` tem permissão 0600 por design
+    (contém refresh tokens). Este módulo só **lê** os campos
+    não-sensíveis (tipo de plano e tier), nunca os tokens.
+    """
+    if not path.is_file():
+        return "", ""
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, PermissionError):
+        return "", ""
+    oauth = data.get("claudeAiOauth") or {}
+    return (
+        str(oauth.get("subscriptionType") or ""),
+        str(oauth.get("rateLimitTier") or ""),
+    )
+
+
 def read_account_info(
     path: Path = DEFAULT_CLAUDE_JSON,
+    credentials_path: Path = DEFAULT_CREDENTIALS_JSON,
 ) -> AccountInfo | None:
-    """Lê ~/.claude.json e extrai info de conta.
+    """Lê ~/.claude.json + ~/.claude/.credentials.json e monta AccountInfo.
 
     Retorna None em três cenários (tratados silenciosamente, sem raise):
-    1. arquivo ausente no path indicado
+    1. claude.json ausente no path indicado
     2. JSON inválido (parse error) ou erro de leitura (OSError)
     3. arquivo existe e parseia mas não tem o bloco `oauthAccount`
 
-    Callers devem checar `is None` antes de acessar campos.
+    O credentials.json é opcional — se não acessível, os campos
+    `subscription_type` e `rate_limit_tier` ficam vazios e
+    `plan_label` retorna '—'. AccountInfo é retornada mesmo assim.
     """
     if not path.is_file():
         return None
@@ -126,6 +187,8 @@ def read_account_info(
     if not oauth:
         return None
 
+    subscription_type, rate_limit_tier = _read_credentials(credentials_path)
+
     return AccountInfo(
         email=oauth.get("emailAddress") or "",
         display_name=oauth.get("displayName") or "",
@@ -137,4 +200,6 @@ def read_account_info(
         first_token_date=data.get("claudeCodeFirstTokenDate"),
         account_uuid=oauth.get("accountUuid") or "",
         organization_uuid=oauth.get("organizationUuid") or "",
+        subscription_type=subscription_type,
+        rate_limit_tier=rate_limit_tier,
     )

--- a/src/claude_dash/mcp_server.py
+++ b/src/claude_dash/mcp_server.py
@@ -177,6 +177,9 @@ def account_info() -> dict[str, Any]:
         "organization_role": acc.organization_role,
         "billing_type": acc.billing_type,
         "billing_label": acc.billing_label,
+        "plan_label": acc.plan_label,
+        "subscription_type": acc.subscription_type,
+        "rate_limit_tier": acc.rate_limit_tier,
         "is_flat_rate": acc.is_flat_rate,
         "has_extra_usage_enabled": acc.has_extra_usage_enabled,
         "extra_usage_disabled_reason": acc.extra_usage_disabled_reason,
@@ -426,6 +429,7 @@ def workflow_snapshot() -> dict[str, Any]:
         "generated_at": datetime.now().isoformat(),
         "account": {
             "email": acc.email if acc else None,
+            "plan": acc.plan_label if acc else None,
             "billing_label": acc.billing_label if acc else None,
             "is_flat_rate": acc.is_flat_rate if acc else None,
         },

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -280,11 +280,23 @@ def _rate_limit_block(snap: RateLimitSnapshot | None) -> Text:
     return out
 
 
-def _header(sessions: list[SessionStats]) -> Panel:
+def _header(
+    sessions: list[SessionStats],
+    acc: AccountInfo | None = None,
+    rl_snap: RateLimitSnapshot | None = None,
+) -> Panel:
+    """Renderiza o painel de header.
+
+    `acc` e `rl_snap` são injetados opcionalmente pelo caller (em
+    `_render`) para evitar dupla leitura de disco: o caller já
+    precisa desses valores para calcular `header_size`. Se `None`,
+    a função lê sozinha (útil para chamadas standalone/testes).
+    """
     n = len(sessions)
     total_tokens = sum(s.total_usage.total for s in sessions)
     total_cost = sum(_total_cost(s) for s in sessions)
-    acc = read_account_info()
+    if acc is None:
+        acc = read_account_info()
 
     total_usage = Usage()
     tool_totals: dict[str, int] = {}
@@ -305,7 +317,9 @@ def _header(sessions: list[SessionStats]) -> Panel:
     if len(acc_line) > 0:
         header_text.append_text(acc_line)
         header_text.append("\n")
-    rl_block = _rate_limit_block(global_worst_case())
+    if rl_snap is None:
+        rl_snap = global_worst_case()
+    rl_block = _rate_limit_block(rl_snap)
     if len(rl_block) > 0:
         header_text.append_text(rl_block)
         header_text.append("\n")
@@ -333,15 +347,18 @@ def _footer(refresh_sec: float) -> Panel:
 
 def _render(sessions: list[SessionStats], refresh_sec: float) -> Layout:
     # Header: 1 borda sup + data/stats + 1 borda inf = 3 linhas base.
-    # Linhas condicionais: +1 se tem account info, +2 se tem rate limits
-    # (bloco renderiza 2 linhas — uma para 5h, outra para 7d).
-    has_account = read_account_info() is not None
-    has_rl = global_worst_case() is not None
+    # Linhas condicionais: +1 se tem account info, +2 se tem rate limits.
+    # Fazemos UMA leitura de cada fonte aqui e injetamos em _header()
+    # para evitar dupla I/O por refresh (antes: 4 reads/2s, agora: 2).
+    acc = read_account_info()
+    rl_snap = global_worst_case()
+    has_account = acc is not None
+    has_rl = rl_snap is not None
     header_size = 3 + (1 if has_account else 0) + (2 if has_rl else 0)
 
     layout = Layout()
     layout.split_column(
-        Layout(_header(sessions), size=header_size, name="header"),
+        Layout(_header(sessions, acc=acc, rl_snap=rl_snap), size=header_size, name="header"),
         Layout(Panel(_session_table(sessions), border_style="dim", title="Sessões",
                      title_align="left"), name="body"),
         Layout(_footer(refresh_sec), size=3, name="footer"),

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -200,20 +200,24 @@ def _cost_label(acc: AccountInfo | None) -> str:
 
 def _account_line(acc: AccountInfo | None) -> Text:
     """Linha de info da conta, organizada em 3 campos semânticos:
-    email · billing type · status dos créditos extras.
+    email · plano (fallback: billing type) · status dos créditos extras.
 
-    Antes os 3 campos apareciam misturados ("Assinatura (extra usage
-    desabilitado: out_of_credits)"), dando a impressão de que "extra
-    usage desabilitado" era o status do plano. Agora separados com
-    nomes dos campos, cada um é claramente identificável.
+    O nome do plano (Max, Pro, etc) é lido de
+    ~/.claude/.credentials.json. Se inacessível, cai em billing_label
+    como aproximação.
     """
     line = Text()
     if acc is None:
         return line
     line.append(" Conta ", style="dim")
     line.append(f"{acc.email}", style="bold")
-    line.append("  ·  Billing: ", style="dim")
-    line.append(f"{acc.billing_label}", style="bold cyan")
+    line.append("  ·  Plano: ", style="dim")
+    plan = acc.plan_label
+    if plan == "—":
+        # Sem credentials lidas — cai em billing como aproximação
+        line.append(f"{acc.billing_label}", style="bold cyan")
+    else:
+        line.append(f"{plan}", style="bold cyan")
     line.append("  ·  Créditos extras: ", style="dim")
     # Cor do status de créditos: verde=disponível, amarelo=sem créditos,
     # dim=desabilitado.

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -100,6 +100,78 @@ def test_extra_usage_label_available() -> None:
     assert acc.extra_usage_label == "habilitado, disponível"
 
 
+class TestPlanLabel:
+    def _acc(self, sub_type: str = "", tier: str = "") -> AccountInfo:
+        return AccountInfo(
+            email="", display_name="", organization_name="",
+            organization_role="", billing_type=BILLING_FLAT_RATE,
+            has_extra_usage_enabled=False, extra_usage_disabled_reason=None,
+            first_token_date=None, account_uuid="", organization_uuid="",
+            subscription_type=sub_type, rate_limit_tier=tier,
+        )
+
+    def test_max_with_5x_variant(self) -> None:
+        acc = self._acc("max", "default_claude_max_5x")
+        assert acc.plan_label == "Max 5×"
+
+    def test_max_with_20x_variant(self) -> None:
+        acc = self._acc("max", "default_claude_max_20x")
+        assert acc.plan_label == "Max 20×"
+
+    def test_pro_without_variant(self) -> None:
+        acc = self._acc("pro", "default_claude_pro")
+        assert acc.plan_label == "Pro"
+
+    def test_empty_when_credentials_unavailable(self) -> None:
+        acc = self._acc("", "")
+        assert acc.plan_label == "—"
+
+    def test_only_sub_without_tier(self) -> None:
+        acc = self._acc("team", "")
+        assert acc.plan_label == "Team"
+
+
+def test_read_credentials_fills_subscription_and_tier(tmp_path: Path) -> None:
+    from claude_dash.account import read_account_info
+
+    claude_json = tmp_path / "claude.json"
+    claude_json.write_text(json.dumps({
+        "oauthAccount": {
+            "emailAddress": "x@y.com",
+            "billingType": BILLING_FLAT_RATE,
+        },
+    }))
+    creds = tmp_path / "credentials.json"
+    creds.write_text(json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "secret-REDACTED",
+            "subscriptionType": "max",
+            "rateLimitTier": "default_claude_max_5x",
+        },
+    }))
+    acc = read_account_info(claude_json, creds)
+    assert acc is not None
+    assert acc.subscription_type == "max"
+    assert acc.rate_limit_tier == "default_claude_max_5x"
+    assert acc.plan_label == "Max 5×"
+
+
+def test_read_credentials_missing_file_falls_back_gracefully(tmp_path: Path) -> None:
+    from claude_dash.account import read_account_info
+
+    claude_json = tmp_path / "claude.json"
+    claude_json.write_text(json.dumps({
+        "oauthAccount": {
+            "emailAddress": "x@y.com",
+            "billingType": BILLING_FLAT_RATE,
+        },
+    }))
+    acc = read_account_info(claude_json, tmp_path / "nao-existe.json")
+    assert acc is not None
+    assert acc.subscription_type == ""
+    assert acc.plan_label == "—"
+
+
 def test_extra_usage_label_unknown_reason_passthrough() -> None:
     """Reason desconhecido é exibido literalmente (não quebra display)."""
     acc = AccountInfo(


### PR DESCRIPTION
**Descoberta chave:** \`~/.claude/.credentials.json:claudeAiOauth\` contém \`subscriptionType\` e \`rateLimitTier\` — o nome REAL do plano está local. Não precisa de call API autenticada.

### Implementação

- \`account.py._read_credentials\` lê os campos não-sensíveis (ignora tokens). Graceful degradation se arquivo inacessível.
- \`plan_label\` property combina subscription + variante do tier:
  - \`("max", "default_claude_max_5x")\` → \`"Max 5×"\`
  - \`("max", "default_claude_max_20x")\` → \`"Max 20×"\`
  - \`("pro", ...)\` → \`"Pro"\`
  - Sem credentials → \`"—"\` (fallback para billing_label no caller)
- Header agora mostra **\`Plano: Max 5×\`** em vez de "Billing: Assinatura (Stripe)".
- MCP \`account_info\` ganha \`plan_label\`, \`subscription_type\`, \`rate_limit_tier\`. \`workflow_snapshot.account.plan\` também exposto.

### Test plan

- [x] 152 testes passando (+7)
- [x] Smoke real: header exibe "Plano: Max 5×" (do meu próprio \`~/.claude/.credentials.json\`)

Bump: \`0.9.1\` → \`0.10.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)