### PR TITLE
release: v0.13.1 — Ctrl+C fecha direto sem popup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.13.0"
+version = "0.13.1"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -118,6 +118,10 @@ class DashboardApp(App):
         Binding("4", "show_tab('tab-session')", "Session"),
         Binding("r", "refresh_current", "Refresh"),
         Binding("q", "quit", "Quit"),
+        # Ctrl+C fecha direto (convenção de terminal). Sobrescreve o popup
+        # padrão do Textual que sugere Ctrl+D — preferimos comportamento
+        # SIGINT clássico, já que `q` continua disponível como atalho seguro.
+        Binding("ctrl+c", "quit", "Quit", priority=True, show=False),
     ]
 
     TITLE = "claude-dashboard"


### PR DESCRIPTION
## Summary

Patch bump `0.13.0` → `0.13.1`.

Adiciona `Binding("ctrl+c", "quit", priority=True, show=False)` na TUI. Sobrescreve o popup padrão do Textual (que sugeria `Ctrl+D` e atrapalhava o fluxo de saída) e restaura a convenção clássica de SIGINT como quit imediato.

## Decisões

- **`priority=True`** — necessário pra interceptar Ctrl+C antes do handler default do Textual
- **`show=False`** — não polui o Footer (já tem 6 bindings visíveis); Ctrl+C é convenção implícita
- **`q` continua sendo o quit canônico** — Ctrl+C é atalho redundante de conveniência
- **Não bumpa minor** — pure UX fix, sem mudança de API

## Test plan

- [x] `pytest`: 244 passed + 1 skipped (audit byte-identity test skipa porque legado foi deletado pós-migração — comportamento correto)
- [x] `ruff`: paridade com baseline (79)
- [ ] Validação pós-merge: pressionar Ctrl+C no \`claude-dash\` fecha o app sem popup