### PR TITLE
v0.11 — dashboard assume o statusLine (inversão de acoplamento)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,27 +55,39 @@ claude-dash tools              # breakdown de tool_use últimas 24h
 claude-dash session <sid>      # drill-down (prefixo de sessionId aceito)
 ```
 
-### Rate limits 5h/7d (hook opcional)
+### Rate limits 5h/7d (via statusline próprio — v0.11+)
 
-Desde v0.9, o dashboard pode exibir o consumo real dos rate limits da
-conta (5h e 7d) — especialmente útil em planos flat-rate (Max/Pro),
-onde o custo em USD é hipotético e o que importa é **quanto do limite
-já foi usado**.
+Desde **v0.11**, o dashboard possui seu próprio statusline
+(`claude-dash-statusline`) que produz a mesma linha visual do script
+bash original E captura os rate_limits automaticamente em `/tmp/` para
+as views consumirem.
 
-O Claude Code só injeta `rate_limits` no JSON do statusline — por
-isso a captura requer uma linha extra no seu script de statusline
-(`settings.json:statusLine.command`). Instalação:
+**Instalação em 1 comando (idempotente):**
 
-1. Identifique o script configurado em `~/.claude/settings.json:statusLine.command`.
-2. Adicione no **topo** do seu script (depois do `input=$(cat)`):
-   ```bash
-   echo "$input" | claude-dash-rate-limit-capture > /dev/null
-   ```
-3. Reinicie a sessão do Claude Code. A cada render do statusline,
-   o snapshot de rate limits é gravado em `/tmp/claude-dash-rate-limits/`.
+```bash
+claude-dash setup-status
+```
 
-Sem o hook instalado, o dashboard continua funcional — apenas omite a
-linha de rate limits no header. Graceful degradation.
+Esse comando:
+- Faz backup do `~/.claude/settings.json`
+- Registra `claude-dash-statusline` como `statusLine.command`
+- Se você já tinha um statusline configurado, preserva o path dele em
+  `~/.claude/.claude-dash.json` como `statusline_wrap_path` — o
+  statusline próprio então executa o seu script original para gerar o
+  output visual (mantém aparência), mas ainda captura rate_limits.
+
+Depois de rodar o setup, reinicie uma sessão do Claude Code. A partir
+daí, o header da TUI passa a exibir as barras de 5h/7d.
+
+**Para remover:** edite `~/.claude/settings.json` e restaure a partir
+do backup em `~/.claude/backups/settings.json.backup.*`.
+
+**Modo manual (pré-v0.11, ainda funciona):** você pode adicionar uma
+linha no seu statusline existente com `echo "$input" | claude-dash-rate-limit-capture > /dev/null`.
+O entrypoint de captura foi preservado por compatibilidade.
+
+Sem nenhuma das formas acima, o dashboard continua funcional — apenas
+omite a linha de rate limits no header. Graceful degradation.
 
 ### MCP server — canal para agentes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.10.0"
+version = "0.11.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -37,6 +37,7 @@ dev = [
 [project.scripts]
 claude-dash = "claude_dash.cli:main"
 claude-dash-mcp = "claude_dash.mcp_server:main"
+claude-dash-statusline = "claude_dash.statusline:main"
 claude-dash-rate-limit-capture = "claude_dash.rate_limit_capture:main"
 
 [project.urls]

--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,3 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/src/claude_dash/cli.py
+++ b/src/claude_dash/cli.py
@@ -26,6 +26,12 @@ def build_parser() -> argparse.ArgumentParser:
     session_p = subparsers.add_parser("session", help="Drill-down de uma sessão")
     session_p.add_argument("sid", help="sessionId (prefixo aceito)")
 
+    subparsers.add_parser(
+        "setup-status",
+        help="Configura claude-dash-statusline como statusLine em settings.json "
+             "(idempotente, preserva statusline anterior via wrap)",
+    )
+
     return parser
 
 
@@ -54,6 +60,10 @@ def main(argv: list[str] | None = None) -> int:
         from claude_dash.views.session import run as run_session
 
         return run_session(args.sid)
+    if args.command == "setup-status":
+        from claude_dash.setup_status import main as run_setup
+
+        return run_setup()
     return 2  # pragma: no cover
 
 

--- a/src/claude_dash/setup_status.py
+++ b/src/claude_dash/setup_status.py
@@ -1,0 +1,118 @@
+"""Setup idempotente: registra claude-dash-statusline como statusLine oficial.
+
+Tratamento de estado:
+- Se `statusLine.command` já é `claude-dash-statusline` → noop
+- Se `statusLine.command` aponta para outro script → preserva o path
+  em `~/.claude/.claude-dash.json:statusline_wrap_path` (wrap chain)
+  e reatribui para `claude-dash-statusline`
+- Se não há statusLine configurado → adiciona limpo
+- Faz backup de settings.json e .claude-dash.json antes de escrever
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+SETTINGS_JSON = Path.home() / ".claude" / "settings.json"
+DASHBOARD_CONFIG = Path.home() / ".claude" / ".claude-dash.json"
+BACKUP_DIR = Path.home() / ".claude" / "backups"
+STATUSLINE_CMD = "claude-dash-statusline"
+
+
+def _backup(path: Path) -> Path | None:
+    """Copia arquivo para backups com timestamp; retorna path do backup."""
+    if not path.is_file():
+        return None
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    dest = BACKUP_DIR / f"{path.name}.backup.{stamp}"
+    shutil.copy2(path, dest)
+    return dest
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_json_atomic(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    tmp.replace(path)
+
+
+def run() -> int:
+    """Idempotente — pode rodar várias vezes sem quebrar.
+
+    Imprime relatório do que foi feito (ou não) no stdout.
+    """
+    settings = _load_json(SETTINGS_JSON)
+    dash_cfg = _load_json(DASHBOARD_CONFIG)
+
+    current_statusline = settings.get("statusLine") or {}
+    current_cmd = (
+        current_statusline.get("command") if isinstance(current_statusline, dict) else None
+    )
+
+    print("claude-dash setup-status")
+    print(f"  settings.json : {SETTINGS_JSON}")
+    print(f"  dashboard cfg : {DASHBOARD_CONFIG}")
+    print()
+
+    # Caso 1: já está configurado com nosso statusline → idempotente noop
+    if current_cmd == STATUSLINE_CMD:
+        print(f"✓ statusLine já aponta para '{STATUSLINE_CMD}'; nada a fazer.")
+        wrap_path = dash_cfg.get("statusline_wrap_path")
+        if wrap_path:
+            print(f"  Wrap ativo: {wrap_path}")
+        return 0
+
+    # Backup preventivo antes de escrever
+    settings_bak = _backup(SETTINGS_JSON)
+    cfg_bak = _backup(DASHBOARD_CONFIG)
+    if settings_bak:
+        print(f"Backup settings.json  → {settings_bak}")
+    if cfg_bak:
+        print(f"Backup .claude-dash.json → {cfg_bak}")
+
+    # Caso 2: há um statusLine externo configurado — preserva via wrap
+    if current_cmd:
+        print(
+            f"Detectei statusLine existente: '{current_cmd}'.\n"
+            f"  → preservando em statusline_wrap_path (chain)"
+        )
+        dash_cfg["statusline_wrap_path"] = current_cmd
+        _save_json_atomic(DASHBOARD_CONFIG, dash_cfg)
+
+    # Caso 3 (ou seguinte do 2): registra o nosso como statusLine ativo
+    settings["statusLine"] = {
+        "type": "command",
+        "command": STATUSLINE_CMD,
+        "padding": 0,
+    }
+    _save_json_atomic(SETTINGS_JSON, settings)
+
+    print()
+    print(f"✓ statusLine agora aponta para '{STATUSLINE_CMD}'")
+    print("  Reinicie uma sessão do Claude Code para ativar.")
+    print()
+    print("Para remover: edite ~/.claude/settings.json e remova o bloco")
+    print("  statusLine (ou restaure a partir do backup acima).")
+    return 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except Exception as exc:  # noqa: BLE001
+        print(f"erro: {exc}", file=sys.stderr)
+        return 1

--- a/src/claude_dash/statusline.py
+++ b/src/claude_dash/statusline.py
@@ -1,0 +1,373 @@
+"""Statusline próprio do dashboard — auto-contido.
+
+Substitui o `statusline-dashboard.sh` bash do usuário por uma versão
+Python que (1) produz a mesma linha visual (modelo ⚡effort · style ·
+barra_ctx · tokens · $custo · Δt · +add/-rem · 5h% · 7d% · [sessão]),
+(2) captura `rate_limits` em /tmp para o dashboard consumir, (3)
+opcionalmente envelopa um statusline externo pré-existente.
+
+Wrap: se a env var `CLAUDE_DASH_STATUSLINE_WRAP` ou o campo
+`statusline_wrap_path` em `~/.claude/.claude-dash.json` apontam para
+um script, este é executado com o JSON no stdin e seu output é
+retornado em vez do statusline próprio. O capture de rate_limits
+continua rodando em paralelo — assim um usuário que tinha statusline
+customizado preserva a aparência + ganha rate_limit capture.
+
+Performance: ANSI cru em vez de `rich` para manter o startup abaixo
+de 50ms (o statusline é chamado múltiplas vezes por interação).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from claude_dash.rate_limit_capture import capture_from_json
+
+
+# --- Locais de config --------------------------------------------------
+
+DASHBOARD_CONFIG = Path(os.environ.get(
+    "CLAUDE_DASH_CONFIG",
+    Path.home() / ".claude" / ".claude-dash.json",
+))
+
+# Env var tem precedência sobre o config file
+WRAP_ENV_VAR = "CLAUDE_DASH_STATUSLINE_WRAP"
+
+
+# --- ANSI ---------------------------------------------------------------
+
+RESET = "\033[0m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+DIM_GREEN = "\033[2;32m"
+DIM_RED = "\033[2;31m"
+CYAN_BOLD = "\033[1;36m"
+BG_YELLOW = "\033[1;33m"
+BG_RED = "\033[1;31m"
+DIM_WHITE = "\033[2;37m"
+
+SEP = f"{DIM} │ {RESET}"
+
+
+# --- Helpers de formato ------------------------------------------------
+
+
+def _fmt_tokens(n: int) -> str:
+    if n >= 1000:
+        return f"{n / 1000:.0f}k"
+    return str(n)
+
+
+def _fmt_cost(usd: float) -> str:
+    if usd >= 1.0:
+        return f"${usd:,.2f}"
+    return f"${usd:.4f}"
+
+
+def _fmt_duration(ms: int) -> str:
+    s = ms // 1000
+    if s >= 86400:
+        d, rem = divmod(s, 86400)
+        return f"{d}d{rem // 3600}h"
+    if s >= 3600:
+        h, rem = divmod(s, 3600)
+        return f"{h}h{rem // 60}m"
+    if s >= 60:
+        m, rem = divmod(s, 60)
+        return f"{m}m{rem:02d}s"
+    return f"{s}s"
+
+
+def _fmt_reset_delta(resets_at_s: int) -> str:
+    """Formato compacto do tempo restante até reset. Vazio se já resetou."""
+    now = int(time.time())
+    delta = resets_at_s - now
+    if delta <= 0:
+        return ""
+    if delta >= 86400:
+        days, rem = divmod(delta, 86400)
+        return f"{days}d{rem // 3600}h"
+    if delta >= 3600:
+        hours, rem = divmod(delta, 3600)
+        return f"{hours}h{rem // 60}m"
+    return f"{delta // 60}m"
+
+
+def _context_bar(pct_int: int, width: int = 12) -> tuple[str, str]:
+    """Barra ASCII + cor por faixa. Retorna (texto_barra, cor_ansi)."""
+    if pct_int >= 80:
+        color = RED
+    elif pct_int >= 50:
+        color = YELLOW
+    else:
+        color = GREEN
+    filled = pct_int * width // 100
+    empty = width - filled
+    return f"[{'█' * filled}{'░' * empty}]", color
+
+
+def _rate_color_ansi(pct: float) -> str:
+    if pct >= 85:
+        return RED
+    if pct >= 60:
+        return YELLOW
+    return DIM
+
+
+# --- Effort level com cache por transcript mtime -----------------------
+
+
+_EFFORT_CACHE_DIR = Path("/tmp")
+_EFFORT_RE = re.compile(r"Set effort level to ([a-z]+)")
+
+
+def _detect_effort(transcript_path: str) -> str:
+    """Lê último 'Set effort level to X' do transcript, cacheado por mtime."""
+    if not transcript_path:
+        return ""
+    path = Path(transcript_path)
+    if not path.is_file():
+        return ""
+
+    # Cache por hash do path (12 chars) — mesmo esquema do bash
+    tpath_hash = hashlib.md5(transcript_path.encode()).hexdigest()[:12]
+    cache_file = _EFFORT_CACHE_DIR / f".claude-statusline-effort-{tpath_hash}"
+
+    try:
+        mtime = int(path.stat().st_mtime)
+    except OSError:
+        return ""
+
+    # Tenta cache
+    if cache_file.is_file():
+        try:
+            cached_mtime, cached_val = cache_file.read_text().splitlines()[:2]
+            if cached_mtime == str(mtime):
+                return cached_val.strip()
+        except (OSError, ValueError):
+            pass
+
+    # Cache miss → lê transcript do fim pra frente
+    effort = ""
+    try:
+        # Lê em blocos do fim pra frente para não carregar arquivo gigante
+        with path.open("rb") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            chunk = 64 * 1024
+            data = b""
+            while size > 0 and not effort:
+                read_size = min(chunk, size)
+                size -= read_size
+                f.seek(size)
+                data = f.read(read_size) + data
+                for m in _EFFORT_RE.finditer(data.decode(errors="ignore")):
+                    effort = m.group(1)
+                # Reset: última ocorrência é a válida
+                if effort:
+                    all_matches = _EFFORT_RE.findall(data.decode(errors="ignore"))
+                    if all_matches:
+                        effort = all_matches[-1]
+    except OSError:
+        pass
+
+    # Grava cache mesmo se vazio (evita reler)
+    try:
+        cache_file.write_text(f"{mtime}\n{effort}\n")
+    except OSError:
+        pass
+    return effort
+
+
+def _effort_from_settings() -> str:
+    """Fallback: lê effortLevel global de ~/.claude/settings.json."""
+    settings = Path.home() / ".claude" / "settings.json"
+    if not settings.is_file():
+        return ""
+    try:
+        data = json.loads(settings.read_text())
+        return str(data.get("effortLevel") or "")
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+
+def _effort_badge(effort: str) -> str:
+    """Badge colorido do effort (bg colorido quando alto)."""
+    eff = (effort or "").lower().strip()
+    if eff in ("xhigh", "max"):
+        return f" {BG_RED}⚡{eff}{RESET}"
+    if eff == "high":
+        return f" {BG_YELLOW}⚡high{RESET}"
+    if eff in ("low", "medium"):
+        return f" {DIM_WHITE}⚡{eff}{RESET}"
+    if not eff:
+        return f" {DIM_WHITE}⚡?{RESET}"
+    return f" {BG_YELLOW}⚡{eff}{RESET}"
+
+
+# --- Wrap (env var ou config file) -------------------------------------
+
+
+def _resolve_wrap_path() -> str | None:
+    """Resolve o path do statusline externo a envelopar, se houver."""
+    env = os.environ.get(WRAP_ENV_VAR)
+    if env:
+        return env
+    if not DASHBOARD_CONFIG.is_file():
+        return None
+    try:
+        data = json.loads(DASHBOARD_CONFIG.read_text())
+        wrap = data.get("statusline_wrap_path")
+        return wrap if isinstance(wrap, str) and wrap else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _run_wrap(wrap_path: str, raw_input: str) -> str | None:
+    """Executa wrap script com raw_input via stdin; retorna stdout ou None em falha."""
+    try:
+        result = subprocess.run(
+            [wrap_path],
+            input=raw_input,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.rstrip("\n")
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+# --- Renderer próprio --------------------------------------------------
+
+
+def render_statusline(data: dict) -> str:
+    """Monta a linha de status a partir do JSON do Claude Code.
+
+    Ordem dos segmentos (compatível com statusline-dashboard.sh bash):
+        modelo ⚡effort · style · [barra] N% tokens · $custo · duração · +add/-rem · 5h% · 7d% · [sessão]
+    """
+    segments: list[str] = []
+
+    # 1. Modelo + effort
+    model = (
+        data.get("model", {}).get("display_name")
+        or data.get("model", {}).get("id")
+        or "N/A"
+    )
+    transcript = data.get("transcript_path") or ""
+    effort = _detect_effort(transcript) or _effort_from_settings()
+    segments.append(f"{CYAN_BOLD}{model}{RESET}{_effort_badge(effort)}")
+
+    # 2. Output style (se não default)
+    style = data.get("output_style", {}).get("name") or ""
+    if style and style != "default":
+        segments.append(f"{DIM}{style}{RESET}")
+
+    # 3. Barra de contexto + tokens
+    ctx = data.get("context_window") or {}
+    used_pct = ctx.get("used_percentage")
+    if used_pct is not None:
+        pct_int = int(round(float(used_pct)))
+        bar, color = _context_bar(pct_int)
+        ctx_seg = f"{BOLD}{color}{bar} {pct_int}%{RESET}"
+        input_tokens = (ctx.get("current_usage") or {}).get("input_tokens")
+        ctx_size = ctx.get("context_window_size")
+        if input_tokens is not None and ctx_size is not None:
+            tokens_str = f"{_fmt_tokens(int(input_tokens))}/{_fmt_tokens(int(ctx_size))}"
+            ctx_seg += f" {DIM}{tokens_str}{RESET}"
+        segments.append(ctx_seg)
+
+    # 4. Custo
+    cost = data.get("cost") or {}
+    cost_usd = cost.get("total_cost_usd")
+    if cost_usd is not None:
+        segments.append(f"{DIM}{_fmt_cost(float(cost_usd))}{RESET}")
+
+    # 5. Duração API
+    dur_ms = cost.get("total_api_duration_ms")
+    if dur_ms is not None:
+        segments.append(f"{DIM}{_fmt_duration(int(dur_ms))}{RESET}")
+
+    # 6. Diff
+    lines_add = cost.get("total_lines_added")
+    lines_rem = cost.get("total_lines_removed")
+    if lines_add is not None or lines_rem is not None:
+        add_val = lines_add if lines_add is not None else 0
+        rem_val = lines_rem if lines_rem is not None else 0
+        segments.append(
+            f"{DIM_GREEN}+{add_val}{RESET}{DIM}/{RESET}{DIM_RED}-{rem_val}{RESET}"
+        )
+
+    # 7. Rate limits
+    rl = data.get("rate_limits") or {}
+    for label, key in (("5h", "five_hour"), ("7d", "seven_day")):
+        window = rl.get(key)
+        if not window:
+            continue
+        pct = window.get("used_percentage")
+        if pct is None:
+            continue
+        color = _rate_color_ansi(float(pct))
+        seg = f"{DIM}{label}:{RESET}{color}{float(pct):.0f}%{RESET}"
+        resets_at = window.get("resets_at")
+        if resets_at:
+            delta = _fmt_reset_delta(int(resets_at))
+            if delta:
+                seg += f"{DIM} ↻{delta}{RESET}"
+        segments.append(seg)
+
+    # 8. Sessão (se campo não documentado existir)
+    session_name = data.get("session_name")
+    if session_name:
+        segments.append(f"{DIM}[{session_name}]{RESET}")
+
+    return SEP.join(segments)
+
+
+# --- Entrypoint --------------------------------------------------------
+
+
+def main() -> int:
+    """Lê stdin, captura rate_limits, renderiza (ou invoca wrap)."""
+    raw = sys.stdin.read()
+
+    # Captura rate_limits em background — nunca falha o statusline
+    try:
+        capture_from_json(raw)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Wrap: se configurado, usa output do script externo
+    wrap_path = _resolve_wrap_path()
+    if wrap_path:
+        wrapped = _run_wrap(wrap_path, raw)
+        if wrapped is not None:
+            sys.stdout.write(wrapped + "\n")
+            return 0
+        # Wrap falhou → cai no renderer próprio (silent fallback)
+
+    # Renderer próprio
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0  # silent fail para não poluir statusline
+
+    sys.stdout.write(render_statusline(data) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/claude_dash/statusline.py
+++ b/src/claude_dash/statusline.py
@@ -234,10 +234,18 @@ def _resolve_wrap_path() -> str | None:
 
 
 def _run_wrap(wrap_path: str, raw_input: str) -> str | None:
-    """Executa wrap script com raw_input via stdin; retorna stdout ou None em falha."""
+    """Executa wrap script com raw_input via stdin; retorna stdout ou None em falha.
+
+    Expande `~` no path antes de executar. O Claude Code aceita
+    `"command": "~/.claude/script.sh"` em settings.json e resolve o
+    til no próprio harness; quando preservamos esse path como
+    wrap_path, o execv NÃO expande — resultaria em FileNotFoundError
+    e fallback silencioso para o renderer próprio.
+    """
+    expanded = os.path.expanduser(wrap_path)
     try:
         result = subprocess.run(
-            [wrap_path],
+            [expanded],
             input=raw_input,
             capture_output=True,
             text=True,

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,227 @@
+"""Testes do statusline próprio e do setup idempotente."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from claude_dash import setup_status, statusline
+
+
+def _minimal_statusline_input(**overrides) -> dict:
+    """JSON base que o Claude Code injeta no statusline."""
+    data = {
+        "model": {"display_name": "Opus 4.7", "id": "claude-opus-4-7"},
+        "session_id": "test-sid",
+        "transcript_path": "/tmp/inexistente.jsonl",
+        "output_style": {"name": "default"},
+        "context_window": {
+            "used_percentage": 12,
+            "context_window_size": 200_000,
+            "current_usage": {"input_tokens": 24_000},
+        },
+        "cost": {
+            "total_cost_usd": 1.42,
+            "total_api_duration_ms": 83_000,
+            "total_lines_added": 12,
+            "total_lines_removed": 3,
+        },
+        "rate_limits": {
+            "five_hour": {
+                "used_percentage": 13,
+                "resets_at": int(time.time()) + 3600,
+            },
+            "seven_day": {
+                "used_percentage": 18,
+                "resets_at": int(time.time()) + 86400 * 3,
+            },
+        },
+    }
+    data.update(overrides)
+    return data
+
+
+class TestRenderStatusline:
+    def test_includes_model(self) -> None:
+        out = statusline.render_statusline(_minimal_statusline_input())
+        assert "Opus 4.7" in out
+
+    def test_falls_back_to_model_id_when_no_display_name(self) -> None:
+        data = _minimal_statusline_input(model={"id": "claude-haiku-4-5"})
+        assert "claude-haiku-4-5" in statusline.render_statusline(data)
+
+    def test_shows_na_when_no_model(self) -> None:
+        data = _minimal_statusline_input(model={})
+        assert "N/A" in statusline.render_statusline(data)
+
+    def test_hides_style_when_default(self) -> None:
+        out = statusline.render_statusline(_minimal_statusline_input())
+        # "default" é omitido; mas a palavra pode aparecer em outros lugares,
+        # então checa que não há segmento autônomo " default "
+        assert " default " not in out and not out.endswith("default")
+
+    def test_shows_style_when_non_default(self) -> None:
+        data = _minimal_statusline_input(output_style={"name": "Explanatory"})
+        assert "Explanatory" in statusline.render_statusline(data)
+
+    def test_context_bar_proportional_to_pct(self) -> None:
+        data = _minimal_statusline_input()
+        data["context_window"]["used_percentage"] = 50
+        out = statusline.render_statusline(data)
+        # 50% de 12 chars = 6 blocos cheios
+        assert "█" * 6 in out
+        assert "50%" in out
+
+    def test_cost_formatting_under_1(self) -> None:
+        data = _minimal_statusline_input()
+        data["cost"]["total_cost_usd"] = 0.1234
+        out = statusline.render_statusline(data)
+        assert "$0.1234" in out
+
+    def test_cost_formatting_over_1(self) -> None:
+        data = _minimal_statusline_input()
+        data["cost"]["total_cost_usd"] = 12.3456
+        out = statusline.render_statusline(data)
+        assert "$12.35" in out
+
+    def test_shows_diff_lines(self) -> None:
+        out = statusline.render_statusline(_minimal_statusline_input())
+        assert "+12" in out and "-3" in out
+
+    def test_rate_limits_both_present(self) -> None:
+        out = statusline.render_statusline(_minimal_statusline_input())
+        assert "5h:" in out and "7d:" in out
+        assert "13%" in out and "18%" in out
+
+    def test_duration_formatting(self) -> None:
+        data = _minimal_statusline_input()
+        data["cost"]["total_api_duration_ms"] = 83_000  # 1m 23s
+        out = statusline.render_statusline(data)
+        assert "1m23s" in out
+
+    def test_tolerates_missing_fields(self) -> None:
+        """Campo mínimo: só model. Não deve crashar."""
+        out = statusline.render_statusline({"model": {"display_name": "X"}})
+        assert "X" in out
+
+
+class TestFmtHelpers:
+    def test_fmt_tokens(self) -> None:
+        assert statusline._fmt_tokens(999) == "999"
+        assert statusline._fmt_tokens(1_500) == "2k"
+        assert statusline._fmt_tokens(200_000) == "200k"
+
+    def test_fmt_duration(self) -> None:
+        assert statusline._fmt_duration(30_000) == "30s"
+        assert statusline._fmt_duration(90_000) == "1m30s"
+        assert statusline._fmt_duration(3_600_000) == "1h0m"
+        assert statusline._fmt_duration(90_000_000) == "1d1h"
+
+    def test_fmt_reset_delta_negative_is_empty(self) -> None:
+        past = int(time.time()) - 100
+        assert statusline._fmt_reset_delta(past) == ""
+
+    def test_fmt_reset_delta_future(self) -> None:
+        future = int(time.time()) + 5400  # 1h30m
+        assert statusline._fmt_reset_delta(future) == "1h30m"
+
+
+class TestWrapResolution:
+    def test_env_var_takes_precedence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(statusline.WRAP_ENV_VAR, "/env/path")
+        # Config file também tem valor — env deve vencer
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({"statusline_wrap_path": "/cfg/path"}))
+        monkeypatch.setattr(statusline, "DASHBOARD_CONFIG", cfg)
+        assert statusline._resolve_wrap_path() == "/env/path"
+
+    def test_falls_back_to_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(statusline.WRAP_ENV_VAR, raising=False)
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({"statusline_wrap_path": "/from/cfg"}))
+        monkeypatch.setattr(statusline, "DASHBOARD_CONFIG", cfg)
+        assert statusline._resolve_wrap_path() == "/from/cfg"
+
+    def test_none_when_neither_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(statusline.WRAP_ENV_VAR, raising=False)
+        monkeypatch.setattr(
+            statusline, "DASHBOARD_CONFIG", tmp_path / "nao-existe.json"
+        )
+        assert statusline._resolve_wrap_path() is None
+
+
+class TestSetupStatus:
+    def _patch_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[Path, Path]:
+        settings = tmp_path / "settings.json"
+        cfg = tmp_path / ".claude-dash.json"
+        backup_dir = tmp_path / "backups"
+        monkeypatch.setattr(setup_status, "SETTINGS_JSON", settings)
+        monkeypatch.setattr(setup_status, "DASHBOARD_CONFIG", cfg)
+        monkeypatch.setattr(setup_status, "BACKUP_DIR", backup_dir)
+        return settings, cfg
+
+    def test_fresh_install_adds_statusline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        settings, _ = self._patch_paths(tmp_path, monkeypatch)
+        settings.write_text(json.dumps({"language": "pt-BR"}))
+        rc = setup_status.run()
+        assert rc == 0
+        saved = json.loads(settings.read_text())
+        assert saved["statusLine"]["command"] == "claude-dash-statusline"
+        # Preservou outras chaves
+        assert saved["language"] == "pt-BR"
+
+    def test_idempotent_when_already_installed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        settings, _ = self._patch_paths(tmp_path, monkeypatch)
+        settings.write_text(json.dumps({
+            "statusLine": {"type": "command", "command": "claude-dash-statusline"}
+        }))
+        mtime_before = settings.stat().st_mtime
+        time.sleep(0.01)
+        rc = setup_status.run()
+        assert rc == 0
+        # Arquivo não foi reescrito — é idempotente
+        assert settings.stat().st_mtime == mtime_before
+        out = capsys.readouterr().out
+        assert "nada a fazer" in out
+
+    def test_preserves_existing_statusline_as_wrap(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings, cfg = self._patch_paths(tmp_path, monkeypatch)
+        settings.write_text(json.dumps({
+            "statusLine": {"type": "command", "command": "~/meu-script.sh"}
+        }))
+        rc = setup_status.run()
+        assert rc == 0
+        saved_settings = json.loads(settings.read_text())
+        saved_cfg = json.loads(cfg.read_text())
+        # Nosso comando agora é o statusLine
+        assert saved_settings["statusLine"]["command"] == "claude-dash-statusline"
+        # O statusline anterior foi preservado em wrap
+        assert saved_cfg["statusline_wrap_path"] == "~/meu-script.sh"
+
+    def test_creates_backup_before_writing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings, _ = self._patch_paths(tmp_path, monkeypatch)
+        settings.write_text(json.dumps({"language": "pt-BR"}))
+        setup_status.run()
+        # Algum backup foi criado
+        backups = list((tmp_path / "backups").iterdir())
+        assert len(backups) >= 1
+        assert any("settings.json.backup" in b.name for b in backups)

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -159,6 +159,28 @@ class TestWrapResolution:
         assert statusline._resolve_wrap_path() is None
 
 
+class TestRunWrap:
+    def test_expands_tilde_in_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regressão: se wrap_path começa com '~/', expandir antes de execv.
+
+        Review do PR #18 pegou este bug — o Claude Code aceita '~'
+        no settings.json:statusLine.command, então quando preservamos
+        esse valor como wrap_path, subprocess.run precisa expandir.
+        Sem este fix, wrap silenciosamente não executa.
+        """
+        # Cria um script executável em tmp_path
+        script = tmp_path / "meu-statusline.sh"
+        script.write_text("#!/bin/sh\necho 'wrapped output'\n")
+        script.chmod(0o755)
+        # Simula cenário em que o path foi salvo como ~/ e HOME é tmp_path
+        monkeypatch.setenv("HOME", str(tmp_path))
+        tilde_path = "~/meu-statusline.sh"
+        result = statusline._run_wrap(tilde_path, "{}")
+        assert result == "wrapped output"
+
+
 class TestSetupStatus:
     def _patch_paths(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Motivação

Feedback: *"compensa algo maior — deixar o dashboard independente da statusline"*. Arranjo anterior dependia do user adicionar linha manual num script externo. Se o script sumisse/settings.json fosse resetado (aconteceu), captura quebrava silenciosamente.

## Arquitetura

Inversão: **dashboard vira dono do statusLine**, statusline externo vira plugin opcional via wrap.

1. **\`claude-dash-statusline\`** (novo entrypoint) — statusline completo em Python, reimplementa todos os segmentos do \`statusline-dashboard.sh\` bash com ANSI cru (startup <100ms). Captura rate_limits + renderiza output no mesmo processo.

2. **Wrap opcional** — \`CLAUDE_DASH_STATUSLINE_WRAP\` env var ou \`~/.claude/.claude-dash.json:statusline_wrap_path\` executa outro script e usa seu output (preserva visual custom). Captura roda de qualquer forma.

3. **\`claude-dash setup-status\`** (novo subcomando, idempotente):
   - Backup de settings.json
   - Se já está configurado: noop
   - Se havia outro statusLine: preserva como wrap_path e reatribui
   - Se não havia: adiciona limpo

## UX

\`\`\`bash
claude-dash setup-status    # uma vez, resolve tudo
\`\`\`

Reinício de sessão → rate_limits aparecem nas views automaticamente.

## Test plan

- [x] 175 testes (+23) — render, wrap resolution, setup idempotente, preservação de statusline antigo, backup
- [x] Smoke real: output byte-idêntico ao bash original
- [x] \`claude-dash-rate-limit-capture\` preservado por compat

Bump: \`0.10.0\` → \`0.11.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)