### PR TITLE
ci: adiciona GitHub Actions com pytest + ruff em PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Dependabot — bumps semanais para GitHub Actions (SHA pinning).
+# Necessário porque .github/workflows/*.yml usa SHAs imutáveis em vez de tags.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout@v4 (v4.3.0)
+        # actions/checkout@v4 (v4.3.1)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           # Necessário para `git diff origin/main...HEAD` no job de ruff (PRs).
           fetch-depth: 0
 
       - name: Setup Python 3.12
-        # actions/setup-python@v5 (v5.6.1)
+        # actions/setup-python@v5 (v5.6.0)
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+# CI: roda pytest e ruff em pushes/PRs para main.
+# - pytest: full suite, deve passar (baseline 245 tests).
+# - ruff: em PRs, valida apenas arquivos .py modificados versus origin/main
+#   (regressão zero p/ código novo, sem exigir limpeza do baseline atual ~79 erros).
+#   Em pushes para main, roda informativo (continue-on-error).
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: pytest + ruff (Python 3.12, Linux)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        # actions/checkout@v4 (v4.3.0)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Necessário para `git diff origin/main...HEAD` no job de ruff (PRs).
+          fetch-depth: 0
+
+      - name: Setup Python 3.12
+        # actions/setup-python@v5 (v5.6.1)
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install package + dev extras
+        run: pip install -e .[dev]
+
+      - name: Run pytest
+        run: pytest
+
+      - name: Ruff em arquivos modificados (PRs)
+        if: github.event_name == 'pull_request'
+        run: |
+          # Pega .py modificados/adicionados no PR contra origin/main.
+          # Falha se algum introduzir erro novo (zero tolerância para código novo).
+          # Baseline existente fica anistiado por enquanto (débito a tratar separado).
+          BASE="origin/${{ github.base_ref }}"
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}" || true
+          CHANGED=$(git diff --name-only --diff-filter=AM "$BASE"...HEAD -- '*.py' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "Nenhum arquivo .py modificado no PR; ruff dispensado."
+            exit 0
+          fi
+          echo "Arquivos a verificar:"
+          echo "$CHANGED"
+          echo "$CHANGED" | xargs ruff check
+
+      - name: Ruff baseline (push em main, informativo)
+        if: github.event_name == 'push'
+        # Baseline atual tem ~79 erros; mantém visível no log sem quebrar build.
+        run: ruff check . || true


### PR DESCRIPTION
## Sumário

Adiciona o primeiro workflow de CI do repo. Hoje PRs entram em `main` sem validação automatizada — bug do Footer (#30) é exemplo recente. Este PR fecha esse gap.

Triggers: `push` e `pull_request` para `main`. Único job (Python 3.12, Ubuntu) instala o package com extras `dev` e roda `pytest` + `ruff`.

## Workflow (`.github/workflows/test.yml`)

```yaml
name: test

on:
  push:
    branches: [main]
  pull_request:
    branches: [main]

jobs:
  test:
    name: pytest + ruff (Python 3.12, Linux)
    runs-on: ubuntu-latest

    steps:
      - name: Checkout
        # actions/checkout@v4 (v4.3.0)
        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
        with:
          fetch-depth: 0

      - name: Setup Python 3.12
        # actions/setup-python@v5 (v5.6.1)
        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
        with:
          python-version: "3.12"
          cache: "pip"

      - name: Upgrade pip
        run: python -m pip install --upgrade pip

      - name: Install package + dev extras
        run: pip install -e .[dev]

      - name: Run pytest
        run: pytest

      - name: Ruff em arquivos modificados (PRs)
        if: github.event_name == 'pull_request'
        run: |
          BASE="origin/${{ github.base_ref }}"
          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}" || true
          CHANGED=$(git diff --name-only --diff-filter=AM "$BASE"...HEAD -- '*.py' || true)
          if [ -z "$CHANGED" ]; then
            echo "Nenhum arquivo .py modificado no PR; ruff dispensado."
            exit 0
          fi
          echo "$CHANGED" | xargs ruff check

      - name: Ruff baseline (push em main, informativo)
        if: github.event_name == 'push'
        run: ruff check . || true
```

## Decisão sobre ruff

Baseline atual = **79 erros** em `main`. Sem mexer em `pyproject.toml` (escopo proibido neste PR — outro agente está bumpando versão lá), três opções foram avaliadas:

| Opção | Captura regressão? | Falha por baseline? |
|---|---|---|
| `ruff check .` global | sim | **sim** (quebra todo PR) |
| `ruff check . \|\| true` | não | não |
| ruff só em `.py` modificados (`git diff origin/main...HEAD`) | **sim** | não |

Escolhida a terceira: **zero tolerância para código novo, anistia para o débito existente**. Em `push` para `main` (merge), o ruff completo roda em modo informativo só pra manter o número visível no log.

Limpeza do baseline está sendo conduzida em paralelo em outra branch — quando aterrissar, basta remover o `\|\| true` do step de push e (idealmente) trocar o step de PR para `ruff check .` global.

## SHA pinning

Conforme padrão da DTI:

| Action | Tag | SHA | Versão |
|---|---|---|---|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.0 |
| `actions/setup-python` | v5 | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.1 |

Atualizações automáticas via `.github/dependabot.yml` (semanal, ecosystem `github-actions`).

## Validação local

- `python -c "import yaml; yaml.safe_load(...)"` — sintaxe OK em ambos YAMLs
- `pip install -e .[dev]` — instalação limpa em venv 3.12
- `pytest` — 244 passed, 1 skipped (245 total, conforme baseline)
- `ruff check .` — 79 erros (idem baseline, confirmando o pin de comportamento)

## Não fecha issue

Higiene de infra; sem issue associada.