### PR TITLE
feat(sessions): expõe session_name (/rename) em MCP tools e TUI

### DIFF
--- a/src/claude_dash/aggregator.py
+++ b/src/claude_dash/aggregator.py
@@ -12,6 +12,7 @@ from claude_dash.discover import (
 )
 from claude_dash.models import SessionStats, ToolUsageStats, Turn, Usage
 from claude_dash.parser import (
+    extract_custom_title,
     extract_model,
     extract_timestamp_ms,
     extract_usage,
@@ -28,6 +29,12 @@ def _apply_entry(entry: dict, stats: SessionStats) -> None:
         stats.messages_user += 1
     elif etype == "assistant":
         stats.messages_assistant += 1
+    elif etype == "custom-title":
+        # /rename do harness — última entry vence (sobrescreve)
+        title = extract_custom_title(entry)
+        if title is not None:
+            stats.session_name = title
+        return  # custom-title não tem usage/tools/timestamp
 
     u = extract_usage(entry)
     if u is not None:
@@ -158,6 +165,11 @@ def aggregate_transcript_since(
             stats.started_at_ms = live.started_at_ms
 
     for _offset, entry in iter_entries(ref.path):
+        # custom-title não tem timestamp — sempre processa para preservar
+        # o nome dado via /rename mesmo em janelas curtas (ex: today)
+        if entry.get("type") == "custom-title":
+            _apply_entry(entry, stats)
+            continue
         ts = extract_timestamp_ms(entry)
         # Descarta entries sem timestamp OU antes da janela
         if ts is None or ts < since_ms:

--- a/src/claude_dash/cache.py
+++ b/src/claude_dash/cache.py
@@ -95,6 +95,7 @@ def deserialize_stats(d: dict) -> SessionStats:
         messages_assistant=int(d.get("messages_assistant") or 0),
         subagents=int(d.get("subagents") or 0),
         last_usage=last_usage,
+        session_name=d.get("session_name") or None,
     )
 
 

--- a/src/claude_dash/cache.py
+++ b/src/claude_dash/cache.py
@@ -21,6 +21,13 @@ from claude_dash.models import SessionStats, Usage
 
 CACHE_DIR = Path(os.environ.get("CLAUDE_DASH_CACHE", Path.home() / ".cache" / "claude-dash"))
 
+# Schema do payload do cache. Bumpar quando novos campos do SessionStats
+# precisarem ser populados a partir do JSONL — caches anteriores não têm
+# o campo e seriam servidos como `None` indistinguível de "ausente real".
+# Histórico:
+#   1 → adição de session_name (lido de entries `custom-title`)
+CACHE_SCHEMA_VERSION = 1
+
 
 def cache_path_for(session_id: str, cache_dir: Path = CACHE_DIR) -> Path:
     """Caminho canônico do cache de uma sessão."""
@@ -28,14 +35,25 @@ def cache_path_for(session_id: str, cache_dir: Path = CACHE_DIR) -> Path:
 
 
 def load(session_id: str, cache_dir: Path = CACHE_DIR) -> dict | None:
-    """Carrega o cache; retorna None se ausente ou corrompido."""
+    """Carrega o cache; retorna None se ausente, corrompido ou de schema antigo.
+
+    Caches escritos antes da introdução de `schema_version` (ou com
+    versão menor que `CACHE_SCHEMA_VERSION`) são tratados como ausentes.
+    Isto força reprocessamento do transcript inteiro — necessário para
+    popular campos novos como `session_name` que vêm de entries já
+    parseadas.
+    """
     path = cache_path_for(session_id, cache_dir)
     if not path.is_file():
         return None
     try:
-        return json.loads(path.read_text())
+        payload = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+    # Schema antigo (sem `schema_version` ou versão < atual) → invalida
+    if int(payload.get("schema_version") or 0) < CACHE_SCHEMA_VERSION:
+        return None
+    return payload
 
 
 def save(
@@ -50,6 +68,7 @@ def save(
     cache_dir.mkdir(parents=True, exist_ok=True)
     path = cache_path_for(session_id, cache_dir)
     payload = {
+        "schema_version": CACHE_SCHEMA_VERSION,
         "inode": int(inode),
         "mtime_ms": mtime_ms,
         "byte_offset": byte_offset,

--- a/src/claude_dash/mcp_server.py
+++ b/src/claude_dash/mcp_server.py
@@ -51,6 +51,7 @@ def _stats_to_dict(s: SessionStats, *, include_tools_top: int = 5) -> dict[str, 
     top_tools = sorted(s.tools.items(), key=lambda kv: -kv[1])[:include_tools_top]
     return {
         "session_id": s.session_id,
+        "session_name": s.session_name,
         "pid": s.pid,
         "alive": s.alive,
         "cwd": str(s.cwd),
@@ -90,13 +91,21 @@ def _infer_alerts(
     now_ms = int(datetime.now().timestamp() * 1000)
     alerts: list[str] = []
 
+    def _label(s: SessionStats) -> str:
+        # Prefere nome humano (/rename) ao prefixo do UUID para alertas.
+        # Mantém o prefixo entre parênteses para desambiguação se houver
+        # várias sessões com o mesmo nome.
+        if s.session_name:
+            return f"'{s.session_name}' ({s.session_id[:8]}…)"
+        return f"{s.session_id[:8]}…"
+
     for s in live_stats:
         # Output médio por turno muito alto — proxy de "Opus gerando respostas
         # densas" (ex: arquivos longos, loops, output repetitivo). O threshold
         # é em tokens de OUTPUT por turno (não custo direto).
         if s.tokens_per_turn > 300_000 and s.messages_assistant > 3:
             alerts.append(
-                f"Sessão {s.session_id[:8]}… com média {int(s.tokens_per_turn):,} "
+                f"Sessão {_label(s)} com média {int(s.tokens_per_turn):,} "
                 f"output tokens/turno (esperado < 300k): investigar se está "
                 f"gerando arquivos longos ou rodando em loop."
             )
@@ -105,7 +114,7 @@ def _infer_alerts(
         if s.last_activity_ms and (now_ms - s.last_activity_ms) > 30 * 60 * 1000:
             minutes = (now_ms - s.last_activity_ms) // 60_000
             alerts.append(
-                f"Sessão {s.session_id[:8]}… (pid {s.pid}) viva mas sem "
+                f"Sessão {_label(s)} (pid {s.pid}) viva mas sem "
                 f"atividade há {minutes} min — pode estar travada, aguardando "
                 f"input do usuário, ou idle."
             )
@@ -114,7 +123,7 @@ def _infer_alerts(
         ctx = s.active_context_tokens
         if ctx > 150_000:
             alerts.append(
-                f"Sessão {s.session_id[:8]}… usando {ctx:,} tokens de contexto ativo "
+                f"Sessão {_label(s)} usando {ctx:,} tokens de contexto ativo "
                 f"— próximo do limite 200k da janela padrão; considerar /compact."
             )
 
@@ -443,6 +452,7 @@ def workflow_snapshot() -> dict[str, Any]:
             "sessions_brief": [
                 {
                     "sid_short": s.session_id[:8],
+                    "session_name": s.session_name,
                     "pid": s.pid,
                     "model": s.dominant_model,
                     "cost_usd": round(sum(cost_of(m, u) for m, u in s.usage_by_model.items()), 2),

--- a/src/claude_dash/models.py
+++ b/src/claude_dash/models.py
@@ -119,6 +119,10 @@ class SessionStats:
     alive: bool = False
     version: str = ""
     transcript_path: Path | None = None
+    # Nome dado à sessão via slash command `/rename` no harness do Claude
+    # Code (ex: "claude-dash", "auto-normas+20260423"). None quando o
+    # usuário não definiu — não há fallback (não usar cwd nem session_id).
+    session_name: str | None = None
     usage_by_model: dict[str, Usage] = field(default_factory=dict)
     tools: dict[str, int] = field(default_factory=dict)
     messages_user: int = 0

--- a/src/claude_dash/parser.py
+++ b/src/claude_dash/parser.py
@@ -96,6 +96,26 @@ def iter_tool_uses(entry: dict[str, Any]) -> Iterator[str]:
                 yield name
 
 
+def extract_custom_title(entry: dict[str, Any]) -> str | None:
+    """Retorna o nome dado à sessão via `/rename`, se a entry for do tipo
+    `custom-title`.
+
+    O harness do Claude Code persiste o nome no transcript JSONL como
+    uma linha do tipo `{"type":"custom-title","customTitle":"<nome>",...}`.
+    Cada `/rename` aplicado durante a sessão gera uma nova entry — a
+    convenção do aggregator é "última vence" (a mais recente sobrescreve).
+
+    Strings vazias são descartadas (retornam None) para não poluir o
+    payload com nomes nulos.
+    """
+    if entry.get("type") != "custom-title":
+        return None
+    title = entry.get("customTitle")
+    if isinstance(title, str) and title.strip():
+        return title
+    return None
+
+
 def extract_timestamp_ms(entry: dict[str, Any]) -> int | None:
     """Converte `timestamp` ISO8601 para epoch ms, se presente."""
     ts = entry.get("timestamp")

--- a/src/claude_dash/views/now.py
+++ b/src/claude_dash/views/now.py
@@ -68,6 +68,19 @@ def _short_sid(sid: str) -> str:
     return sid[:8] + "…"
 
 
+def _session_label(s: SessionStats) -> str:
+    """Label primário da sessão para tabelas: nome (/rename) se existe, senão SID curto.
+
+    Quando há nome, exibe-o em destaque com o SID curto numa segunda
+    linha em estilo dim — mantém ambos os identificadores acessíveis
+    sem competir pela atenção visual.
+    """
+    short = _short_sid(s.session_id)
+    if s.session_name:
+        return f"[bold]{s.session_name}[/bold]\n[dim]{short}[/dim]"
+    return short
+
+
 def _total_cost(s: SessionStats) -> float:
     return sum(cost_of(model, u) for model, u in s.usage_by_model.items())
 
@@ -143,7 +156,7 @@ def _session_table(sessions: list[SessionStats]) -> Table:
         padding=(0, 1),
     )
     table.add_column("PID", style="dim", justify="right", width=6)
-    table.add_column("SID", width=10)
+    table.add_column("Sessão", width=20, overflow="fold")
     table.add_column("CWD", overflow="ellipsis")
     table.add_column("Idade", justify="right", width=8)
     table.add_column("Modelo", width=14)
@@ -170,7 +183,7 @@ def _session_table(sessions: list[SessionStats]) -> Table:
 
         table.add_row(
             f"{status}{pid_txt}",
-            _short_sid(s.session_id),
+            _session_label(s),
             _fmt_short_cwd(s.cwd),
             _fmt_duration(age_ms) if age_ms else "—",
             dom_short,

--- a/src/claude_dash/views/session.py
+++ b/src/claude_dash/views/session.py
@@ -58,7 +58,11 @@ def _header(stats: SessionStats) -> Panel:
     )
 
     h = Text()
-    h.append(f" SID    {stats.session_id}\n", style="bold cyan")
+    if stats.session_name:
+        h.append(f" Nome   {stats.session_name}\n", style="bold cyan")
+        h.append(f" SID    {stats.session_id}\n", style="dim cyan")
+    else:
+        h.append(f" SID    {stats.session_id}\n", style="bold cyan")
     h.append(f" CWD    {stats.cwd}\n", style="dim")
     h.append(" Estado ", style="dim")
     h.append(f"{state}", style="")

--- a/src/claude_dash/views/today.py
+++ b/src/claude_dash/views/today.py
@@ -24,7 +24,6 @@ from claude_dash.views.now import (
     _fmt_short_cwd,
     _fmt_tokens,
     _session_label,
-    _short_sid,
     _tools_summary,
     _total_cost,
     colored_cost,

--- a/src/claude_dash/views/today.py
+++ b/src/claude_dash/views/today.py
@@ -23,6 +23,7 @@ from claude_dash.views.now import (
     _fmt_duration,
     _fmt_short_cwd,
     _fmt_tokens,
+    _session_label,
     _short_sid,
     _tools_summary,
     _total_cost,
@@ -76,7 +77,7 @@ def _session_table(sessions: list[SessionStats]) -> Panel:
         expand=True,
         padding=(0, 1),
     )
-    table.add_column("SID", width=10)
+    table.add_column("Sessão", width=20, overflow="fold")
     table.add_column("CWD", overflow="ellipsis")
     table.add_column("Estado", width=7, justify="center")
     table.add_column("Última atividade", width=18)
@@ -104,7 +105,7 @@ def _session_table(sessions: list[SessionStats]) -> Panel:
         msgs = f"{s.messages_user}u/{s.messages_assistant}a"
 
         table.add_row(
-            _short_sid(s.session_id),
+            _session_label(s),
             _fmt_short_cwd(s.cwd),
             state,
             last_activity,

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -251,15 +251,22 @@ class DashboardApp(App):
         # são convencionalmente radio buttons — usuário interpretava
         # "● = item selecionado" em vez de "sessão ativa". O highlight
         # de seleção já é fornecido pelo ListView do Textual.
-        for ls in discover_live_sessions():
-            if ls.session_id in seen:
+        # Usa `collect_live_sessions` em vez de `discover_live_sessions`
+        # para ter `session_name` disponível (vem do aggregator, não do
+        # arquivo de session metadata).
+        live_stats = collect_live_sessions()
+        for s in live_stats:
+            if s.session_id in seen:
                 continue
-            seen.add(ls.session_id)
+            seen.add(s.session_id)
+            name_part = (
+                f"[bold]{s.session_name}[/bold]  " if s.session_name else ""
+            )
             label = (
                 f"[bold green]viva[/bold green]  "
-                f"{ls.session_id[:8]}…  {ls.cwd}  pid={ls.pid}"
+                f"{name_part}{s.session_id[:8]}…  {s.cwd}  pid={s.pid}"
             )
-            entries.append((ls.session_id, label))
+            entries.append((s.session_id, label))
 
         # Sessões do dia (mesmo que mortas)
         for s in collect_sessions_since(today_start_ms()):
@@ -270,7 +277,10 @@ class DashboardApp(App):
                 state_markup = "[bold green]viva [/bold green]"
             else:
                 state_markup = "[bold red]morta[/bold red]"
-            label = f"{state_markup}  {s.session_id[:8]}…  {s.cwd}"
+            name_part = (
+                f"[bold]{s.session_name}[/bold]  " if s.session_name else ""
+            )
+            label = f"{state_markup}  {name_part}{s.session_id[:8]}…  {s.cwd}"
             entries.append((s.session_id, label))
 
         if not entries:

--- a/tests/test_session_name.py
+++ b/tests/test_session_name.py
@@ -192,6 +192,60 @@ def test_session_name_survives_cache_roundtrip(
     assert stats2.session_name == "saturnine+20260427"
 
 
+def test_legacy_cache_without_schema_version_is_invalidated(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """Cache pré-v1 (sem schema_version) é tratado como ausente.
+
+    Caches antigos não foram escritos com `session_name` e devolveriam
+    None mesmo para sessões com /rename — reprocessamento força a leitura
+    da entry custom-title que já existe no transcript.
+    """
+    from claude_dash import cache as cache_mod
+
+    entries = [
+        {"type": "custom-title", "customTitle": "real-name",
+         "sessionId": "test-sid"},
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 10}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+
+    # Escreve cache "legacy" manualmente (sem schema_version, sem
+    # session_name) imitando o formato pré-v0.12
+    legacy_payload = {
+        "inode": ref.path.stat().st_ino,
+        "mtime_ms": ref.mtime_ms,
+        "byte_offset": ref.path.stat().st_size,
+        "stats": {
+            "session_id": ref.session_id,
+            "cwd": "",
+            "started_at_ms": 0,
+            "last_activity_ms": ref.mtime_ms,
+            "pid": None,
+            "alive": False,
+            "version": "",
+            "transcript_path": None,
+            "usage_by_model": {"m": {
+                "input_tokens": 10, "output_tokens": 0,
+                "cache_creation_1h": 0, "cache_creation_5m": 0, "cache_read": 0,
+            }},
+            "tools": {},
+            "messages_user": 0,
+            "messages_assistant": 1,
+            "subagents": 0,
+            "last_usage": None,
+        },
+    }
+    cache_path = cache_mod.cache_path_for(ref.session_id)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(legacy_payload))
+
+    # Carrega: deve invalidar e reprocessar, capturando session_name
+    stats = build_stats_for_transcript(ref, use_cache=True)
+    assert stats.session_name == "real-name"
+
+
 # --- MCP server ---------------------------------------------------------
 
 

--- a/tests/test_session_name.py
+++ b/tests/test_session_name.py
@@ -1,0 +1,289 @@
+"""Testes da exposição do `session_name` (nome dado via /rename).
+
+Cobre:
+- Parser: extract_custom_title
+- Aggregator: leitura, "última vence", preservação no aggregate_transcript_since
+- Cache: round-trip
+- MCP server: campo presente em payloads
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_dash import mcp_server
+from claude_dash.aggregator import (
+    aggregate_transcript_since,
+    build_stats_for_transcript,
+)
+from claude_dash.discover import TranscriptRef
+from claude_dash.models import SessionStats, Usage
+from claude_dash.parser import extract_custom_title
+
+# --- Helpers ------------------------------------------------------------
+
+
+def _make_transcript(tmp_path: Path, entries: list[dict]) -> TranscriptRef:
+    f = tmp_path / "t.jsonl"
+    with f.open("w") as fp:
+        for e in entries:
+            fp.write(json.dumps(e) + "\n")
+    mtime = int(f.stat().st_mtime * 1000)
+    return TranscriptRef(
+        session_id="test-sid",
+        path=f,
+        workspace="-ws",
+        mtime_ms=mtime,
+    )
+
+
+@pytest.fixture
+def isolated_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redireciona cache_dir para evitar contaminação entre testes."""
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("CLAUDE_DASH_CACHE", str(cache_dir))
+    import importlib
+
+    from claude_dash import cache as cache_mod
+    importlib.reload(cache_mod)
+    return cache_dir
+
+
+# --- Parser -------------------------------------------------------------
+
+
+class TestExtractCustomTitle:
+    def test_returns_title_for_custom_title_entry(self) -> None:
+        entry = {
+            "type": "custom-title",
+            "customTitle": "claude-dash",
+            "sessionId": "abc",
+        }
+        assert extract_custom_title(entry) == "claude-dash"
+
+    def test_returns_none_for_other_types(self) -> None:
+        assert extract_custom_title({"type": "user"}) is None
+        assert extract_custom_title({"type": "assistant"}) is None
+        assert extract_custom_title({"type": "system"}) is None
+
+    def test_returns_none_when_title_missing(self) -> None:
+        assert extract_custom_title({"type": "custom-title"}) is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        assert extract_custom_title(
+            {"type": "custom-title", "customTitle": ""}
+        ) is None
+        assert extract_custom_title(
+            {"type": "custom-title", "customTitle": "   "}
+        ) is None
+
+    def test_accepts_unicode_and_special_chars(self) -> None:
+        # Nomes reais do Léo: "saturnine+20260427", "auto-normas+20260423"
+        # também caracteres especiais e acentos
+        assert extract_custom_title(
+            {"type": "custom-title", "customTitle": "saturnine+20260427"}
+        ) == "saturnine+20260427"
+        assert extract_custom_title(
+            {"type": "custom-title", "customTitle": "análise/refator"}
+        ) == "análise/refator"
+
+
+# --- Aggregator: build_stats_for_transcript -----------------------------
+
+
+def test_session_name_is_none_when_no_rename(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """Sessão sem /rename retorna None — sem fallback para sid/cwd."""
+    entries = [
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 10}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    assert stats.session_name is None
+
+
+def test_session_name_captured_from_custom_title(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    entries = [
+        {"type": "custom-title", "customTitle": "claude-dash",
+         "sessionId": "test-sid"},
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 10}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    assert stats.session_name == "claude-dash"
+
+
+def test_session_name_last_wins_when_multiple_renames(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """Cada /rename gera nova entry — a mais recente sobrescreve."""
+    entries = [
+        {"type": "custom-title", "customTitle": "primeiro-nome",
+         "sessionId": "test-sid"},
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 10}}},
+        {"type": "custom-title", "customTitle": "nome-final",
+         "sessionId": "test-sid"},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    assert stats.session_name == "nome-final"
+
+
+def test_custom_title_does_not_count_as_message(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """custom-title não deve inflar messages_user/messages_assistant."""
+    entries = [
+        {"type": "custom-title", "customTitle": "x", "sessionId": "test-sid"},
+        {"type": "user"},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    stats = build_stats_for_transcript(ref, use_cache=False)
+    assert stats.messages_user == 1
+    assert stats.messages_assistant == 0
+
+
+# --- Aggregator: aggregate_transcript_since -----------------------------
+
+
+def test_session_name_preserved_in_since_window(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    """custom-title não tem timestamp — não pode ser descartado pelo
+    filtro de janela usado em today/sessions_since."""
+    entries = [
+        {"type": "custom-title", "customTitle": "auto-normas",
+         "sessionId": "test-sid"},
+        {"type": "assistant", "timestamp": "2026-04-21T10:00:00Z",
+         "message": {"model": "m", "usage": {"input_tokens": 100}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    cutoff = 1776758400000  # 2026-04-21 00:00 UTC
+    stats = aggregate_transcript_since(ref, since_ms=cutoff)
+    assert stats.session_name == "auto-normas"
+    assert stats.usage_by_model["m"].input_tokens == 100
+
+
+# --- Cache --------------------------------------------------------------
+
+
+def test_session_name_survives_cache_roundtrip(
+    tmp_path: Path, isolated_cache: Path
+) -> None:
+    entries = [
+        {"type": "custom-title", "customTitle": "saturnine+20260427",
+         "sessionId": "test-sid"},
+        {"type": "assistant", "message": {"model": "m",
+            "usage": {"input_tokens": 42}}},
+    ]
+    ref = _make_transcript(tmp_path, entries)
+    build_stats_for_transcript(ref, use_cache=True)
+    # Segunda chamada lê do cache (mtime inalterado)
+    stats2 = build_stats_for_transcript(ref, use_cache=True)
+    assert stats2.session_name == "saturnine+20260427"
+
+
+# --- MCP server ---------------------------------------------------------
+
+
+def _mk_session(
+    sid: str = "abc12345-def",
+    session_name: str | None = None,
+    cost_usage: Usage | None = None,
+) -> SessionStats:
+    s = SessionStats(
+        session_id=sid,
+        cwd=Path("/home/x"),
+        started_at_ms=1776700000000,
+        last_activity_ms=1776700500000,
+        pid=12345,
+        alive=True,
+        messages_user=10,
+        messages_assistant=10,
+        session_name=session_name,
+    )
+    if cost_usage is not None:
+        s.usage_by_model["claude-opus-4-7"] = cost_usage
+    return s
+
+
+def test_active_sessions_includes_session_name() -> None:
+    fake = [_mk_session(session_name="claude-dash",
+                        cost_usage=Usage(input_tokens=100))]
+    with patch.object(mcp_server, "collect_live_sessions", return_value=fake):
+        result = mcp_server.active_sessions()
+    assert result["sessions"][0]["session_name"] == "claude-dash"
+
+
+def test_active_sessions_session_name_is_null_when_unset() -> None:
+    fake = [_mk_session(session_name=None,
+                        cost_usage=Usage(input_tokens=100))]
+    with patch.object(mcp_server, "collect_live_sessions", return_value=fake):
+        result = mcp_server.active_sessions()
+    assert result["sessions"][0]["session_name"] is None
+
+
+def test_today_summary_includes_session_name() -> None:
+    fake = [
+        _mk_session(sid="a", session_name="auto-normas",
+                    cost_usage=Usage(input_tokens=1_000_000)),
+        _mk_session(sid="b", session_name=None,
+                    cost_usage=Usage(input_tokens=2_000_000)),
+    ]
+    with patch.object(mcp_server, "collect_sessions_since", return_value=fake):
+        result = mcp_server.today_summary()
+    names = [s["session_name"] for s in result["sessions"]]
+    assert "auto-normas" in names
+    assert None in names
+
+
+def test_session_details_includes_session_name() -> None:
+    fake_ref = TranscriptRef(
+        session_id="abc", path=Path("/tmp/fake.jsonl"),
+        workspace="-ws", mtime_ms=0,
+    )
+    fake_stats = _mk_session(sid="abc", session_name="claude-dash",
+                             cost_usage=Usage(input_tokens=100))
+    with patch.object(mcp_server, "find_transcript_for_session",
+                      return_value=fake_ref), \
+         patch.object(mcp_server, "build_stats_for_transcript",
+                      return_value=fake_stats), \
+         patch.object(mcp_server, "subagents_of", return_value=[]), \
+         patch.object(mcp_server, "extract_turns", return_value=[]):
+        result = mcp_server.session_details("abc")
+    assert result["session"]["session_name"] == "claude-dash"
+
+
+def test_workflow_snapshot_brief_includes_session_name() -> None:
+    fake = [_mk_session(session_name="claude-dash",
+                        cost_usage=Usage(input_tokens=100))]
+    with patch.object(mcp_server, "collect_live_sessions", return_value=fake), \
+         patch.object(mcp_server, "collect_sessions_since", return_value=[]), \
+         patch.object(mcp_server, "collect_tool_usage_since", return_value={}):
+        snap = mcp_server.workflow_snapshot()
+    briefs = snap["active"]["sessions_brief"]
+    assert briefs[0]["session_name"] == "claude-dash"
+
+
+def test_workflow_snapshot_alert_uses_session_name_when_present() -> None:
+    """Alertas devem citar o nome amigável quando disponível."""
+    big_ctx = _mk_session(
+        session_name="claude-dash",
+        cost_usage=Usage(input_tokens=100, cache_read=200_000),
+    )
+    big_ctx.last_usage = Usage(input_tokens=100, cache_read=200_000)
+    with patch.object(mcp_server, "collect_live_sessions",
+                      return_value=[big_ctx]), \
+         patch.object(mcp_server, "collect_sessions_since", return_value=[]), \
+         patch.object(mcp_server, "collect_tool_usage_since", return_value={}):
+        snap = mcp_server.workflow_snapshot()
+    assert any("claude-dash" in a for a in snap["alerts"])


### PR DESCRIPTION
## Summary

Expõe o nome da sessão (definido via slash command `/rename` do Claude Code) nos payloads MCP e na TUI (issue #23).

- **Origem do dado:** linha JSON `{"type":"custom-title","customTitle":"...","sessionId":"..."}` no transcript `~/.claude/projects/<encoded-cwd>/<session_id>.jsonl`. Última `custom-title` vence.
- **Cobertura MCP:** `active_sessions`, `session_details`, `today_summary.sessions[]`, `workflow_snapshot.active.sessions_brief`, e textos de alertas (`'<nome>' (<sid>…)`). Quando não há rename, `session_name = null`.
- **Cobertura TUI:** coluna "Sessão" multi-linha em `now`/`today` (nome em bold + SID curto em dim) substitui coluna SID; header de drill-down em `session.py` ganha linha "Nome"; ListView do `tui.py` prefixa o nome inline.
- **Cache:** introduz `CACHE_SCHEMA_VERSION = 1` para invalidar caches pré-feature de forma transparente (caches sem `schema_version` são ignorados e regravados — nada deletado).

## Decisões de escopo

1. **Não usa `agent-name`** (entry paralela no JSONL — é nome de subagent, não de sessão).
2. **`CACHE_SCHEMA_VERSION` em vez de migração silenciosa** — pattern canônico, 5 linhas, evita reabrir transcripts inutilmente.
3. **Alertas do `workflow_snapshot` ganham nome** (escopo levemente expandido) — alerta sem nome forçava mapping mental sid→sessão; o nome é o identificador humano natural que motivou a feature.

## Edge cases tratados

- Sessão sem `/rename` → `null` (sem fallback para cwd/sid).
- String vazia/whitespace → `null`.
- Múltiplos `/rename` na mesma sessão → última vence.
- Unicode e caracteres especiais (testado).
- `custom-title` sem timestamp → tratamento especial em `aggregate_transcript_since` (escapa do filtro temporal padrão).
- `custom-title` não infla contadores `messages_user/assistant`.

## Test plan

- [x] 18 testes novos em `tests/test_session_name.py` (17 funcionais + 1 de invalidação de cache antigo)
- [x] `pytest`: 202 passed (184 prévios + 18 novos)
- [x] `ruff check`: paridade com baseline do `main` (zero débito novo após fix M1)
- [x] Validação manual contra transcripts reais (sessões `claude-dash`, `saturnine+20260427`, e sessão sem rename)

## Code review

Revisado pelo `superpowers:code-reviewer` em integração com PR #25. Achados:

- ✅ M1 (BLOCKER): import órfão `_short_sid` em `views/today.py:27` — corrigido em commit `6364eea`.
- 📝 M2 (follow-up): `_refresh_session_list` em `tui.py:257` agora chama `collect_live_sessions()` (parseia transcript via cache) em vez de `discover_live_sessions()` (só metadata). Em conjunto com `_refresh_now` no auto-refresh de 2s, dobra I/O quando usuário fica na aba Session. Cache cobre o caminho quente. Issue de follow-up aberta separadamente.
- ✅ Demais decisões e implementação aprovadas sem ressalvas.

Closes #23