### PR TITLE
perf(aggregator): TTL cache em collect_live_sessions e collect_sessions_since

### DIFF
--- a/src/claude_dash/aggregator.py
+++ b/src/claude_dash/aggregator.py
@@ -1,6 +1,8 @@
 """Monta SessionStats a partir de transcripts, com cache incremental."""
 from __future__ import annotations
 
+import functools
+import time
 from pathlib import Path
 
 from claude_dash import cache
@@ -20,6 +22,44 @@ from claude_dash.parser import (
     iter_tool_uses,
 )
 from claude_dash.pricing import normalize_model
+
+# Memoização TTL para coletas pesadas. Não thread-safe (a TUI roda em
+# single-thread via Textual), sem evicção por tamanho (poucas chaves
+# possíveis: nome da função x argumentos imutáveis pequenos).
+#
+# Aplicado em `collect_live_sessions` e `collect_sessions_since` — ambas
+# são chamadas múltiplas vezes em janela curta (on_mount agrupa 4
+# refreshes; refresh manual `r` pode cair logo após tick do auto-refresh
+# de 2s). TTL=1.0s garante que o próximo tick do `_refresh_now` (cada
+# 2s) sempre invalide o cache — margem 2x sobre o intervalo do timer.
+#
+# IMPORTANTE: o retorno é a lista interna do cache; chamadores NÃO devem
+# mutá-la. Os call sites atuais só leem (ordenam para display, iteram
+# para somar) — se um futuro call site precisar mutar, fazer .copy()
+# explicitamente no chamador.
+_cache: dict[tuple, tuple[float, object]] = {}
+
+
+def _ttl_cached(seconds: float):
+    """Decorator de cache com TTL curto."""
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            key = (fn.__name__, args, tuple(sorted(kwargs.items())))
+            now = time.monotonic()
+            hit = _cache.get(key)
+            if hit is not None and now - hit[0] < seconds:
+                return hit[1]
+            result = fn(*args, **kwargs)
+            _cache[key] = (now, result)
+            return result
+
+        # Exposto para testes e para invalidação manual em casos
+        # excepcionais (ex: mudança de relógio do sistema).
+        wrapper.cache_clear = lambda: _cache.clear()
+        return wrapper
+
+    return decorator
 
 
 def _apply_entry(entry: dict, stats: SessionStats) -> None:
