### PR TITLE
release: v0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.12.0"
+version = "0.13.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bump minor de `0.12.0` → `0.13.0`.

## Includes

- **#29** — `perf(aggregator): TTL cache em collect_live_sessions e collect_sessions_since` (fecha #27, premissa do reviewer corrigida no comment do issue). `on_mount` 35% mais rápido (162ms → 105ms); `_refresh_session_list` cai de 60ms para ~0ms quando há tick recente do `_refresh_now`.
- **#30** — `feat(audit): empacota hook + subcomando setup-audit (issue #24 fase 1)`. Hook re-implementado como entry point Python `claude-dash-audit-hook` (paridade byte-a-byte com o bash legado validada por teste). Subcomando `claude-dash setup-audit` com modos `migrate`/`fresh`/`partial`/`installed` + `--print-sudo` + `--uninstall` + `--dry-run`. Geração de scripts root idempotentes em `/tmp/claude-audit-root-{setup,uninstall}.sh`. Templates como arquivos lidos via `importlib.resources`. Issue #24 fica aberta até Fase 2 (aba TUI 'Audit') ser concluída.
- **TUI:** linha de versão dock-bottom abaixo do Footer (commit `ed91315` parte do PR #30).

## Justificativa do bump minor

PR #30 adiciona:
- Novo entry point `claude-dash-audit-hook` (não breaking)
- Novo subcomando `claude-dash setup-audit` (não breaking)
- Nova seção no README

Por SemVer, adição de funcionalidade backward-compatible = minor bump.

## Pendências carregadas pra próximo ciclo

- **#24 fase 2** — aba 'Audit' na TUI (issue derivada a abrir após validação prod)
- Validação produção: rodar `claude-dash setup-audit` real no Predator (modo migrate), confirmar tool calls continuam sendo gravadas, deletar `~/.claude/iris/hooks/audit-tool.sh` legado

## Pós-merge

- Tag `v0.13.0` criada apontando para o merge commit
- Atualização local: `pipx reinstall claude-dashboard`