### PR TITLE
feat(cli): expõe flag --version em claude-dash

### DIFF
--- a/src/claude_dash/__init__.py
+++ b/src/claude_dash/__init__.py
@@ -1,3 +1,13 @@
 """claude-dashboard — TUI de monitoramento do Claude Code."""
+from __future__ import annotations
 
-__version__ = "0.11.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+# Fonte de verdade da versão é o pyproject.toml (distribuição instalada).
+# Em execuções fora de uma instalação (ex.: árvore de fontes sem `pip install`),
+# caímos num fallback estável.
+try:
+    __version__ = _pkg_version("claude-dashboard")
+except PackageNotFoundError:  # pragma: no cover - defesa para árvore não instalada
+    __version__ = "0.0.0+unknown"

--- a/src/claude_dash/cli.py
+++ b/src/claude_dash/cli.py
@@ -9,11 +9,18 @@ from __future__ import annotations
 import argparse
 import sys
 
+from claude_dash import __version__
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="claude-dash",
         description="Dashboard de uso do Claude Code. Sem args = TUI interativa.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     # subcomando é opcional: sem argumento → TUI
     subparsers = parser.add_subparsers(dest="command", required=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+"""Testes do CLI — foco em flags utilitárias (sem TTY)."""
+from __future__ import annotations
+
+import pytest
+
+from claude_dash import __version__
+from claude_dash.cli import build_parser, main
+
+
+def test_version_flag_prints_prog_and_version(capsys: pytest.CaptureFixture[str]) -> None:
+    """`claude-dash --version` deve sair com 0 e imprimir `claude-dash <versão>`.
+
+    A versão exibida é a mesma exposta em `claude_dash.__version__`,
+    derivada do pyproject via `importlib.metadata` (não hardcoded).
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--version"])
+    assert excinfo.value.code == 0
+
+    captured = capsys.readouterr()
+    # argparse roteia `action="version"` para stdout em Python 3.4+.
+    output = (captured.out + captured.err).strip()
+    assert output == f"claude-dash {__version__}"
+
+
+def test_version_action_registered_in_parser() -> None:
+    """Garante que a flag --version está exposta pelo parser
+    (proteção contra remoção acidental em refactors futuros)."""
+    parser = build_parser()
+    actions = {opt for action in parser._actions for opt in action.option_strings}
+    assert "--version" in actions


### PR DESCRIPTION
## Summary

- Adiciona `--version` ao CLI `claude-dash` (issue #22).
- `__version__` agora derivado de `importlib.metadata.version("claude-dashboard")` com fallback `"0.0.0+unknown"` — single source of truth no `pyproject.toml`.
- Bonus: corrige divergência silenciosa pré-existente (`__init__.py` hardcoded em `0.11.0` vs pyproject `0.11.3`).

## Decisão de escopo

Os outros 3 entry points (`claude-dash-mcp`, `claude-dash-statusline`, `claude-dash-rate-limit-capture`) **não** receberam a flag — são daemons stdio sem argparse, invocados pelo harness do Claude Code, nunca por humano. `--version` ali quebraria o handshake/pipeline.

## Test plan

- [x] `claude-dash --version` imprime `claude-dash 0.11.3`
- [x] Subcomandos existentes continuam funcionando
- [x] 2 testes novos em `tests/test_cli.py`: output literal + anti-regressão de registro do parser
- [x] `pytest`: 188 passed (186 prévios + 2 novos)
- [x] `ruff check`: sem débito novo introduzido

Closes #22