@@ -182,6 +222,7 @@ def aggregate_transcript_since(
     return stats
 
 
+@_ttl_cached(1.0)
 def collect_sessions_since(since_ms: int) -> list[SessionStats]:
     """Coleta SessionStats de sessões com atividade desde `since_ms`.
 
@@ -337,6 +378,7 @@ def collect_tool_usage_since(since_ms: int) -> dict[str, ToolUsageStats]:
     return out
 
 
+@_ttl_cached(1.0)
 def collect_live_sessions(use_cache: bool = True) -> list[SessionStats]:
     """Coleta SessionStats de todas as sessões atualmente vivas.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Fixtures globais da suíte de testes."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_aggregator_ttl_cache():
+    """Limpa o cache TTL do aggregator entre testes.
+
+    `collect_live_sessions` e `collect_sessions_since` são memoizadas
+    com TTL de 1s. Sem isso, testes que rodam em sequência rápida
+    poderiam ver resultados de fixtures anteriores (ex: testes do MCP
+    que mockam o módulo após uma chamada real).
+    """
+    from claude_dash import aggregator
+    aggregator._cache.clear()
+    yield
+    aggregator._cache.clear()

--- a/tests/test_aggregator_cache.py
+++ b/tests/test_aggregator_cache.py
@@ -1,0 +1,142 @@
+"""Testes da memoização TTL em collect_live_sessions e collect_sessions_since.
+
+Cobre os comportamentos garantidos pelo decorator `_ttl_cached`:
+- hit dentro da janela retorna o mesmo objeto (identidade);
+- miss após expiração re-executa;
+- chaves diferentes não compartilham cache;
+- cache_clear() força re-execução.
+
+Não usa `time.sleep` — controla o relógio via monkeypatch em
+`time.monotonic`, conforme orientação do issue #27.
+"""
+from __future__ import annotations
+
+import pytest
+
+from claude_dash import aggregator
+
+
+@pytest.fixture
+def fake_clock(monkeypatch: pytest.MonkeyPatch):
+    """Relógio monotônico controlável via `clock['t']`."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(aggregator.time, "monotonic", lambda: clock["t"])
+    return clock
+
+
+def test_hit_dentro_do_ttl_retorna_mesmo_objeto(
+    fake_clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Chamada idêntica dentro do TTL deve devolver o objeto cacheado."""
+    chamadas = {"n": 0}
+
+    def fake_discover_live():
+        chamadas["n"] += 1
+        return []
+
+    def fake_discover_transcripts():
+        return []
+
+    monkeypatch.setattr(aggregator, "discover_live_sessions", fake_discover_live)
+    monkeypatch.setattr(aggregator, "discover_transcripts", fake_discover_transcripts)
+
+    aggregator.collect_live_sessions.cache_clear()
+
+    primeiro = aggregator.collect_live_sessions()
+    fake_clock["t"] += 0.5  # ainda dentro do TTL de 1.0s
+    segundo = aggregator.collect_live_sessions()
+
+    assert primeiro is segundo, "esperava cache hit (mesmo objeto)"
+    assert chamadas["n"] == 1, "função interna executou mais de uma vez"
+
+
+def test_miss_apos_expiracao_re_executa(
+    fake_clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Após o TTL expirar, a função interna deve rodar novamente."""
+    chamadas = {"n": 0}
+
+    def fake_discover_live():
+        chamadas["n"] += 1
+        return []
+
+    monkeypatch.setattr(aggregator, "discover_live_sessions", fake_discover_live)
+    monkeypatch.setattr(aggregator, "discover_transcripts", lambda: [])
+
+    aggregator.collect_live_sessions.cache_clear()
+
+    aggregator.collect_live_sessions()
+    fake_clock["t"] += 1.5  # > TTL de 1.0s
+    aggregator.collect_live_sessions()
+
+    assert chamadas["n"] == 2, "esperava re-execução após expiração"
+
+
+def test_argumentos_diferentes_nao_compartilham_cache(
+    fake_clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`collect_sessions_since(a)` e `(b)` devem ter entradas separadas."""
+    chamadas = {"n": 0}
+
+    def fake_discover_live():
+        return []
+
+    def fake_discover_transcripts():
+        chamadas["n"] += 1
+        return []
+
+    monkeypatch.setattr(aggregator, "discover_live_sessions", fake_discover_live)
+    monkeypatch.setattr(aggregator, "discover_transcripts", fake_discover_transcripts)
+
+    aggregator.collect_sessions_since.cache_clear()
+
+    aggregator.collect_sessions_since(1000)
+    aggregator.collect_sessions_since(2000)  # since_ms diferente → outra chave
+    # Sem avançar o relógio, mesma chamada → cache hit
+    aggregator.collect_sessions_since(1000)
+
+    assert chamadas["n"] == 2, (
+        "esperava 2 execuções (uma por valor de since_ms); "
+        f"obteve {chamadas['n']}"
+    )
+
+
+def test_cache_clear_forca_re_execucao(
+    fake_clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`cache_clear()` deve invalidar entradas mesmo dentro do TTL."""
+    chamadas = {"n": 0}
+
+    def fake_discover_live():
+        chamadas["n"] += 1
+        return []
+
+    monkeypatch.setattr(aggregator, "discover_live_sessions", fake_discover_live)
+    monkeypatch.setattr(aggregator, "discover_transcripts", lambda: [])
+
+    aggregator.collect_live_sessions.cache_clear()
+
+    aggregator.collect_live_sessions()
+    aggregator.collect_live_sessions.cache_clear()
+    aggregator.collect_live_sessions()  # sem avançar o relógio
+
+    assert chamadas["n"] == 2, "esperava re-execução após cache_clear"
+
+
+def test_collect_live_e_collect_since_tem_chaves_distintas(
+    fake_clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """O nome da função compõe a chave; uma não invalida a outra."""
+    monkeypatch.setattr(aggregator, "discover_live_sessions", lambda: [])
+    monkeypatch.setattr(aggregator, "discover_transcripts", lambda: [])
+
+    aggregator.collect_live_sessions.cache_clear()
+    aggregator.collect_sessions_since.cache_clear()
+
+    a = aggregator.collect_live_sessions()
+    b = aggregator.collect_sessions_since(0)
+
+    # Listas distintas (objetos diferentes), mas dentro do TTL cada uma
+    # devolve o próprio objeto cacheado em chamadas subsequentes.
+    assert aggregator.collect_live_sessions() is a
+    assert aggregator.collect_sessions_since(0) is b


### PR DESCRIPTION
## Contexto

Issue [#27](https://github.com/mencoding/claude-dashboard/issues/27) foi aberto com a premissa de que `_refresh_session_list` "dobra I/O com `_refresh_now` no auto-refresh de 2s". Conforme detalhado em [comentário no issue](https://github.com/mencoding/claude-dashboard/issues/27#issuecomment-4331939394), **a premissa está errada**: `_refresh_session_list` não entra no auto-refresh recorrente (apenas `_refresh_now` está em `set_interval`, ver `tui.py:156`).

## Causa real

Existe redundância, mas em outro lugar:

1. **`on_mount` faz 4 collects sem compartilhar trabalho** (`tui.py:151-154`):
   - `_refresh_now` → `collect_live_sessions()`
   - `_refresh_today` → `collect_sessions_since(today_start)`
   - `_refresh_tools` → `collect_tool_usage_since(...)`
   - `_refresh_session_list` → `collect_live_sessions()` + `collect_sessions_since(today_start)`

   Resultado: `collect_live_sessions` roda 2x e `collect_sessions_since(today_start)` roda 2x no mount, em sequência imediata, com inputs idênticos.

2. **`r` na Session logo após tick do `_refresh_now`** re-faz `collect_live_sessions()` que estava quente 0–2s atrás.

## Solução

Decorator `_ttl_cached` (helper local, sem dependência externa) com TTL de **1.0s**, aplicado em:

- `collect_live_sessions()`
- `collect_sessions_since(since_ms)`

`collect_tool_usage_since` ficou fora — chamada única no mount, sem redundância.

### Justificativa do TTL=1s

- Auto-refresh do `_refresh_now` ocorre a cada 2s (`NOW_REFRESH_SEC`).
- TTL=1s garante que o próximo tick **sempre** invalida (margem 2x).
- Usuário nunca vê dado >1s antigo.

## Decisões não-óbvias

| Decisão | Justificativa |
|---|---|
| **Mutabilidade do retorno** | Retorna a lista interna do cache (não cópia). Call sites atuais só leem (sort para display, iteração para somar). Documentado no docstring que chamadores não devem mutar; futuros usos que precisem mutar fazem `.copy()` explícito. |
| **Sem `copy.deepcopy`** | Overhead caro para ganho ilusório. |
| **Sem thread-lock** | TUI é single-thread (Textual usa event loop). |
| **Sem evicção por tamanho** | Chaves possíveis são poucas (nome da função x argumentos imutáveis pequenos). Memória cresce O(1) na prática. |
| **`cache_clear()` exposto** | Atributo no wrapper para testes e invalidação manual em casos excepcionais (ex: mudança de relógio do sistema). |
| **`conftest.py` autouse** | Limpa `_cache` entre testes para evitar contaminação cruzada (sem isso, mocks aplicados após uma chamada real veriam o resultado em cache). |

## Benchmark

Simulação do `on_mount` (4 collects em sequência) sobre transcripts reais:

```
== SEM TTL cache ==
  refresh_now             :     8.3 ms
  refresh_today           :    49.3 ms
  refresh_tools           :    45.5 ms
  refresh_session_list    :    59.7 ms
  TOTAL                   :   162.8 ms

== COM TTL cache ==
  refresh_now             :     7.8 ms
  refresh_today           :    50.9 ms
  refresh_tools           :    46.8 ms
  refresh_session_list    :     0.0 ms   ← cache hit em ambas as funções
  TOTAL                   :   105.5 ms

Speedup no on_mount: 1.54x  (economia: 57.3 ms)
```

O ganho concentra-se no `_refresh_session_list`, que cai de ~60ms para ~0ms (cache hit em `collect_live_sessions` e `collect_sessions_since`).

## Testes

`tests/test_aggregator_cache.py` (5 novos casos, todos passando):

1. Hit dentro do TTL retorna **mesmo objeto** (identidade `is`).
2. Miss após TTL expirado re-executa (mock de `time.monotonic` via `monkeypatch`, sem `sleep`).
3. Argumentos diferentes não compartilham cache.
4. `cache_clear()` força re-execução.
5. `collect_live_sessions` e `collect_sessions_since` têm chaves distintas.

## Validação

```
pytest:        209 passed in 8.86s   (204 + 5 novos)
ruff check .:  79 errors             (= baseline, sem débito novo)
```

Closes #27