### PR TITLE
fix(tui): versão como SUB_TITLE no Header (Footer estava sendo escondido)

### DIFF
--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -109,15 +109,6 @@ class DashboardApp(App):
     #session-hint {
         margin: 0 0 1 0;
     }
-    /* Linha discreta abaixo do Footer com a versão do software. */
-    #version-line {
-        dock: bottom;
-        height: 1;
-        background: $boost;
-        color: $text-disabled;
-        text-align: right;
-        padding: 0 1;
-    }
     """
 
     BINDINGS = [
@@ -130,6 +121,7 @@ class DashboardApp(App):
     ]
 
     TITLE = "claude-dashboard"
+    SUB_TITLE = f"v{__version__}"
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -149,7 +141,6 @@ class DashboardApp(App):
                     yield ListView(id="session-list")
                     yield Static(id="session-detail")
         yield Footer()
-        yield Static(f"claude-dashboard v{__version__}", id="version-line")
 
     def on_mount(self) -> None:
         """Renderiza as 4 abas no mount e agenda auto-refresh só da Now.


### PR DESCRIPTION
## Problema

A abordagem do commit `ed91315` (linha de versão `dock: bottom` abaixo do Footer) **escondia o próprio Footer** — conflito de dock entre os dois widgets resultava em sobreposição do bottom slot. Léo reportou: "agora mostra somente a versão, sem mostrar os demais itens que tinha anteriormente".

## Fix

Substitui pela forma canônica do Textual: `SUB_TITLE` no `App`. O Header (já presente) renderiza `claude-dashboard — v0.13.0` no topo, sempre visível, sem tocar no Footer.

## Mudanças

- Removido bloco CSS `#version-line`
- Removido `yield Static(... id="version-line")` do `compose`
- Adicionado `SUB_TITLE = f"v{__version__}"` no `DashboardApp`

## Test plan

- [x] `pytest`: 245 passed
- [x] `ruff`: paridade com baseline (79)
- [ ] Validação visual pós-merge: `claude-dash` mostra `claude-dashboard — v0.13.0` no Header e Footer com as bindings (`1 Now  2 Today  ...  q Quit`) de volta

## Nota de release

Este fix entra em **v0.13.0** (sem bump de versão) — a tag `v0.13.0` apontará para o merge commit deste PR, garantindo que a release pública não tenha o bug.