### PR TITLE
release: v0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.11.3"
+version = "0.12.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bump minor de `0.11.3` → `0.12.0`.

## Includes

- **#25** — `feat(cli): --version` (fecha #22)
- **#26** — `feat(sessions): session_name (/rename) em MCP tools e TUI` (fecha #23)

## Justificativa do bump minor (não patch)

PR #26 adiciona o campo `session_name` nos payloads de:
- `mcp__claude-dashboard__active_sessions[]`
- `mcp__claude-dashboard__session_details`
- `mcp__claude-dashboard__today_summary.sessions[]`
- `mcp__claude-dashboard__workflow_snapshot.active.sessions_brief[]`
- Texto dos alertas (`'<nome>' (<sid>…)` em vez de só `<sid>…`)

Clientes MCP estritamente schema-fechados podem precisar atualizar. Por SemVer, adição de campo opcional em payload público = minor bump.

## Pendências carregadas pra próximo ciclo

- **#27** — `perf(tui): _refresh_session_list dobra I/O com _refresh_now no auto-refresh` (não-bloqueante; cache cobre o caminho quente)

## Pós-merge

- Tag `v0.12.0` será criada apontando para o merge commit.
- Atualização local: `pipx reinstall claude-dashboard` (Vaio) ou migrar para pipx (Predator — atualmente em editable install com `.dist-info` defasado).