### PR TITLE
feat(audit): empacota hook + subcomando setup-audit (issue #24 fase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,131 @@ O entrypoint de captura foi preservado por compatibilidade.
 Sem nenhuma das formas acima, o dashboard continua funcional — apenas
 omite a linha de rate limits no header. Graceful degradation.
 
+### Audit log de tool calls
+
+Desde **v0.13** o dashboard empacota um sistema de auditoria de toda
+chamada de tool do Claude Code (Bash, Read, Edit, Write, WebFetch,
+WebSearch, MCP, Agent, Skill). O hook `PostToolUse` com matcher `.*`
+escreve em **dois destinos**, cada um com um propósito distinto:
+
+| Destino | Conteúdo | Permissão | Sync Drive |
+|:---|:---|:---|:---:|
+| `/var/log/claude/tools.log` | **Completo** (cmd, path, url, query até 4 KB) | `syslog:adm 0640` | não |
+| `~/.claude/iris/audit/sessions.log` | **Metadata-only** (timestamp, session, tool, status, hash, bytes) | `menzani 0600` | sim |
+
+**Threat model.** A motivação foi um incidente de prompt injection
+(2026-04-27, repo `paperclipai/paperclip` via `WebFetch`) que plantou
+tags `<system-reminder>` falsificadas no conteúdo de uma página externa.
+Auditoria fora do controle do agente é a defesa de última camada: o
+forense local fica em `/var/log/claude/`, escrito pelo `rsyslog` (root),
+imune a adulteração pelo próprio Claude. O `sessions.log` em metadata-only
+é syncado para o Drive — timeline cross-device sem vazar `cmd`/`path`/`url`.
+Hook é **fail-silent** (exit 0 sempre) — perda de log preferível a quebra
+de fluxo da sessão.
+
+**Bootstrap em 3 comandos:**
+
+```bash
+pipx install ~/Desenvolvimento/claude-dashboard
+claude-dash setup-audit                    # parte user-mode + script root
+sudo bash /tmp/claude-audit-root-setup.sh  # rsyslog + logrotate + /var/log/claude/
+```
+
+`setup-audit` é idempotente. Detecta o estado e age só no delta:
+
+- `fresh`: nada instalado → bootstrap completo (cria `~/.claude/iris/audit/`,
+  configura logrotate user, habilita systemd user timer, wira o
+  `PostToolUse`, gera o script root).
+- `migrate`: setup antigo em `~/.claude/iris/hooks/audit-tool.sh` → apenas
+  re-wira `settings.json` para o entry point `claude-dash-audit-hook`.
+- `partial`: alguns componentes presentes → completa o que falta.
+- `installed`: tudo presente → no-op.
+
+Flags relevantes:
+
+```bash
+claude-dash setup-audit --dry-run     # simula tudo
+claude-dash setup-audit --print-sudo  # imprime o conteúdo dos scripts root
+claude-dash setup-audit --uninstall   # reverte user-mode (preserva sessions.log)
+```
+
+**O `audit-tool.sh` legado em `~/.claude/iris/hooks/` nunca é deletado
+automaticamente** — após validar a migração, remova manualmente.
+
+**Limitação conhecida — subagentes.** Quando uma sessão pai dispara
+`Agent(...)`, o hook captura **apenas a chamada inicial** (com
+`subagent_type`, `description`, `duration_ms`). As tool calls internas do
+subagent **não disparam `PostToolUse` no parent** e não aparecem no audit.
+Granularidade no nível "Agent foi spawnado para X, levou N ms" está OK;
+para saber comandos exatos, inspecionar o `transcript_path` do subagent
+diretamente.
+
+#### Receitas de consulta
+
+Premissa: usuário no grupo `adm` lê os dois arquivos sem `sudo`.
+
+**Tail vivo:**
+
+```bash
+tail -f ~/.claude/iris/audit/sessions.log     # metadata-only
+tail -f /var/log/claude/tools.log             # com cmd/path/url
+journalctl -t claude-audit -f                 # via journald
+```
+
+**Filtragem básica:**
+
+```bash
+SESSION="b531e7ac-b76b-4658-9e3f-940ea94e9cb6"
+grep "$SESSION" /var/log/claude/tools.log | tail -10
+grep 'tool="Bash"'    /var/log/claude/tools.log | tail -10
+grep 'tool="WebFetch"' /var/log/claude/tools.log
+grep 'status="error"' /var/log/claude/tools.log
+```
+
+**Janela temporal:**
+
+```bash
+# Última hora
+awk -v t="$(date -d '1 hour ago' -Iseconds)" '$0 > t' /var/log/claude/tools.log
+# Hoje a partir das 14h
+grep "^$(date +%Y-%m-%d)T1[4-9]" /var/log/claude/tools.log
+```
+
+**Estatísticas:**
+
+```bash
+# Top tools
+grep -oE 'tool="[^"]*"' ~/.claude/iris/audit/sessions.log | sort | uniq -c | sort -rn
+# Top sessões
+grep -oE 'session="[^"]*"' ~/.claude/iris/audit/sessions.log | sort | uniq -c | sort -rn | head -10
+# Sessões com erros
+grep 'status="error"' ~/.claude/iris/audit/sessions.log \
+  | grep -oE 'session="[^"]*"' | sort | uniq -c
+```
+
+**Histórico (arquivos rotacionados):**
+
+```bash
+# Sistema (root-protected, 26 weeks comprimido)
+ls /var/log/claude/
+zgrep "session=\"$SESSION\"" /var/log/claude/tools.log-*.gz
+# User-mode (metadata, syncado pro Drive)
+ls ~/.claude/iris/audit/archive/
+zgrep "tool=\"WebFetch\"" ~/.claude/iris/audit/archive/sessions-*.gz
+```
+
+**JSON via journald (parsing programático):**
+
+```bash
+journalctl -t claude-audit -o json --since "1 hour ago" | jq .
+```
+
+Retenção: 26 semanas (6 meses), gzip via `logrotate` sistema (cron diário)
++ `systemd --user` timer semanal (segunda 03:30 + jitter 15 min).
+
+A aba TUI dedicada (`Audit`) com filtros e tail real-time fica para a
+fase 2 (issue derivada do #24).
+
 ### MCP server — canal para agentes
 
 A partir da v0.7, um servidor MCP expõe o estado do Claude Code como
@@ -195,8 +320,14 @@ sem reinstalar.
 
 ## Status
 
-**v0.11.x** — projeto funcionalmente maduro para uso diário.
-Entregas principais por versão:
+**v0.13** (em andamento, branch `feat/audit-phase1`) — empacota o hook
+de auditoria de tool calls (`claude-dash-audit-hook`) e o subcomando
+idempotente `claude-dash setup-audit`. Aba TUI dedicada fica para fase 2.
+
+**v0.12** — flag `--version`, exposição de `session_name` (`/rename`)
+em MCP tools e TUI.
+
+Entregas principais anteriores:
 
 - **v0.11.3** — detecção explícita de `statusLine` ausente em
   `~/.claude/settings.json` (robustez contra sync cross-device que

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ claude-dash = "claude_dash.cli:main"
 claude-dash-mcp = "claude_dash.mcp_server:main"
 claude-dash-statusline = "claude_dash.statusline:main"
 claude-dash-rate-limit-capture = "claude_dash.rate_limit_capture:main"
+claude-dash-audit-hook = "claude_dash.audit.hook:main"
 
 [project.urls]
 Homepage = "https://github.com/mencoding/claude-dashboard"
@@ -46,6 +47,9 @@ Issues = "https://github.com/mencoding/claude-dashboard/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"claude_dash.audit.templates" = ["*.conf", "*.service", "*.timer", "logrotate-system-claude-audit"]
 
 [tool.ruff]
 line-length = 100

--- a/src/claude_dash/audit/__init__.py
+++ b/src/claude_dash/audit/__init__.py
@@ -1,0 +1,17 @@
+"""Audit log de tool calls do Claude Code.
+
+Pacote responsavel por:
+- hook.py: entry point ``claude-dash-audit-hook`` que substitui o bash legado
+  ``~/.claude/iris/hooks/audit-tool.sh``. Le payload PostToolUse via stdin e
+  emite linha syslog RFC 5424 em dois destinos (logger -> rsyslog e append
+  direto em ~/.claude/iris/audit/sessions.log).
+- setup.py: subcomando ``claude-dash setup-audit`` idempotente que detecta
+  o estado do bootstrap (fresh / migrate / partial / installed) e age so
+  no delta. Parte root e isolada num script gerado em /tmp para o usuario
+  rodar manualmente com sudo.
+- templates/: configuracoes-modelo (rsyslog, logrotate, systemd) lidas via
+  importlib.resources.
+
+Fase 1 do issue #24 — apenas captura/persistencia. A aba "Audit" da TUI
+fica para fase 2 (issue derivada).
+"""

--- a/src/claude_dash/audit/hook.py
+++ b/src/claude_dash/audit/hook.py
@@ -1,0 +1,180 @@
+"""Hook PostToolUse: registra cada tool call do Claude Code.
+
+Entry point ``claude-dash-audit-hook``. Substitui 1:1 o bash legado
+``~/.claude/iris/hooks/audit-tool.sh``. A saida emitida (linha syslog RFC 5424
+no logger e linha de metadata no LOCAL_LOG) e **byte-identica** a do bash
+para o mesmo payload — mudar formato exige mudar o teste de equivalencia.
+
+Fail-silent: qualquer excecao -> ``sys.exit(0)``. Critical: hook NUNCA pode
+quebrar a sessao Claude. Trade-off consciente — prefere-se perder um log a
+travar o fluxo do usuario.
+
+Variaveis de ambiente reconhecidas:
+
+- ``CLAUDE_AUDIT_LOCAL_LOG``: override do path do sessions.log (default:
+  ``~/.claude/iris/audit/sessions.log``).
+- ``CLAUDE_PID``: PID logico da sessao Claude. Default: ``os.getppid()``.
+- ``HOSTNAME``: ignorado; usa ``socket.gethostname().split('.')[0]`` para
+  bater com ``hostname -s`` do bash.
+"""
+from __future__ import annotations
+
+import contextlib
+import datetime
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+MAX_INPUT = 4096
+
+
+def _local_log_path() -> str:
+    override = os.environ.get("CLAUDE_AUDIT_LOCAL_LOG")
+    if override:
+        return override
+    return str(Path.home() / ".claude" / "iris" / "audit" / "sessions.log")
+
+
+def _hostname_short() -> str:
+    # Equivalente a `hostname -s 2>/dev/null || hostname` do bash.
+    try:
+        return socket.gethostname().split(".")[0]
+    except Exception:
+        return "localhost"
+
+
+def _pid() -> str:
+    val = os.environ.get("CLAUDE_PID")
+    if val:
+        return val
+    # Sem CLAUDE_PID -> PPID. No bash: ${CLAUDE_PID:-$PPID}.
+    return str(os.getppid())
+
+
+def _summarize(t_name: str, t_input: dict) -> str:
+    """Resumo legivel por tipo de tool. Mantem ordem do bash legado."""
+    if t_name == "Bash":
+        return f'cmd={t_input.get("command", "")!r}'
+    if t_name in ("Read", "Edit", "Write"):
+        return f'path={t_input.get("file_path", "")!r}'
+    if t_name == "WebFetch":
+        return f'url={t_input.get("url", "")!r}'
+    if t_name == "WebSearch":
+        return f'query={t_input.get("query", "")!r}'
+    if t_name == "Skill":
+        return f'skill={t_input.get("skill", "")!r}'
+    if t_name == "Agent":
+        return (
+            f'subagent={t_input.get("subagent_type", "")!r} '
+            f'desc={t_input.get("description", "")!r}'
+        )
+    return ""
+
+
+def _build_messages(payload: dict) -> tuple[str, str]:
+    """Monta as duas mensagens (full + meta-only) a partir do payload.
+
+    Retorna ``(full_msg, meta_msg)`` — meta_msg ja inclui o ``\\n`` final
+    para append direto no LOCAL_LOG. full_msg vai como argumento do
+    ``logger`` (sem trailing newline; logger adiciona).
+    """
+    session_id = payload.get("session_id", "")
+    tool_name = payload.get("tool_name", "?")
+    tool_input = payload.get("tool_input", {}) or {}
+    tool_resp = payload.get("tool_response", {}) or {}
+    cwd = payload.get("cwd", "")
+    tool_use_id = payload.get("tool_use_id", "")
+    duration_ms = payload.get("duration_ms", 0)
+    perm_mode = payload.get("permission_mode", "")
+
+    input_serialized = json.dumps(tool_input, sort_keys=True, ensure_ascii=False)
+    input_bytes = len(input_serialized.encode("utf-8"))
+    input_sha = hashlib.sha256(input_serialized.encode("utf-8")).hexdigest()[:16]
+
+    status = "success"
+    if isinstance(tool_resp, dict) and (tool_resp.get("is_error") or tool_resp.get("error")):
+        status = "error"
+
+    try:
+        output_bytes = len(json.dumps(tool_resp, ensure_ascii=False).encode("utf-8"))
+    except Exception:
+        output_bytes = 0
+
+    summary = _summarize(tool_name, tool_input)
+    if len(summary.encode("utf-8")) > MAX_INPUT:
+        summary = summary[:MAX_INPUT] + "...[truncated]"
+
+    ts = datetime.datetime.now().astimezone().isoformat(timespec="milliseconds")
+    hostname = _hostname_short()
+    pid = _pid()
+
+    sd_parts = [
+        f'session="{session_id}"',
+        f'tool="{tool_name}"',
+        f'tool_use_id="{tool_use_id}"',
+        f'status="{status}"',
+        f'duration_ms="{duration_ms}"',
+        f'perm_mode="{perm_mode}"',
+        f'input_sha="{input_sha}"',
+        f'input_bytes="{input_bytes}"',
+        f'output_bytes="{output_bytes}"',
+    ]
+    if tool_name == "Agent":
+        subagent_type = (tool_input.get("subagent_type") or "").replace('"', "'")
+        sd_parts.append(f'subagent_type="{subagent_type}"')
+
+    sd = "[audit@iris " + " ".join(sd_parts) + "]"
+
+    full_msg = (
+        f"<134>1 {ts} {hostname} claude-code {pid} TOOLCALL {sd} "
+        f"cwd={cwd!r} {summary}"
+    )
+    meta_msg = f"<134>1 {ts} {hostname} claude-code {pid} TOOLCALL {sd}\n"
+    return full_msg, meta_msg
+
+
+def _emit_logger(full_msg: str) -> None:
+    """Despacha pro syslog via /usr/bin/logger. Fail-silent."""
+    with contextlib.suppress(Exception):
+        subprocess.run(
+            ["logger", "-t", "claude-audit", "-p", "local0.info", "--", full_msg],
+            timeout=2,
+            check=False,
+        )
+
+
+def _append_local(meta_msg: str, local_log: str) -> None:
+    """Append direto no LOCAL_LOG. Fail-silent."""
+    with contextlib.suppress(Exception), open(local_log, "a", encoding="utf-8") as f:
+        f.write(meta_msg)
+
+
+def main() -> int:
+    """Entry point. Le stdin (JSON), emite as duas mensagens, sai 0."""
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return 0
+    if not raw:
+        return 0
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return 0
+
+    try:
+        full_msg, meta_msg = _build_messages(payload)
+    except Exception:
+        return 0
+
+    _emit_logger(full_msg)
+    _append_local(meta_msg, _local_log_path())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/claude_dash/audit/setup.py
+++ b/src/claude_dash/audit/setup.py
@@ -1,0 +1,586 @@
+"""Subcomando ``claude-dash setup-audit``.
+
+Idempotente: detecta o estado atual e age so no delta. Os efeitos sao
+divididos em duas camadas:
+
+- **User-mode**: tudo que vive em ``~/.claude/`` e ``~/.config/`` —
+  diretorios, sessions.log, logrotate user, systemd user timer e re-wire
+  do ``settings.json``. Executado direto pelo subcomando (com ``--dry-run``
+  apenas simula).
+- **Root-mode**: tudo que exige ``sudo`` (criar ``/var/log/claude/``,
+  escrever em ``/etc/rsyslog.d/`` e ``/etc/logrotate.d/``, restart do
+  rsyslog). Materializado num script idempotente em
+  ``/tmp/claude-audit-root-setup.sh``; o usuario roda manualmente com
+  ``sudo bash``.
+
+Modos detectados:
+
+- ``fresh``: nada instalado.
+- ``migrate``: ``settings.json`` ainda referencia
+  ``~/.claude/iris/hooks/audit-tool.sh`` -> apenas re-wira para
+  ``claude-dash-audit-hook``. Nao toca em rsyslog/logrotate/timer.
+- ``partial``: alguns componentes ja presentes -> completa o que falta.
+- ``installed``: tudo presente e wired para o entry point novo -> no-op.
+
+NUNCA deleta ``~/.claude/iris/hooks/audit-tool.sh`` automaticamente —
+imprime aviso pedindo remocao manual apos validacao.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from importlib import resources
+from pathlib import Path
+
+# Paths user-mode -------------------------------------------------------------
+SETTINGS_JSON = Path.home() / ".claude" / "settings.json"
+LEGACY_HOOK = Path.home() / ".claude" / "iris" / "hooks" / "audit-tool.sh"
+LOCAL_LOG_DEFAULT = Path.home() / ".claude" / "iris" / "audit" / "sessions.log"
+ARCHIVE_DIR_DEFAULT = Path.home() / ".claude" / "iris" / "audit" / "archive"
+LOGROTATE_USER_CONF = Path.home() / ".config" / "logrotate" / "claude-audit.conf"
+SYSTEMD_USER_DIR = Path.home() / ".config" / "systemd" / "user"
+SYSTEMD_SERVICE = SYSTEMD_USER_DIR / "claude-audit-rotate.service"
+SYSTEMD_TIMER = SYSTEMD_USER_DIR / "claude-audit-rotate.timer"
+
+# Paths root-mode -------------------------------------------------------------
+RSYSLOG_CONF = Path("/etc/rsyslog.d/30-claude-audit.conf")
+LOGROTATE_SYS_CONF = Path("/etc/logrotate.d/claude-audit")
+VAR_LOG_DIR = Path("/var/log/claude")
+VAR_LOG_FILE = Path("/var/log/claude/tools.log")
+
+# Comando alvo do PostToolUse (entry point novo)
+NEW_HOOK_CMD = "claude-dash-audit-hook"
+LEGACY_HOOK_CMD_FRAGMENT = "audit-tool.sh"
+
+# Path do script root gerado
+ROOT_SETUP_SCRIPT = Path("/tmp/claude-audit-root-setup.sh")
+ROOT_UNINSTALL_SCRIPT = Path("/tmp/claude-audit-root-uninstall.sh")
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+def _read_template(name: str) -> str:
+    """Le template empacotado em ``claude_dash.audit.templates``."""
+    return resources.files("claude_dash.audit.templates").joinpath(name).read_text(
+        encoding="utf-8"
+    )
+
+
+def _render_logrotate_user(local_log: Path, archive_dir: Path, user: str) -> str:
+    tpl = _read_template("logrotate-user-claude-audit.conf")
+    return (
+        tpl.replace("__LOCAL_LOG__", str(local_log))
+        .replace("__ARCHIVE_DIR__", str(archive_dir))
+        .replace("__USER__", user)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detector de estado
+# ---------------------------------------------------------------------------
+
+@dataclass
+class State:
+    settings_present: bool = False
+    posttooluse_entries: list[dict] = field(default_factory=list)
+    has_legacy_wire: bool = False
+    has_new_wire: bool = False
+    legacy_hook_file_exists: bool = False
+
+    local_log_exists: bool = False
+    archive_dir_exists: bool = False
+    logrotate_user_exists: bool = False
+    systemd_service_exists: bool = False
+    systemd_timer_exists: bool = False
+    timer_active: bool = False
+
+    rsyslog_conf_exists: bool = False
+    logrotate_sys_exists: bool = False
+    var_log_dir_exists: bool = False
+    var_log_file_exists: bool = False
+
+    def mode(self) -> str:
+        """fresh | migrate | partial | installed."""
+        any_user = (
+            self.local_log_exists
+            or self.logrotate_user_exists
+            or self.systemd_timer_exists
+            or self.has_new_wire
+        )
+        any_root = (
+            self.rsyslog_conf_exists
+            or self.logrotate_sys_exists
+            or self.var_log_dir_exists
+        )
+        if self.has_legacy_wire and not self.has_new_wire:
+            return "migrate"
+        all_user = (
+            self.local_log_exists
+            and self.logrotate_user_exists
+            and self.systemd_timer_exists
+            and self.has_new_wire
+        )
+        all_root = (
+            self.rsyslog_conf_exists
+            and self.logrotate_sys_exists
+            and self.var_log_dir_exists
+        )
+        if all_user and all_root:
+            return "installed"
+        if not any_user and not any_root:
+            return "fresh"
+        return "partial"
+
+
+def _load_settings() -> dict:
+    if not SETTINGS_JSON.is_file():
+        return {}
+    try:
+        return json.loads(SETTINGS_JSON.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _detect_state() -> State:
+    s = State()
+    settings = _load_settings()
+    s.settings_present = bool(settings)
+
+    # PostToolUse
+    hooks = (settings.get("hooks") or {}).get("PostToolUse") or []
+    for entry in hooks:
+        for h in entry.get("hooks", []) or []:
+            cmd = h.get("command", "") or ""
+            s.posttooluse_entries.append({"matcher": entry.get("matcher", ""), "command": cmd})
+            if LEGACY_HOOK_CMD_FRAGMENT in cmd:
+                s.has_legacy_wire = True
+            if NEW_HOOK_CMD in cmd:
+                s.has_new_wire = True
+
+    s.legacy_hook_file_exists = LEGACY_HOOK.is_file()
+
+    # User-mode artefatos
+    s.local_log_exists = LOCAL_LOG_DEFAULT.is_file()
+    s.archive_dir_exists = ARCHIVE_DIR_DEFAULT.is_dir()
+    s.logrotate_user_exists = LOGROTATE_USER_CONF.is_file()
+    s.systemd_service_exists = SYSTEMD_SERVICE.is_file()
+    s.systemd_timer_exists = SYSTEMD_TIMER.is_file()
+    if s.systemd_timer_exists:
+        try:
+            r = subprocess.run(
+                ["systemctl", "--user", "is-active", "claude-audit-rotate.timer"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            s.timer_active = r.stdout.strip() == "active"
+        except Exception:
+            s.timer_active = False
+
+    # Root-mode artefatos (legiveis sem sudo)
+    s.rsyslog_conf_exists = RSYSLOG_CONF.is_file()
+    s.logrotate_sys_exists = LOGROTATE_SYS_CONF.is_file()
+    s.var_log_dir_exists = VAR_LOG_DIR.is_dir()
+    s.var_log_file_exists = VAR_LOG_FILE.is_file()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Acoes user-mode
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Plan:
+    actions: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _action(plan: Plan, msg: str, dry_run: bool, fn) -> None:
+    plan.actions.append(("[dry-run] " if dry_run else "") + msg)
+    if not dry_run:
+        fn()
+
+
+def _ensure_user_artifacts(plan: Plan, dry_run: bool) -> None:
+    user = os.environ.get("USER") or Path.home().name
+    archive = ARCHIVE_DIR_DEFAULT
+    local_log = LOCAL_LOG_DEFAULT
+
+    if not archive.is_dir():
+        def _mk_archive() -> None:
+            archive.mkdir(parents=True, exist_ok=True)
+            os.chmod(archive.parent, 0o700)
+            os.chmod(archive, 0o700)
+        _action(plan, f"mkdir -p {archive} (mode 0700)", dry_run, _mk_archive)
+
+    if not local_log.is_file():
+        def _create_log() -> None:
+            local_log.parent.mkdir(parents=True, exist_ok=True)
+            local_log.touch()
+            os.chmod(local_log, 0o600)
+        _action(plan, f"touch {local_log} (mode 0600)", dry_run, _create_log)
+
+    if not LOGROTATE_USER_CONF.is_file():
+        rendered = _render_logrotate_user(local_log, archive, user)
+        def _write_logrotate() -> None:
+            LOGROTATE_USER_CONF.parent.mkdir(parents=True, exist_ok=True)
+            LOGROTATE_USER_CONF.write_text(rendered, encoding="utf-8")
+        _action(plan, f"escrever {LOGROTATE_USER_CONF}", dry_run, _write_logrotate)
+
+    if not SYSTEMD_SERVICE.is_file():
+        content = _read_template("systemd-claude-audit-rotate.service")
+        def _write_svc() -> None:
+            SYSTEMD_USER_DIR.mkdir(parents=True, exist_ok=True)
+            SYSTEMD_SERVICE.write_text(content, encoding="utf-8")
+        _action(plan, f"escrever {SYSTEMD_SERVICE}", dry_run, _write_svc)
+
+    if not SYSTEMD_TIMER.is_file():
+        content = _read_template("systemd-claude-audit-rotate.timer")
+        def _write_tmr() -> None:
+            SYSTEMD_USER_DIR.mkdir(parents=True, exist_ok=True)
+            SYSTEMD_TIMER.write_text(content, encoding="utf-8")
+        _action(plan, f"escrever {SYSTEMD_TIMER}", dry_run, _write_tmr)
+
+
+def _enable_timer(plan: Plan, dry_run: bool) -> None:
+    def _do() -> None:
+        subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, timeout=10)
+        subprocess.run(
+            ["systemctl", "--user", "enable", "--now", "claude-audit-rotate.timer"],
+            check=False, timeout=10,
+        )
+    _action(plan, "systemctl --user daemon-reload && enable --now claude-audit-rotate.timer",
+            dry_run, _do)
+
+
+def _backup_settings() -> Path | None:
+    if not SETTINGS_JSON.is_file():
+        return None
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    bak = SETTINGS_JSON.with_suffix(f".json.bak.{stamp}")
+    shutil.copy2(SETTINGS_JSON, bak)
+    return bak
+
+
+def _wire_settings(plan: Plan, dry_run: bool, mode: str) -> None:
+    """Re-wira settings.json.
+
+    Em ``migrate``: substitui o command da entry com ``audit-tool.sh`` por
+    ``claude-dash-audit-hook``, preservando matcher e demais hooks.
+    Em ``fresh``/``partial``: garante que existe uma entry PostToolUse
+    matcher ``.*`` apontando para ``claude-dash-audit-hook``, sem mexer
+    nas outras.
+    """
+    settings = _load_settings()
+    if not isinstance(settings, dict):
+        plan.warnings.append("settings.json invalido; pulando wire")
+        return
+
+    hooks = settings.setdefault("hooks", {})
+    pt = hooks.setdefault("PostToolUse", [])
+
+    changed = False
+    found_new = False
+
+    for entry in pt:
+        for h in entry.get("hooks", []) or []:
+            cmd = h.get("command", "") or ""
+            if NEW_HOOK_CMD in cmd:
+                found_new = True
+            if LEGACY_HOOK_CMD_FRAGMENT in cmd and NEW_HOOK_CMD not in cmd:
+                h["command"] = NEW_HOOK_CMD
+                changed = True
+
+    if not found_new and not changed:
+        # Fresh ou partial sem wire: adiciona entry nova
+        pt.append({
+            "matcher": ".*",
+            "hooks": [{
+                "type": "command",
+                "command": NEW_HOOK_CMD,
+                "timeout": 5,
+            }],
+        })
+        changed = True
+
+    if not changed:
+        plan.actions.append("settings.json: ja wired para claude-dash-audit-hook")
+        return
+
+    bak_label = "settings.json.bak.<ts>"
+    prefix = "[dry-run] " if dry_run else ""
+    plan.actions.append(f"{prefix}re-wire {SETTINGS_JSON} (backup {bak_label})")
+    if dry_run:
+        return
+
+    bak = _backup_settings()
+    if bak:
+        plan.actions.append(f"  backup criado: {bak}")
+    SETTINGS_JSON.parent.mkdir(parents=True, exist_ok=True)
+    tmp = SETTINGS_JSON.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(settings, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(SETTINGS_JSON)
+
+
+# ---------------------------------------------------------------------------
+# Geracao do script root
+# ---------------------------------------------------------------------------
+
+def _root_setup_script() -> str:
+    rsyslog_body = _read_template("rsyslog-30-claude-audit.conf")
+    logrotate_body = _read_template("logrotate-system-claude-audit")
+    # Heredocs com EOF unico por bloco; sem expansao de variaveis
+    return f"""#!/usr/bin/env bash
+# Bootstrap root-mode do audit log do Claude Code.
+# Idempotente: rodar varias vezes produz o mesmo estado.
+# Gerado por `claude-dash setup-audit` em {datetime.now().isoformat(timespec='seconds')}.
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Este script precisa ser executado como root: sudo bash $0" >&2
+  exit 1
+fi
+
+# 1. /var/log/claude/ (owner syslog:adm, mode 0750)
+if [ ! -d /var/log/claude ]; then
+  mkdir -p /var/log/claude
+fi
+chown syslog:adm /var/log/claude
+chmod 0750 /var/log/claude
+
+if [ ! -f /var/log/claude/tools.log ]; then
+  touch /var/log/claude/tools.log
+fi
+chown syslog:adm /var/log/claude/tools.log
+chmod 0640 /var/log/claude/tools.log
+
+# 2. Regra rsyslog
+cat > /etc/rsyslog.d/30-claude-audit.conf <<'RSYSLOG_EOF'
+{rsyslog_body.rstrip()}
+RSYSLOG_EOF
+chmod 0644 /etc/rsyslog.d/30-claude-audit.conf
+
+# 3. Logrotate sistema
+cat > /etc/logrotate.d/claude-audit <<'LOGROTATE_EOF'
+{logrotate_body.rstrip()}
+LOGROTATE_EOF
+chmod 0644 /etc/logrotate.d/claude-audit
+
+# 4. Restart rsyslog para aplicar a nova regra
+systemctl restart rsyslog
+
+echo "OK — bootstrap root-mode concluido."
+echo "Smoke test:"
+echo "  logger -t claude-audit -p local0.info -- \\"bootstrap test \\$(date -Iseconds)\\""
+echo "  sudo tail -1 /var/log/claude/tools.log"
+"""
+
+
+def _root_uninstall_script() -> str:
+    stamp = datetime.now().isoformat(timespec="seconds")
+    return f"""#!/usr/bin/env bash
+# Uninstall root-mode do audit log do Claude Code.
+# Remove rsyslog rule e logrotate sistema; PRESERVA /var/log/claude/tools.log
+# (forense). Para apagar de vez: rm -rf /var/log/claude/ apos validar.
+# Gerado por `claude-dash setup-audit --uninstall` em {stamp}.
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Este script precisa ser executado como root: sudo bash $0" >&2
+  exit 1
+fi
+
+rm -f /etc/rsyslog.d/30-claude-audit.conf
+rm -f /etc/logrotate.d/claude-audit
+systemctl restart rsyslog
+
+echo "OK — rsyslog rule e logrotate sistema removidos."
+echo "/var/log/claude/ preservado. Para apagar:"
+echo "  sudo rm -rf /var/log/claude/"
+"""
+
+
+def _write_root_script(path: Path, body: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    path.write_text(body, encoding="utf-8")
+    os.chmod(path, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# Uninstall user-mode
+# ---------------------------------------------------------------------------
+
+def _uninstall_user(plan: Plan, dry_run: bool) -> None:
+    # Para o timer e desabilita
+    if SYSTEMD_TIMER.is_file():
+        def _stop() -> None:
+            subprocess.run(["systemctl", "--user", "disable", "--now", "claude-audit-rotate.timer"],
+                           check=False, timeout=10)
+        _action(plan, "systemctl --user disable --now claude-audit-rotate.timer", dry_run, _stop)
+
+    for p in (SYSTEMD_TIMER, SYSTEMD_SERVICE, LOGROTATE_USER_CONF):
+        if p.is_file():
+            _action(plan, f"rm {p}", dry_run, lambda p=p: p.unlink())
+
+    # Daemon-reload final
+    def _reload() -> None:
+        subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, timeout=10)
+    _action(plan, "systemctl --user daemon-reload", dry_run, _reload)
+
+    # Re-wire: remove a entry com claude-dash-audit-hook
+    settings = _load_settings()
+    if isinstance(settings, dict):
+        hooks = settings.get("hooks") or {}
+        pt = hooks.get("PostToolUse") or []
+        new_pt = []
+        changed = False
+        for entry in pt:
+            sub = []
+            for h in entry.get("hooks", []) or []:
+                if NEW_HOOK_CMD in (h.get("command", "") or ""):
+                    changed = True
+                    continue
+                sub.append(h)
+            if sub:
+                e2 = dict(entry)
+                e2["hooks"] = sub
+                new_pt.append(e2)
+            else:
+                changed = True  # entry vazia removida
+        if changed:
+            hooks["PostToolUse"] = new_pt
+            prefix = "[dry-run] " if dry_run else ""
+            plan.actions.append(f"{prefix}remover wire de {SETTINGS_JSON}")
+            if not dry_run:
+                bak = _backup_settings()
+                if bak:
+                    plan.actions.append(f"  backup criado: {bak}")
+                tmp = SETTINGS_JSON.with_suffix(".json.tmp")
+                payload = json.dumps(settings, indent=2, ensure_ascii=False) + "\n"
+                tmp.write_text(payload, encoding="utf-8")
+                tmp.replace(SETTINGS_JSON)
+
+    plan.warnings.append(f"sessions.log preservado em {LOCAL_LOG_DEFAULT} (nao apagado).")
+
+
+# ---------------------------------------------------------------------------
+# Pretty-print
+# ---------------------------------------------------------------------------
+
+def _print_state(state: State) -> None:
+    def yn(b: bool) -> str:
+        return "sim" if b else "nao"
+
+    legacy = "sim (audit-tool.sh)" if state.has_legacy_wire else "nao"
+    new_wire = "sim (claude-dash-audit-hook)" if state.has_new_wire else "nao"
+    timer = f"{yn(state.systemd_timer_exists)} (active={state.timer_active})"
+
+    print("Estado detectado:")
+    print(f"  modo                : {state.mode()}")
+    print(f"  settings.json       : {yn(state.settings_present)}")
+    print(f"  wire legado         : {legacy}")
+    print(f"  wire novo           : {new_wire}")
+    print(f"  hook legado em FS   : {yn(state.legacy_hook_file_exists)} ({LEGACY_HOOK})")
+    print(f"  sessions.log        : {yn(state.local_log_exists)}")
+    print(f"  archive dir         : {yn(state.archive_dir_exists)}")
+    print(f"  logrotate user      : {yn(state.logrotate_user_exists)}")
+    print(f"  systemd timer       : {timer}")
+    print(f"  rsyslog rule        : {yn(state.rsyslog_conf_exists)}")
+    print(f"  logrotate sistema   : {yn(state.logrotate_sys_exists)}")
+    print(f"  /var/log/claude/    : {yn(state.var_log_dir_exists)}")
+
+
+def _print_plan(plan: Plan) -> None:
+    if plan.actions:
+        print("\nAcoes:")
+        for a in plan.actions:
+            print(f"  - {a}")
+    if plan.warnings:
+        print("\nAvisos:")
+        for w in plan.warnings:
+            print(f"  ! {w}")
+
+
+# ---------------------------------------------------------------------------
+# Entry-point
+# ---------------------------------------------------------------------------
+
+def main_setup_audit(args: argparse.Namespace) -> int:
+    state = _detect_state()
+    mode = state.mode()
+
+    if args.print_sudo:
+        print(f"# === {ROOT_SETUP_SCRIPT} ===")
+        print(_root_setup_script())
+        print(f"# === {ROOT_UNINSTALL_SCRIPT} ===")
+        print(_root_uninstall_script())
+        return 0
+
+    _print_state(state)
+    plan = Plan()
+
+    if args.uninstall:
+        print("\nModo: UNINSTALL")
+        _uninstall_user(plan, args.dry_run)
+        body = _root_uninstall_script()
+        _write_root_script(ROOT_UNINSTALL_SCRIPT, body, args.dry_run)
+        prefix = "[dry-run] " if args.dry_run else ""
+        plan.actions.append(f"{prefix}escrever {ROOT_UNINSTALL_SCRIPT}")
+        _print_plan(plan)
+        if not args.dry_run:
+            print(f"\nProximo passo (root):  sudo bash {ROOT_UNINSTALL_SCRIPT}")
+        return 0
+
+    if mode == "installed":
+        print("\nTudo OK — nada a fazer.")
+        if state.legacy_hook_file_exists:
+            print(
+                f"\nAviso: arquivo legado ainda existe em {LEGACY_HOOK} — "
+                f"delete manualmente apos validar."
+            )
+        return 0
+
+    print(f"\nModo: {mode.upper()}")
+
+    if mode == "migrate":
+        # Apenas re-wira settings; nao toca em rsyslog/logrotate/timer.
+        _wire_settings(plan, args.dry_run, mode)
+        _print_plan(plan)
+        if state.legacy_hook_file_exists:
+            print(
+                f"\nAviso: arquivo legado ainda existe em {LEGACY_HOOK} — "
+                f"delete manualmente apos validar:"
+            )
+            print(f"  rm {LEGACY_HOOK}")
+        print("\nNota: rsyslog/logrotate/timer ja estavam configurados pelo setup antigo.")
+        print("      Nada a fazer no lado root para migracao.")
+        return 0
+
+    # fresh ou partial: bootstrap user-mode + script root
+    _ensure_user_artifacts(plan, args.dry_run)
+    if not state.timer_active:
+        _enable_timer(plan, args.dry_run)
+    _wire_settings(plan, args.dry_run, mode)
+
+    body = _root_setup_script()
+    _write_root_script(ROOT_SETUP_SCRIPT, body, args.dry_run)
+    plan.actions.append(("[dry-run] " if args.dry_run else "") + f"escrever {ROOT_SETUP_SCRIPT}")
+
+    _print_plan(plan)
+
+    needs_root = not (
+        state.rsyslog_conf_exists and state.logrotate_sys_exists and state.var_log_dir_exists
+    )
+    if needs_root and not args.dry_run:
+        print(f"\nProximo passo (root):  sudo bash {ROOT_SETUP_SCRIPT}")
+        print("Conteudo do script:    claude-dash setup-audit --print-sudo")
+    return 0

--- a/src/claude_dash/audit/templates/logrotate-system-claude-audit
+++ b/src/claude_dash/audit/templates/logrotate-system-claude-audit
@@ -1,0 +1,14 @@
+/var/log/claude/tools.log {
+    weekly
+    rotate 26
+    compress
+    delaycompress
+    missingok
+    notifempty
+    dateext
+    dateformat -%Y-W%V
+    create 0640 syslog adm
+    postrotate
+        /usr/lib/rsyslog/rsyslog-rotate 2>/dev/null || systemctl kill -s HUP rsyslog
+    endscript
+}

--- a/src/claude_dash/audit/templates/logrotate-user-claude-audit.conf
+++ b/src/claude_dash/audit/templates/logrotate-user-claude-audit.conf
@@ -1,0 +1,13 @@
+__LOCAL_LOG__ {
+    weekly
+    rotate 26
+    compress
+    delaycompress
+    missingok
+    notifempty
+    dateext
+    dateformat -%Y-W%V
+    olddir __ARCHIVE_DIR__
+    create 0600 __USER__ __USER__
+    copytruncate
+}

--- a/src/claude_dash/audit/templates/rsyslog-30-claude-audit.conf
+++ b/src/claude_dash/audit/templates/rsyslog-30-claude-audit.conf
@@ -1,0 +1,6 @@
+# Audit do Claude Code: roteia mensagens com tag "claude-audit"
+# para arquivo dedicado e interrompe o processamento (evita /var/log/syslog).
+if $programname == "claude-audit" or $syslogtag startswith "claude-audit" then {
+    action(type="omfile" file="/var/log/claude/tools.log" fileCreateMode="0640" fileOwner="root" fileGroup="adm")
+    stop
+}

--- a/src/claude_dash/audit/templates/systemd-claude-audit-rotate.service
+++ b/src/claude_dash/audit/templates/systemd-claude-audit-rotate.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Rotaciona sessions.log do audit do Claude Code (user-mode)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/logrotate --state %h/.config/logrotate/claude-audit.state %h/.config/logrotate/claude-audit.conf

--- a/src/claude_dash/audit/templates/systemd-claude-audit-rotate.timer
+++ b/src/claude_dash/audit/templates/systemd-claude-audit-rotate.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Disparo semanal do logrotate de audit do Claude Code
+
+[Timer]
+OnCalendar=Mon *-*-* 03:30:00
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/src/claude_dash/cli.py
+++ b/src/claude_dash/cli.py
@@ -39,6 +39,29 @@ def build_parser() -> argparse.ArgumentParser:
              "(idempotente, preserva statusline anterior via wrap)",
     )
 
+    audit_p = subparsers.add_parser(
+        "setup-audit",
+        help="Instala/migra o audit log de tool calls do Claude Code "
+             "(hook PostToolUse + rsyslog + logrotate + systemd user timer). "
+             "Idempotente; parte root vai num script gerado em /tmp.",
+    )
+    audit_p.add_argument(
+        "--print-sudo",
+        action="store_true",
+        help="Apenas imprime o conteudo dos scripts root (setup + uninstall); nao toca em nada.",
+    )
+    audit_p.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="Reverte user-mode (timer, configs, wire) e gera script root de uninstall. "
+             "Preserva sessions.log.",
+    )
+    audit_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Simula todas as acoes sem escrever em disco nem invocar systemctl.",
+    )
+
     return parser
 
 
@@ -71,6 +94,10 @@ def main(argv: list[str] | None = None) -> int:
         from claude_dash.setup_status import main as run_setup
 
         return run_setup()
+    if args.command == "setup-audit":
+        from claude_dash.audit.setup import main_setup_audit
+
+        return main_setup_audit(args)
     return 2  # pragma: no cover
 
 

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -26,6 +26,8 @@ from textual.widgets import (
     TabPane,
 )
 
+from claude_dash import __version__
+
 
 class SessionListItem(ListItem):
     """ListItem que carrega o sessionId como atributo tipado.
@@ -107,6 +109,15 @@ class DashboardApp(App):
     #session-hint {
         margin: 0 0 1 0;
     }
+    /* Linha discreta abaixo do Footer com a versão do software. */
+    #version-line {
+        dock: bottom;
+        height: 1;
+        background: $boost;
+        color: $text-disabled;
+        text-align: right;
+        padding: 0 1;
+    }
     """
 
     BINDINGS = [
@@ -138,6 +149,7 @@ class DashboardApp(App):
                     yield ListView(id="session-list")
                     yield Static(id="session-detail")
         yield Footer()
+        yield Static(f"claude-dashboard v{__version__}", id="version-line")
 
     def on_mount(self) -> None:
         """Renderiza as 4 abas no mount e agenda auto-refresh só da Now.

--- a/tests/test_audit_hook.py
+++ b/tests/test_audit_hook.py
@@ -1,0 +1,379 @@
+"""Testes do hook ``claude_dash.audit.hook``.
+
+Cobre:
+- Resumo por tool (Bash/Read/Edit/Write/WebFetch/WebSearch/Skill/Agent).
+- STRUCTURED-DATA RFC 5424 com campos esperados; subagent_type so em Agent.
+- Status ``error`` quando ``tool_response.is_error``.
+- input_sha estavel (hash determinico).
+- LOCAL_LOG via env var.
+- Fail-silent quando logger ou disco falham.
+- Paridade byte-a-byte com ``~/.claude/iris/hooks/audit-tool.sh`` (apenas
+  se o script bash existir na maquina; caso contrario o teste e skipped).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from claude_dash.audit import hook as ah
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+BASH_PAYLOAD = {
+    "session_id": "00000000-1111-2222-3333-444444444444",
+    "tool_use_id": "toolu_abc123",
+    "tool_name": "Bash",
+    "tool_input": {"command": "ls -la"},
+    "tool_response": {"output": "total 0", "is_error": False},
+    "cwd": "/tmp",
+    "duration_ms": 42,
+    "permission_mode": "default",
+    "transcript_path": "/tmp/x.jsonl",
+    "hook_event_name": "PostToolUse",
+}
+
+READ_PAYLOAD = {
+    "session_id": "s1",
+    "tool_use_id": "t1",
+    "tool_name": "Read",
+    "tool_input": {"file_path": "/etc/hostname"},
+    "tool_response": {"output": "host"},
+    "cwd": "/tmp",
+    "duration_ms": 1,
+    "permission_mode": "default",
+}
+
+WEBFETCH_PAYLOAD = {
+    "session_id": "s2",
+    "tool_use_id": "t2",
+    "tool_name": "WebFetch",
+    "tool_input": {"url": "https://example.com/x", "prompt": "..."},
+    "tool_response": {"output": "..."},
+    "cwd": "/tmp",
+    "duration_ms": 100,
+    "permission_mode": "default",
+}
+
+AGENT_PAYLOAD = {
+    "session_id": "s3",
+    "tool_use_id": "t3",
+    "tool_name": "Agent",
+    "tool_input": {
+        "subagent_type": "general-purpose",
+        "description": "exemplo",
+        "prompt": "faca x",
+    },
+    "tool_response": {"output": "..."},
+    "cwd": "/tmp",
+    "duration_ms": 5000,
+    "permission_mode": "default",
+}
+
+ERROR_PAYLOAD = {
+    "session_id": "s4",
+    "tool_use_id": "t4",
+    "tool_name": "Bash",
+    "tool_input": {"command": "false"},
+    "tool_response": {"output": "", "is_error": True},
+    "cwd": "/tmp",
+    "duration_ms": 1,
+    "permission_mode": "default",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build(payload: dict) -> tuple[str, str]:
+    return ah._build_messages(payload)
+
+
+def _sd(full_msg: str) -> str:
+    m = re.search(r"\[audit@iris ([^\]]+)\]", full_msg)
+    assert m, f"sem SD em {full_msg!r}"
+    return m.group(1)
+
+
+def _kv(sd_inner: str) -> dict[str, str]:
+    return dict(re.findall(r'(\w+)="([^"]*)"', sd_inner))
+
+
+# ---------------------------------------------------------------------------
+# Resumos
+# ---------------------------------------------------------------------------
+
+def test_summarize_bash():
+    full, _ = _build(BASH_PAYLOAD)
+    assert "cmd='ls -la'" in full
+
+
+def test_summarize_read():
+    full, _ = _build(READ_PAYLOAD)
+    assert "path='/etc/hostname'" in full
+
+
+def test_summarize_edit():
+    p = dict(READ_PAYLOAD)
+    p["tool_name"] = "Edit"
+    full, _ = _build(p)
+    assert "path='/etc/hostname'" in full
+
+
+def test_summarize_write():
+    p = dict(READ_PAYLOAD)
+    p["tool_name"] = "Write"
+    full, _ = _build(p)
+    assert "path='/etc/hostname'" in full
+
+
+def test_summarize_webfetch():
+    full, _ = _build(WEBFETCH_PAYLOAD)
+    assert "url='https://example.com/x'" in full
+
+
+def test_summarize_websearch():
+    p = dict(WEBFETCH_PAYLOAD)
+    p["tool_name"] = "WebSearch"
+    p["tool_input"] = {"query": "ifsp licitacao"}
+    full, _ = _build(p)
+    assert "query='ifsp licitacao'" in full
+
+
+def test_summarize_skill():
+    p = dict(BASH_PAYLOAD)
+    p["tool_name"] = "Skill"
+    p["tool_input"] = {"skill": "wrapup"}
+    full, _ = _build(p)
+    assert "skill='wrapup'" in full
+
+
+def test_summarize_agent_subagent_in_sd():
+    full, _ = _build(AGENT_PAYLOAD)
+    sd = _kv(_sd(full))
+    assert sd["subagent_type"] == "general-purpose"
+    assert "subagent='general-purpose'" in full
+    assert "desc='exemplo'" in full
+
+
+def test_subagent_type_only_for_agent():
+    full, _ = _build(BASH_PAYLOAD)
+    sd = _kv(_sd(full))
+    assert "subagent_type" not in sd
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+def test_status_error_when_is_error():
+    full, _ = _build(ERROR_PAYLOAD)
+    sd = _kv(_sd(full))
+    assert sd["status"] == "error"
+
+
+def test_status_success_default():
+    full, _ = _build(BASH_PAYLOAD)
+    sd = _kv(_sd(full))
+    assert sd["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# input_sha
+# ---------------------------------------------------------------------------
+
+def test_input_sha_stable_and_16_hex():
+    sd1 = _kv(_sd(_build(BASH_PAYLOAD)[0]))
+    sd2 = _kv(_sd(_build(BASH_PAYLOAD)[0]))
+    assert sd1["input_sha"] == sd2["input_sha"]
+    assert re.fullmatch(r"[0-9a-f]{16}", sd1["input_sha"])
+
+
+def test_input_sha_changes_with_input():
+    p2 = dict(BASH_PAYLOAD)
+    p2["tool_input"] = {"command": "ls -la /"}
+    sd_a = _kv(_sd(_build(BASH_PAYLOAD)[0]))
+    sd_b = _kv(_sd(_build(p2)[0]))
+    assert sd_a["input_sha"] != sd_b["input_sha"]
+
+
+# ---------------------------------------------------------------------------
+# Estrutura geral RFC 5424
+# ---------------------------------------------------------------------------
+
+def test_full_msg_starts_with_pri_version():
+    full, _ = _build(BASH_PAYLOAD)
+    assert full.startswith("<134>1 ")
+
+
+def test_meta_msg_ends_with_newline_and_has_no_summary():
+    _full, meta = _build(BASH_PAYLOAD)
+    assert meta.endswith("\n")
+    # meta nao tem cwd/cmd, so o SD
+    assert "cmd=" not in meta
+    assert "cwd=" not in meta
+
+
+def test_hostname_short():
+    full, _ = _build(BASH_PAYLOAD)
+    expected = socket.gethostname().split(".")[0]
+    assert f" {expected} claude-code " in full
+
+
+# ---------------------------------------------------------------------------
+# Local log via env
+# ---------------------------------------------------------------------------
+
+def test_local_log_env_override(tmp_path, monkeypatch):
+    target = tmp_path / "custom.log"
+    monkeypatch.setenv("CLAUDE_AUDIT_LOCAL_LOG", str(target))
+    assert ah._local_log_path() == str(target)
+
+
+def test_local_log_default(monkeypatch):
+    monkeypatch.delenv("CLAUDE_AUDIT_LOCAL_LOG", raising=False)
+    assert ah._local_log_path().endswith("/.claude/iris/audit/sessions.log")
+
+
+# ---------------------------------------------------------------------------
+# main() — fluxo completo
+# ---------------------------------------------------------------------------
+
+def test_main_writes_local_log_and_invokes_logger(tmp_path, monkeypatch, capsys):
+    target = tmp_path / "sessions.log"
+    monkeypatch.setenv("CLAUDE_AUDIT_LOCAL_LOG", str(target))
+    monkeypatch.setattr(sys, "stdin", _StringStdin(json.dumps(BASH_PAYLOAD)))
+    calls = []
+
+    class _FakeResult:
+        returncode = 0
+
+    def fake_run(*args, **kwargs):
+        calls.append(args[0])
+        return _FakeResult()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = ah.main()
+    assert rc == 0
+    assert target.is_file()
+    contents = target.read_text()
+    assert contents.startswith("<134>1 ")
+    assert calls and calls[0][:3] == ["logger", "-t", "claude-audit"]
+
+
+def test_main_fail_silent_on_logger_failure(tmp_path, monkeypatch):
+    target = tmp_path / "sessions.log"
+    monkeypatch.setenv("CLAUDE_AUDIT_LOCAL_LOG", str(target))
+    monkeypatch.setattr(sys, "stdin", _StringStdin(json.dumps(BASH_PAYLOAD)))
+    monkeypatch.setattr(subprocess, "run", mock.Mock(side_effect=OSError("logger ausente")))
+    rc = ah.main()
+    assert rc == 0
+    # LOCAL_LOG ainda assim foi escrito
+    assert target.read_text().startswith("<134>1 ")
+
+
+def test_main_fail_silent_on_local_log_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_AUDIT_LOCAL_LOG", "/proc/1/this-cannot-be-written")
+    monkeypatch.setattr(sys, "stdin", _StringStdin(json.dumps(BASH_PAYLOAD)))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    rc = ah.main()
+    assert rc == 0
+
+
+def test_main_fail_silent_on_malformed_json(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", _StringStdin("not json"))
+    rc = ah.main()
+    assert rc == 0
+
+
+def test_main_fail_silent_on_empty_stdin(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", _StringStdin(""))
+    rc = ah.main()
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Paridade byte-a-byte com bash legado
+# ---------------------------------------------------------------------------
+
+LEGACY_BASH = Path.home() / ".claude" / "iris" / "hooks" / "audit-tool.sh"
+
+
+def _normalize_dynamic(line: str) -> str:
+    """Remove timestamp e PID variaveis; mantem tudo o resto."""
+    # Timestamp ISO com offset tz (precisao ms)
+    line = re.sub(
+        r"<134>1 \S+ ",
+        "<134>1 <TS> ",
+        line,
+    )
+    # PID apos hostname/claude-code
+    line = re.sub(
+        r"(claude-code) \d+ ",
+        r"\1 <PID> ",
+        line,
+    )
+    return line
+
+
+@pytest.mark.skipif(not LEGACY_BASH.is_file(), reason="audit-tool.sh legado nao presente")
+def test_byte_identical_to_legacy_bash(tmp_path, monkeypatch):
+    """Roda o bash legado e o hook novo com o mesmo payload e LOCAL_LOG;
+    compara as linhas escritas (apos normalizar timestamp e PID).
+    """
+    py_log = tmp_path / "py.log"
+
+    payload = json.dumps(BASH_PAYLOAD)
+
+    # Bash legado: env var AUDIT_LOCAL_LOG (interno) nao e exposta;
+    # ele monta o path via $HOME. Para isolar, simulamos $HOME.
+    fake_home = tmp_path / "home"
+    (fake_home / ".claude" / "iris" / "audit").mkdir(parents=True)
+    (fake_home / ".claude" / "iris" / "audit" / "sessions.log").touch()
+    bash_env = dict(os.environ, HOME=str(fake_home), CLAUDE_PID="99999")
+    # Mock logger -> /dev/null (capturamos so o LOCAL_LOG)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "logger").write_text("#!/usr/bin/env bash\nexit 0\n")
+    os.chmod(fake_bin / "logger", 0o755)
+    bash_env["PATH"] = f"{fake_bin}:{bash_env.get('PATH','')}"
+    subprocess.run(
+        ["bash", str(LEGACY_BASH)],
+        input=payload, text=True, env=bash_env, check=True, timeout=10,
+    )
+    bash_line = (fake_home / ".claude" / "iris" / "audit" / "sessions.log").read_text()
+
+    # Hook novo
+    monkeypatch.setenv("CLAUDE_AUDIT_LOCAL_LOG", str(py_log))
+    monkeypatch.setenv("CLAUDE_PID", "99999")
+    monkeypatch.setattr(sys, "stdin", _StringStdin(payload))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    rc = ah.main()
+    assert rc == 0
+    py_line = py_log.read_text()
+
+    assert _normalize_dynamic(bash_line) == _normalize_dynamic(py_line), (
+        f"\n--- BASH ---\n{bash_line}\n--- PY ---\n{py_line}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Util de fixture
+# ---------------------------------------------------------------------------
+
+class _StringStdin:
+    """Stdin fake; aceita read()."""
+    def __init__(self, text: str) -> None:
+        self._text = text
+    def read(self) -> str:
+        return self._text

--- a/tests/test_audit_setup.py
+++ b/tests/test_audit_setup.py
@@ -1,0 +1,352 @@
+"""Testes do subcomando ``claude-dash setup-audit``.
+
+Cobre:
+- Detector de estado (settings.json em tmp_path).
+- Modo migrate: settings.json com audit-tool.sh -> re-wire para entry novo.
+- Modo fresh: bootstrap completo cria todos os artefatos user-mode.
+- Dry-run nao escreve nada.
+- Uninstall remove user-mode mas preserva sessions.log.
+- Script root gerado e idempotente (contem mkdir -p, etc).
+- ``--print-sudo`` so imprime os scripts.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest import mock
+
+from claude_dash.audit import setup as au
+
+# ---------------------------------------------------------------------------
+# Helpers para isolar paths em tmp_path
+# ---------------------------------------------------------------------------
+
+def _patch_paths(monkeypatch, tmp_path: Path) -> dict[str, Path]:
+    home = tmp_path / "home"
+    (home / ".claude" / "iris" / "hooks").mkdir(parents=True)
+    (home / ".config").mkdir(parents=True)
+
+    settings = home / ".claude" / "settings.json"
+    legacy_hook = home / ".claude" / "iris" / "hooks" / "audit-tool.sh"
+    local_log = home / ".claude" / "iris" / "audit" / "sessions.log"
+    archive = home / ".claude" / "iris" / "audit" / "archive"
+    logrotate_user = home / ".config" / "logrotate" / "claude-audit.conf"
+    systemd_dir = home / ".config" / "systemd" / "user"
+    systemd_svc = systemd_dir / "claude-audit-rotate.service"
+    systemd_tmr = systemd_dir / "claude-audit-rotate.timer"
+
+    monkeypatch.setattr(au, "SETTINGS_JSON", settings)
+    monkeypatch.setattr(au, "LEGACY_HOOK", legacy_hook)
+    monkeypatch.setattr(au, "LOCAL_LOG_DEFAULT", local_log)
+    monkeypatch.setattr(au, "ARCHIVE_DIR_DEFAULT", archive)
+    monkeypatch.setattr(au, "LOGROTATE_USER_CONF", logrotate_user)
+    monkeypatch.setattr(au, "SYSTEMD_USER_DIR", systemd_dir)
+    monkeypatch.setattr(au, "SYSTEMD_SERVICE", systemd_svc)
+    monkeypatch.setattr(au, "SYSTEMD_TIMER", systemd_tmr)
+
+    # Root paths apontam para tmp para nao bater com o sistema real
+    rsyslog = tmp_path / "etc-rsyslog" / "30-claude-audit.conf"
+    logrotate_sys = tmp_path / "etc-logrotate" / "claude-audit"
+    var_log_dir = tmp_path / "var-log-claude"
+    var_log_file = var_log_dir / "tools.log"
+    monkeypatch.setattr(au, "RSYSLOG_CONF", rsyslog)
+    monkeypatch.setattr(au, "LOGROTATE_SYS_CONF", logrotate_sys)
+    monkeypatch.setattr(au, "VAR_LOG_DIR", var_log_dir)
+    monkeypatch.setattr(au, "VAR_LOG_FILE", var_log_file)
+
+    # Bloqueia subprocess.run (systemctl) por padrao
+    monkeypatch.setattr(au.subprocess, "run", mock.Mock(return_value=mock.Mock(stdout="inactive")))
+
+    return {
+        "home": home, "settings": settings, "legacy_hook": legacy_hook,
+        "local_log": local_log, "archive": archive, "logrotate_user": logrotate_user,
+        "systemd_svc": systemd_svc, "systemd_tmr": systemd_tmr,
+    }
+
+
+def _args(uninstall=False, print_sudo=False, dry_run=False) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="setup-audit",
+        uninstall=uninstall,
+        print_sudo=print_sudo,
+        dry_run=dry_run,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detector de estado
+# ---------------------------------------------------------------------------
+
+def test_state_fresh(tmp_path, monkeypatch):
+    _patch_paths(monkeypatch, tmp_path)
+    state = au._detect_state()
+    assert state.mode() == "fresh"
+    assert not state.has_legacy_wire
+    assert not state.has_new_wire
+
+
+def test_state_migrate_detects_legacy_wire(tmp_path, monkeypatch):
+    p = _patch_paths(monkeypatch, tmp_path)
+    settings = {
+        "hooks": {
+            "PostToolUse": [{
+                "matcher": ".*",
+                "hooks": [{"type": "command", "command": "~/.claude/iris/hooks/audit-tool.sh"}],
+            }]
+        }
+    }
+    p["settings"].write_text(json.dumps(settings))
+    p["legacy_hook"].write_text("#!/bin/bash\n")
+    state = au._detect_state()
+    assert state.mode() == "migrate"
+    assert state.has_legacy_wire and not state.has_new_wire
+    assert state.legacy_hook_file_exists
+
+
+def test_state_installed_when_all_present(tmp_path, monkeypatch):
+    p = _patch_paths(monkeypatch, tmp_path)
+    settings = {
+        "hooks": {"PostToolUse": [{
+            "matcher": ".*",
+            "hooks": [{"type": "command", "command": "claude-dash-audit-hook"}],
+        }]}
+    }
+    p["settings"].write_text(json.dumps(settings))
+    p["local_log"].parent.mkdir(parents=True, exist_ok=True)
+    p["local_log"].touch()
+    p["archive"].mkdir(parents=True)
+    p["logrotate_user"].parent.mkdir(parents=True, exist_ok=True)
+    p["logrotate_user"].write_text("x")
+    p["systemd_svc"].parent.mkdir(parents=True, exist_ok=True)
+    p["systemd_svc"].write_text("x")
+    p["systemd_tmr"].write_text("x")
+    au.RSYSLOG_CONF.parent.mkdir(parents=True, exist_ok=True)
+    au.RSYSLOG_CONF.write_text("x")
+    au.LOGROTATE_SYS_CONF.parent.mkdir(parents=True, exist_ok=True)
+    au.LOGROTATE_SYS_CONF.write_text("x")
+    au.VAR_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    state = au._detect_state()
+    assert state.mode() == "installed"
+
+
+def test_state_partial(tmp_path, monkeypatch):
+    p = _patch_paths(monkeypatch, tmp_path)
+    p["local_log"].parent.mkdir(parents=True, exist_ok=True)
+    p["local_log"].touch()
+    state = au._detect_state()
+    assert state.mode() == "partial"
+
+
+# ---------------------------------------------------------------------------
+# Modo migrate: re-wire
+# ---------------------------------------------------------------------------
+
+def test_migrate_replaces_command_in_settings(tmp_path, monkeypatch, capsys):
+    p = _patch_paths(monkeypatch, tmp_path)
+    initial = {
+        "hooks": {
+            "PostToolUse": [
+                {"matcher": "Write|Edit", "hooks": [{"type": "command",
+                  "command": "~/.claude/iris/hooks/memory-timestamp.sh"}]},
+                {"matcher": ".*", "hooks": [{"type": "command",
+                  "command": "~/.claude/iris/hooks/audit-tool.sh", "timeout": 5}]},
+            ]
+        },
+        "permissions": {"allow": []},
+    }
+    p["settings"].write_text(json.dumps(initial))
+    p["legacy_hook"].write_text("#!/bin/bash\n")
+
+    rc = au.main_setup_audit(_args())
+    assert rc == 0
+
+    final = json.loads(p["settings"].read_text())
+    pt = final["hooks"]["PostToolUse"]
+    cmds = [h["command"] for entry in pt for h in entry["hooks"]]
+    assert "claude-dash-audit-hook" in cmds
+    assert "~/.claude/iris/hooks/audit-tool.sh" not in cmds
+    # memory-timestamp preservado
+    assert "~/.claude/iris/hooks/memory-timestamp.sh" in cmds
+    # backup criado (.bak.<ts>)
+    baks = list(p["settings"].parent.glob("settings.json.bak.*"))
+    assert baks, "backup nao foi criado"
+
+    out = capsys.readouterr().out
+    assert "MIGRATE" in out
+    # Aviso pedindo remocao manual do legado
+    assert "delete manualmente" in out
+
+
+# ---------------------------------------------------------------------------
+# Modo fresh: bootstrap completo
+# ---------------------------------------------------------------------------
+
+def test_fresh_creates_user_artifacts_and_root_script(tmp_path, monkeypatch, capsys):
+    p = _patch_paths(monkeypatch, tmp_path)
+    monkeypatch.setattr(au, "ROOT_SETUP_SCRIPT", tmp_path / "root-setup.sh")
+
+    rc = au.main_setup_audit(_args())
+    assert rc == 0
+
+    assert p["local_log"].is_file()
+    assert p["archive"].is_dir()
+    assert p["logrotate_user"].is_file()
+    assert p["systemd_svc"].is_file()
+    assert p["systemd_tmr"].is_file()
+
+    settings = json.loads(p["settings"].read_text())
+    cmds = [
+        h["command"]
+        for entry in settings["hooks"]["PostToolUse"]
+        for h in entry["hooks"]
+    ]
+    assert "claude-dash-audit-hook" in cmds
+
+    root_script = (tmp_path / "root-setup.sh").read_text()
+    assert "mkdir -p /var/log/claude" in root_script
+    assert "chown syslog:adm /var/log/claude" in root_script
+    assert "/etc/rsyslog.d/30-claude-audit.conf" in root_script
+    assert "/etc/logrotate.d/claude-audit" in root_script
+    assert "systemctl restart rsyslog" in root_script
+
+    out = capsys.readouterr().out
+    assert "FRESH" in out
+    assert "sudo bash" in out
+
+
+# ---------------------------------------------------------------------------
+# Dry-run: nao escreve nada
+# ---------------------------------------------------------------------------
+
+def test_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
+    p = _patch_paths(monkeypatch, tmp_path)
+    monkeypatch.setattr(au, "ROOT_SETUP_SCRIPT", tmp_path / "root-setup.sh")
+    rc = au.main_setup_audit(_args(dry_run=True))
+    assert rc == 0
+    assert not p["local_log"].is_file()
+    assert not p["logrotate_user"].is_file()
+    assert not p["systemd_tmr"].is_file()
+    assert not p["settings"].is_file()
+    assert not (tmp_path / "root-setup.sh").is_file()
+    out = capsys.readouterr().out
+    assert "[dry-run]" in out
+
+
+# ---------------------------------------------------------------------------
+# --print-sudo
+# ---------------------------------------------------------------------------
+
+def test_print_sudo_emits_both_scripts(tmp_path, monkeypatch, capsys):
+    _patch_paths(monkeypatch, tmp_path)
+    rc = au.main_setup_audit(_args(print_sudo=True))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "claude-audit-root-setup.sh" in out
+    assert "claude-audit-root-uninstall.sh" in out
+    assert "mkdir -p /var/log/claude" in out
+    assert "rm -f /etc/rsyslog.d/30-claude-audit.conf" in out
+
+
+# ---------------------------------------------------------------------------
+# Uninstall preserva sessions.log
+# ---------------------------------------------------------------------------
+
+def test_uninstall_removes_user_mode_preserves_sessions_log(tmp_path, monkeypatch, capsys):
+    p = _patch_paths(monkeypatch, tmp_path)
+    monkeypatch.setattr(au, "ROOT_UNINSTALL_SCRIPT", tmp_path / "root-uninstall.sh")
+    # Pre-popula tudo
+    p["local_log"].parent.mkdir(parents=True, exist_ok=True)
+    p["local_log"].write_text("dado-importante\n")
+    p["logrotate_user"].parent.mkdir(parents=True, exist_ok=True)
+    p["logrotate_user"].write_text("x")
+    p["systemd_svc"].parent.mkdir(parents=True, exist_ok=True)
+    p["systemd_svc"].write_text("x")
+    p["systemd_tmr"].write_text("x")
+    settings = {"hooks": {"PostToolUse": [
+        {"matcher": ".*", "hooks": [{"type": "command", "command": "claude-dash-audit-hook"}]},
+        {"matcher": "Write|Edit", "hooks": [{"type": "command", "command": "other"}]},
+    ]}}
+    p["settings"].write_text(json.dumps(settings))
+
+    rc = au.main_setup_audit(_args(uninstall=True))
+    assert rc == 0
+
+    # User-mode removido
+    assert not p["logrotate_user"].is_file()
+    assert not p["systemd_svc"].is_file()
+    assert not p["systemd_tmr"].is_file()
+    # sessions.log preservado
+    assert p["local_log"].is_file()
+    assert p["local_log"].read_text() == "dado-importante\n"
+    # Wire removido, mas outras entries preservadas
+    final = json.loads(p["settings"].read_text())
+    cmds = [h["command"] for entry in final["hooks"]["PostToolUse"] for h in entry["hooks"]]
+    assert "claude-dash-audit-hook" not in cmds
+    assert "other" in cmds
+    # Script root de uninstall foi gerado
+    assert (tmp_path / "root-uninstall.sh").is_file()
+    out = capsys.readouterr().out
+    assert "UNINSTALL" in out
+
+
+# ---------------------------------------------------------------------------
+# Script root: idempotencia textual
+# ---------------------------------------------------------------------------
+
+def test_root_setup_script_is_idempotent_shape():
+    body = au._root_setup_script()
+    # Guards de existencia
+    assert "if [ ! -d /var/log/claude ]" in body
+    assert "if [ ! -f /var/log/claude/tools.log ]" in body
+    # set -euo pipefail e checagem de root
+    assert "set -euo pipefail" in body
+    assert 'id -u' in body
+    # Termina com echo OK
+    assert "OK" in body
+
+
+def test_root_uninstall_script_preserves_log():
+    body = au._root_uninstall_script()
+    assert "rm -f /etc/rsyslog.d/30-claude-audit.conf" in body
+    assert "rm -f /etc/logrotate.d/claude-audit" in body
+    # Nao apaga /var/log/claude automaticamente; so menciona como sugestao no echo
+    # (linhas executaveis nao devem conter rm -rf de /var/log/claude)
+    exec_lines = [
+        ln for ln in body.splitlines()
+        if ln.strip() and not ln.lstrip().startswith("#") and not ln.lstrip().startswith("echo")
+    ]
+    assert not any("rm -rf /var/log/claude" in ln for ln in exec_lines)
+    assert "preservado" in body
+
+
+# ---------------------------------------------------------------------------
+# Modo installed: no-op
+# ---------------------------------------------------------------------------
+
+def test_installed_is_noop(tmp_path, monkeypatch, capsys):
+    p = _patch_paths(monkeypatch, tmp_path)
+    settings = {"hooks": {"PostToolUse": [{
+        "matcher": ".*",
+        "hooks": [{"type": "command", "command": "claude-dash-audit-hook"}],
+    }]}}
+    p["settings"].write_text(json.dumps(settings))
+    p["local_log"].parent.mkdir(parents=True, exist_ok=True)
+    p["local_log"].touch()
+    p["archive"].mkdir(parents=True)
+    p["logrotate_user"].parent.mkdir(parents=True, exist_ok=True)
+    p["logrotate_user"].write_text("x")
+    p["systemd_svc"].parent.mkdir(parents=True, exist_ok=True)
+    p["systemd_svc"].write_text("x")
+    p["systemd_tmr"].write_text("x")
+    au.RSYSLOG_CONF.parent.mkdir(parents=True, exist_ok=True)
+    au.RSYSLOG_CONF.write_text("x")
+    au.LOGROTATE_SYS_CONF.parent.mkdir(parents=True, exist_ok=True)
+    au.LOGROTATE_SYS_CONF.write_text("x")
+    au.VAR_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    au.VAR_LOG_FILE.touch()
+
+    rc = au.main_setup_audit(_args())
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Tudo OK" in out


### PR DESCRIPTION
## Resumo

Fase 1 do issue #24: empacota o sistema de audit log de tool calls dentro do `claude-dashboard`. Hoje o sistema vive fora do dashboard (hooks bash em `~/.claude/iris/`); este PR migra a captura/persistencia para dentro do pacote, mantendo o formato de saida byte-identico para nao quebrar o que ja esta em producao.

A aba TUI dedicada (`Audit`) **NAO esta inclusa** — fica para a fase 2 (issue derivada apos merge desta). #24 permanece aberto ate la.

## O que entra

- **`claude-dash-audit-hook`** — entry point Python que substitui 1:1 o bash `~/.claude/iris/hooks/audit-tool.sh`. Saida byte-identica para o mesmo payload (validado por `test_byte_identical_to_legacy_bash`, que roda o bash original e compara as linhas escritas no LOCAL_LOG).
- **`claude-dash setup-audit`** — subcomando idempotente. Detecta o estado e age so no delta. 4 modos:
  - `fresh`: nada instalado -> bootstrap completo (user-mode + script root em `/tmp`).
  - `migrate`: settings.json ainda referencia `audit-tool.sh` -> apenas re-wira para `claude-dash-audit-hook`.
  - `partial`: completa o que falta.
  - `installed`: no-op.
- **`--dry-run`**, **`--print-sudo`**, **`--uninstall`** suportados.
- Templates (rsyslog, logrotate sistema/user, systemd service/timer) empacotados em `src/claude_dash/audit/templates/` e lidos via `importlib.resources`.
- Documentacao: secao "Audit log de tool calls" no README com threat model, bootstrap em 3 comandos, 4 modos, limitacao de subagents e receitas de consulta.

## Validacao no Predator

`claude-dash setup-audit --dry-run` no host com setup antigo ja em producao:

```
Estado detectado:
  modo                : migrate
  settings.json       : sim
  wire legado         : sim (audit-tool.sh)
  wire novo           : nao
  hook legado em FS   : sim (/home/menzani/.claude/iris/hooks/audit-tool.sh)
  sessions.log        : sim
  archive dir         : sim
  logrotate user      : sim
  systemd timer       : sim (active=True)
  rsyslog rule        : sim
  logrotate sistema   : sim
  /var/log/claude/    : sim

Modo: MIGRATE

Acoes:
  - [dry-run] re-wire /home/menzani/.claude/settings.json (backup settings.json.bak.<ts>)

Aviso: arquivo legado ainda existe em /home/menzani/.claude/iris/hooks/audit-tool.sh — delete manualmente apos validar:
  rm /home/menzani/.claude/iris/hooks/audit-tool.sh

Nota: rsyslog/logrotate/timer ja estavam configurados pelo setup antigo.
      Nada a fazer no lado root para migracao.
```

Detector identificou corretamente o cenario `migrate`, propos apenas re-wirar o `settings.json`, e nao toca em rsyslog/logrotate/timer — exatamente o comportamento esperado para nao perturbar o que ja funciona. O arquivo legado nunca e deletado automaticamente.

## Restricoes respeitadas

- Hook **fail-silent** (qualquer excecao -> `sys.exit(0)`). Sessao Claude jamais quebra por causa do audit.
- `~/.claude/iris/hooks/audit-tool.sh` **nunca** e deletado automaticamente — apenas avisa.
- Em modo `migrate`, **nao** mexe em rsyslog/logrotate/timer (ja configurados).
- Templates como arquivos, nao strings.
- Parte root SOMENTE via script gerado em `/tmp` — `setup-audit` jamais invoca `sudo`.

## Test plan

- [x] 36 testes novos (`test_audit_hook.py` + `test_audit_setup.py`); 240 testes totais, todos passando.
- [x] Paridade byte-a-byte com o bash legado validada (test rodando o bash original num payload conhecido e comparando).
- [x] `uvx ruff check .`: 79 erros antes, 79 erros depois (mesmo baseline do `main`; sem debito novo).
- [x] `setup-audit --dry-run` no Predator detecta `migrate` corretamente.
- [x] `setup-audit --print-sudo` imprime os scripts coerentes.
- [ ] Apos merge: rodar `claude-dash setup-audit` real no Predator, verificar que `settings.json` foi re-wirado para `claude-dash-audit-hook`, validar que tool calls continuam sendo gravadas em `/var/log/claude/tools.log` e `~/.claude/iris/audit/sessions.log`, e remover manualmente o `audit-tool.sh` legado.
- [ ] Apos validar producao: abrir issue derivada para fase 2 (aba `Audit` na TUI com tail real-time e filtros).

Closes parcialmente #24 — manter aberto ate fase 2 fechar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Adicional pós-PR (commit `ed91315`)

**TUI:** linha de versão dock-bottom abaixo do Footer (após `q Quit`).

- Lê `claude_dash.__version__` (importlib.metadata desde v0.12.0)
- Estilo discreto: cor `text-disabled`, alinhada à direita
- Mudança ortogonal ao audit, agrupada aqui dada a janela de release