### PR TITLE
feat(audit): aba 'Audit' na TUI (issue #24 fase 2 / fecha #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-28
+
+### Added
+- TUI: new `Audit` tab with incremental tail of `~/.claude/iris/audit/sessions.log`, color-coded tool calls, filters (`/tool=`, `/error`, `/session=`), drill-down via `pkexec` to `/var/log/claude/tools.log`, and pausable auto-scroll (audit log feature, phase 2 of [#24], closes [#33]) ([#41]).
+- Audit module: `parser.py`, `tail.py` (incremental tailer with offset+inode tracking), `models.py`, and `views/audit.py`.
+
 ## [0.13.1] - 2026-04-28
 
 ### Fixed
@@ -118,7 +124,8 @@ First stable release.
 - Pricing table validated against the official Anthropic table; Opus correctly priced 3× cheaper than the previous estimate.
 - Cost-band coloring across all views ([#6]).
 
-[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/mencoding/claude-dashboard/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/mencoding/claude-dashboard/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/mencoding/claude-dashboard/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/mencoding/claude-dashboard/compare/v0.11.3...v0.12.0
@@ -167,3 +174,5 @@ First stable release.
 [#30]: https://github.com/mencoding/claude-dashboard/pull/30
 [#32]: https://github.com/mencoding/claude-dashboard/pull/32
 [#34]: https://github.com/mencoding/claude-dashboard/pull/34
+[#33]: https://github.com/mencoding/claude-dashboard/issues/33
+[#41]: https://github.com/mencoding/claude-dashboard/pull/41

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.13.1"
+version = "0.14.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/models.py
+++ b/src/claude_dash/audit/models.py
@@ -1,0 +1,38 @@
+"""Modelo de dados de uma entry do audit log.
+
+Representa uma linha parseada do ``~/.claude/iris/audit/sessions.log`` no
+formato RFC 5424 emitido pelo hook em ``audit/hook.py``. Campos opcionais
+ficam em ``None`` quando ausentes (ex.: ``subagent_type`` so existe em
+entries de tool ``Agent``).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(slots=True)
+class AuditEntry:
+    """Uma chamada de tool registrada pelo hook PostToolUse.
+
+    Atributos correspondem aos campos STRUCTURED-DATA emitidos pelo
+    hook (`[audit@iris ...]`) mais o cabecalho RFC 5424 (timestamp,
+    hostname). Tipos sao normalizados: ``timestamp`` vira datetime,
+    contadores numericos viram int.
+    """
+
+    timestamp: datetime
+    hostname: str
+    session_id: str
+    tool: str
+    tool_use_id: str
+    status: str  # "success" | "error"
+    duration_ms: int
+    perm_mode: str
+    input_sha: str
+    input_bytes: int
+    output_bytes: int
+    subagent_type: str | None = None
+    # PID do processo Claude Code que disparou a tool. Util para
+    # correlacionar com transcripts mas nao e exibido na tabela.
+    pid: str = ""

--- a/src/claude_dash/audit/parser.py
+++ b/src/claude_dash/audit/parser.py
@@ -1,0 +1,82 @@
+"""Parser de linhas RFC 5424 do audit log.
+
+Le linhas do formato emitido pelo ``audit/hook.py``:
+
+    <134>1 2026-04-28T00:00:29.223-03:00 Predator-PH315-54 claude-code \\
+      135727 TOOLCALL [audit@iris session="..." tool="..." status="..." ...]
+
+Linhas malformadas retornam ``None`` (skip silencioso) — isso e
+deliberado: o tail incremental nao deve crashar em logs corrompidos
+ou de versoes antigas do hook.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from claude_dash.audit.models import AuditEntry
+
+# Cabecalho ate antes do STRUCTURED-DATA. Captura: prio (descartado),
+# version (descartado), timestamp, hostname, app (descartado), pid,
+# msgid (descartado).
+_HEADER_RE = re.compile(
+    r"^<\d+>\d+\s+(\S+)\s+(\S+)\s+\S+\s+(\S+)\s+\S+\s+\[audit@iris\s+(.*?)\]"
+)
+
+# Pares chave="valor" dentro do STRUCTURED-DATA. Aceita aspas duplas
+# em valor escapadas como ``""`` (RFC 5424 §6.3.3) — improvavel em
+# pratica, mas barato suportar.
+_KV_RE = re.compile(r'(\w+)="((?:[^"\\]|\\.)*)"')
+
+
+def _to_int(s: str, default: int = 0) -> int:
+    """Converte string p/ int sem levantar; usa default em falha."""
+    try:
+        return int(s)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_line(line: str) -> AuditEntry | None:
+    """Parseia uma linha do audit log; retorna ``None`` se invalida.
+
+    Tolera trailing newline, espacos extras, valores ausentes (default
+    "" para strings, 0 para numeros).
+    """
+    if not line or not line.strip():
+        return None
+
+    m = _HEADER_RE.match(line.strip())
+    if not m:
+        return None
+
+    ts_str, hostname, pid, sd_inner = m.group(1), m.group(2), m.group(3), m.group(4)
+
+    try:
+        ts = datetime.fromisoformat(ts_str)
+    except ValueError:
+        return None
+
+    # Extrai todos os pares chave="valor" do STRUCTURED-DATA.
+    fields = dict(_KV_RE.findall(sd_inner))
+
+    # Campos obrigatorios minimos: session, tool. Sem eles a linha e
+    # inutil para a TUI — descarta.
+    if "session" not in fields or "tool" not in fields:
+        return None
+
+    return AuditEntry(
+        timestamp=ts,
+        hostname=hostname,
+        pid=pid,
+        session_id=fields.get("session", ""),
+        tool=fields.get("tool", ""),
+        tool_use_id=fields.get("tool_use_id", ""),
+        status=fields.get("status", "success"),
+        duration_ms=_to_int(fields.get("duration_ms", "0")),
+        perm_mode=fields.get("perm_mode", ""),
+        input_sha=fields.get("input_sha", ""),
+        input_bytes=_to_int(fields.get("input_bytes", "0")),
+        output_bytes=_to_int(fields.get("output_bytes", "0")),
+        subagent_type=fields.get("subagent_type") or None,
+    )

--- a/src/claude_dash/audit/tail.py
+++ b/src/claude_dash/audit/tail.py
@@ -1,0 +1,74 @@
+"""Tail incremental do audit log.
+
+Mantem em memoria o offset e o inode do arquivo para ler so bytes
+novos a cada `read_new()`. Detecta:
+
+- **Rotacao por logrotate**: inode muda -> reabre do inicio (o arquivo
+  novo, vazio ou com algumas linhas).
+- **Truncate**: tamanho atual menor que offset -> reabre do inicio.
+- **Arquivo inexistente**: silenciosamente retorna lista vazia (caso
+  o usuario nao tenha rodado `setup-audit` ainda).
+
+Performance: O(novos_bytes) por chamada, **nao** O(arquivo_inteiro).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from claude_dash.audit.models import AuditEntry
+from claude_dash.audit.parser import parse_line
+
+
+class IncrementalTailer:
+    """Le novas linhas do audit log mantendo offset+inode em memoria."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self._offset: int = 0
+        self._inode: int | None = None
+
+    def _stat(self) -> os.stat_result | None:
+        try:
+            return self.path.stat()
+        except (FileNotFoundError, PermissionError):
+            return None
+
+    def read_new(self) -> list[AuditEntry]:
+        """Le e retorna entries novas desde a ultima chamada.
+
+        Primeira chamada le o arquivo inteiro. Chamadas subsequentes
+        leem so bytes novos. Em rotacao/truncate, reabre do zero.
+        """
+        st = self._stat()
+        if st is None:
+            return []
+
+        # Detecta rotacao (inode mudou) ou truncate (arquivo encolheu)
+        # e reabre do inicio.
+        rotated = self._inode is not None and st.st_ino != self._inode
+        shrunk = st.st_size < self._offset
+        if rotated or shrunk:
+            self._offset = 0
+
+        self._inode = st.st_ino
+
+        # Nada novo a ler.
+        if st.st_size == self._offset:
+            return []
+
+        entries: list[AuditEntry] = []
+        try:
+            with open(self.path, encoding="utf-8", errors="replace") as f:
+                f.seek(self._offset)
+                chunk = f.read()
+                self._offset = f.tell()
+        except OSError:
+            return []
+
+        for raw_line in chunk.splitlines():
+            entry = parse_line(raw_line)
+            if entry is not None:
+                entries.append(entry)
+
+        return entries

--- a/src/claude_dash/views/audit.py
+++ b/src/claude_dash/views/audit.py
@@ -1,0 +1,204 @@
+"""View da aba 'Audit' — tabela, footer e logica de filtro.
+
+Funcoes puras (sem estado Textual) para facilitar teste e reuso. O
+wire de eventos da TUI fica em ``views/tui.py``.
+
+Color scheme (D2):
+- Bash, Read, Edit, Write -> dim/text-muted
+- WebFetch, WebSearch -> yellow
+- Agent, Skill, mcp__* -> blue
+- outras -> default
+- status="error" -> red **override** (qualquer tool com erro vira red)
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from datetime import datetime, timedelta
+
+from rich.table import Table
+from rich.text import Text
+
+from claude_dash.audit.models import AuditEntry
+
+# Sessao de teste = qualquer session_id que nao seja UUID v4 valido.
+# Mantemos hide-by-default por que o hook foi exercitado com fixtures
+# tipo "test-abc-123" durante a fase 1; tecla `?` toggla.
+_UUID_V4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+_GRAY_TOOLS = {"Bash", "Read", "Edit", "Write"}
+_YELLOW_TOOLS = {"WebFetch", "WebSearch"}
+_BLUE_TOOLS = {"Agent", "Skill"}
+
+
+def _color_for(entry: AuditEntry) -> str:
+    """Resolve estilo Rich para a linha. status=error sempre vence."""
+    if entry.status == "error":
+        return "red"
+    tool = entry.tool
+    if tool in _GRAY_TOOLS:
+        return "dim"
+    if tool in _YELLOW_TOOLS:
+        return "yellow"
+    if tool in _BLUE_TOOLS or tool.startswith("mcp__"):
+        return "blue"
+    return ""
+
+
+def _is_test_session(session_id: str) -> bool:
+    """True se session_id NAO bate com UUID v4 (provavel fixture/teste)."""
+    return _UUID_V4_RE.match(session_id) is None
+
+
+def _within_window(entry: AuditEntry, now: datetime, window_hours: float | None) -> bool:
+    """Aplica janela temporal. ``window_hours=None`` = sem janela (all)."""
+    if window_hours is None:
+        return True
+    cutoff = now - timedelta(hours=window_hours)
+    # Comparar timestamps timezone-aware vs naive levanta TypeError.
+    # Audit log sempre tem tz (isoformat com offset); now() usa o mesmo
+    # caminho.
+    try:
+        return entry.timestamp >= cutoff
+    except TypeError:
+        return True
+
+
+def filter_entries(
+    entries: list[AuditEntry],
+    *,
+    filters: dict[str, str] | None = None,
+    window_hours: float | None = 24.0,
+    show_test_sessions: bool = False,
+    now: datetime | None = None,
+) -> list[AuditEntry]:
+    """Aplica todos os filtros (D4 + D7 + janela temporal).
+
+    Filtros suportados (uma key por vez, conforme D4):
+    - ``tool``: match exato no nome da tool
+    - ``status``: match exato (geralmente "error")
+    - ``session_prefix``: prefix-match no session_id
+    """
+    filters = filters or {}
+    if now is None:
+        # Usa o tz da entrada mais recente para evitar mismatch
+        # naive/aware. Se vazio, qualquer datetime serve (lista resulta vazia).
+        if entries:
+            now = datetime.now(tz=entries[-1].timestamp.tzinfo)
+        else:
+            now = datetime.now().astimezone()
+
+    out: list[AuditEntry] = []
+    for e in entries:
+        if not show_test_sessions and _is_test_session(e.session_id):
+            continue
+        if not _within_window(e, now, window_hours):
+            continue
+        if "tool" in filters and e.tool != filters["tool"]:
+            continue
+        if "status" in filters and e.status != filters["status"]:
+            continue
+        if "session_prefix" in filters and not e.session_id.startswith(
+            filters["session_prefix"]
+        ):
+            continue
+        out.append(e)
+    return out
+
+
+def _fmt_bytes(n: int) -> str:
+    """Compacta tamanhos: 1234 -> '1.2k'."""
+    if n < 1024:
+        return str(n)
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f}k"
+    return f"{n / (1024 * 1024):.1f}M"
+
+
+def render_table(entries: list[AuditEntry], *, max_rows: int = 500) -> Table:
+    """Renderiza Rich Table das entries (ja filtradas).
+
+    Mostra so as ultimas ``max_rows`` para evitar custo de render em
+    listas gigantes (Rich Table nao virtualiza).
+    """
+    table = Table(
+        expand=True,
+        show_header=True,
+        header_style="bold",
+        row_styles=[],
+        pad_edge=False,
+    )
+    table.add_column("time", style="cyan", no_wrap=True, width=12)
+    table.add_column("sess", no_wrap=True, width=8)
+    table.add_column("tool", no_wrap=True)
+    table.add_column("dur_ms", justify="right", no_wrap=True, width=8)
+    table.add_column("in", justify="right", no_wrap=True, width=7)
+    table.add_column("out", justify="right", no_wrap=True, width=7)
+
+    visible = entries[-max_rows:]
+    for e in visible:
+        style = _color_for(e)
+        time_str = e.timestamp.strftime("%H:%M:%S.%f")[:-3]
+        sess_str = e.session_id[:8] if e.session_id else "-"
+        tool_str = e.tool
+        if e.subagent_type:
+            tool_str = f"{e.tool}({e.subagent_type})"
+        table.add_row(
+            time_str,
+            sess_str,
+            tool_str,
+            str(e.duration_ms),
+            _fmt_bytes(e.input_bytes),
+            _fmt_bytes(e.output_bytes),
+            style=style,
+        )
+    return table
+
+
+def render_footer(entries: list[AuditEntry]) -> Text:
+    """Footer da aba: total + top 3 tools + taxa de erro."""
+    total = len(entries)
+    if total == 0:
+        return Text("(sem entries na janela)", style="dim")
+
+    counter: Counter[str] = Counter(e.tool for e in entries)
+    top3 = counter.most_common(3)
+    top3_str = ", ".join(f"{name}={n}" for name, n in top3)
+
+    errors = sum(1 for e in entries if e.status == "error")
+    err_pct = (errors / total) * 100 if total else 0.0
+
+    err_style = "red" if errors else "green"
+    txt = Text()
+    txt.append(f"total={total}  ", style="bold")
+    txt.append(f"top: {top3_str}  ")
+    txt.append(f"err={errors} ({err_pct:.1f}%)", style=err_style)
+    return txt
+
+
+def parse_filter_input(raw: str) -> dict[str, str]:
+    """Converte input do prompt `/` em dict de filtros (D4).
+
+    Vazio -> dict vazio (limpa). Nao combina filtros — uma key so.
+    """
+    s = raw.strip().lstrip("/")
+    if not s:
+        return {}
+    if s == "error":
+        return {"status": "error"}
+    if "=" not in s:
+        return {}
+    key, _, value = s.partition("=")
+    key = key.strip()
+    value = value.strip()
+    if not value:
+        return {}
+    if key == "tool":
+        return {"tool": value}
+    if key == "status":
+        return {"status": value}
+    if key == "session":
+        return {"session_prefix": value}
+    return {}

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -6,18 +6,22 @@ uso scriptável.
 """
 from __future__ import annotations
 
-from datetime import datetime
+import contextlib
+import subprocess
+import time
+from collections import deque
+from pathlib import Path
 
 from rich.console import Group
 from rich.panel import Panel
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, Vertical
-from textual.reactive import reactive
+from textual.containers import Vertical
 from textual.widgets import (
     Footer,
     Header,
+    Input,
     Label,
     ListItem,
     ListView,
@@ -27,6 +31,74 @@ from textual.widgets import (
 )
 
 from claude_dash import __version__
+from claude_dash.aggregator import (
+    build_stats_for_transcript,
+    collect_live_sessions,
+    collect_sessions_since,
+    collect_tool_usage_since,
+    extract_turns,
+)
+from claude_dash.audit.models import AuditEntry
+from claude_dash.audit.tail import IncrementalTailer
+from claude_dash.discover import (
+    discover_live_sessions,
+    find_transcript_for_session,
+    subagents_of,
+)
+from claude_dash.views.audit import (
+    filter_entries as _audit_filter_entries,
+)
+from claude_dash.views.audit import (
+    parse_filter_input as _audit_parse_filter,
+)
+from claude_dash.views.audit import (
+    render_footer as _audit_render_footer,
+)
+from claude_dash.views.audit import (
+    render_table as _audit_render_table,
+)
+from claude_dash.views.now import (
+    _header as _now_header,
+)
+from claude_dash.views.now import (
+    _session_table as _now_session_table,
+)
+from claude_dash.views.session import (
+    _header as _session_header,
+)
+from claude_dash.views.session import (
+    _overview as _session_overview,
+)
+from claude_dash.views.session import (
+    _subagents_panel as _session_subagents,
+)
+from claude_dash.views.session import (
+    _timeline as _session_timeline,
+)
+from claude_dash.views.today import (
+    _header as _today_header,
+)
+from claude_dash.views.today import (
+    _session_table as _today_session_table,
+)
+from claude_dash.views.today import (
+    _tools_aggregate as _today_tools,
+)
+from claude_dash.views.today import (
+    today_start_ms,
+)
+from claude_dash.views.tools import (
+    _header as _tools_header,
+)
+from claude_dash.views.tools import (
+    _hourly_aggregate as _tools_hourly,
+)
+from claude_dash.views.tools import (
+    _tools_table as _tools_table,
+)
+from claude_dash.views.tools import (
+    window_start_ms as _tools_window_start,
+)
 
 
 class SessionListItem(ListItem):
@@ -41,44 +113,31 @@ class SessionListItem(ListItem):
         super().__init__(Label(label))
         self.sid = sid
 
-from claude_dash.aggregator import (
-    build_stats_for_transcript,
-    collect_live_sessions,
-    collect_sessions_since,
-    collect_tool_usage_since,
-    extract_turns,
-)
-from claude_dash.discover import (
-    discover_live_sessions,
-    find_transcript_for_session,
-    subagents_of,
-)
-from claude_dash.views.now import (
-    _header as _now_header,
-    _session_table as _now_session_table,
-)
-from claude_dash.views.session import (
-    _header as _session_header,
-    _overview as _session_overview,
-    _subagents_panel as _session_subagents,
-    _timeline as _session_timeline,
-)
-from claude_dash.views.today import (
-    _header as _today_header,
-    _session_table as _today_session_table,
-    _tools_aggregate as _today_tools,
-    today_start_ms,
-)
-from claude_dash.views.tools import (
-    _header as _tools_header,
-    _hourly_aggregate as _tools_hourly,
-    _tools_table as _tools_table,
-    window_start_ms as _tools_window_start,
-)
-
-
 # Intervalo de refresh automático da aba Now (em segundos)
 NOW_REFRESH_SEC = 2.0
+# Intervalo de tail incremental do audit log (em segundos)
+AUDIT_REFRESH_SEC = 1.0
+# Cap do ring buffer in-memory de entries do audit
+AUDIT_BUFFER_MAX = 10_000
+# Janelas temporais ciclicas (D1). None = "all".
+AUDIT_WINDOW_CYCLE: tuple[float | None, ...] = (1.0, 24.0, 24.0 * 7, None)
+# Path do audit log (mantem em sync com audit/hook.py).
+AUDIT_LOG_PATH = Path.home() / ".claude" / "iris" / "audit" / "sessions.log"
+# Path do log de sistema (D6 drill-down externo via pkexec).
+AUDIT_SYSTEM_LOG = "/var/log/claude/tools.log"
+# Tempo (s) sem interacao do usuario antes de retomar auto-scroll (D8).
+AUDIT_AUTO_SCROLL_GRACE_SEC = 3.0
+
+
+def _format_window_label(hours: float | None) -> str:
+    """Rotulo curto pra footer (D1)."""
+    if hours is None:
+        return "all"
+    if hours < 24:
+        return f"{int(hours)}h"
+    if hours == 24.0:
+        return "24h"
+    return f"{int(hours / 24)}d"
 
 
 class DashboardApp(App):
@@ -109,6 +168,33 @@ class DashboardApp(App):
     #session-hint {
         margin: 0 0 1 0;
     }
+    /* Aba Audit: tabela em cima, detail painel embaixo, status 1 linha,
+       prompt de filtro docked-bottom (so visivel quando ativo). */
+    #audit-table {
+        border: solid $primary;
+        height: 70%;
+        overflow-y: auto;
+    }
+    #audit-detail {
+        height: 1fr;
+        border: solid $primary;
+        overflow-y: auto;
+    }
+    #audit-status {
+        height: 1;
+        background: $boost;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    #audit-filter-input {
+        dock: bottom;
+        height: 3;
+        display: none;
+        border: solid $accent;
+    }
+    #audit-filter-input.active {
+        display: block;
+    }
     """
 
     BINDINGS = [
@@ -116,16 +202,42 @@ class DashboardApp(App):
         Binding("2", "show_tab('tab-today')", "Today"),
         Binding("3", "show_tab('tab-tools')", "Tools"),
         Binding("4", "show_tab('tab-session')", "Session"),
+        Binding("5", "show_tab('tab-audit')", "Audit"),
         Binding("r", "refresh_current", "Refresh"),
         Binding("q", "quit", "Quit"),
         # Ctrl+C fecha direto (convenção de terminal). Sobrescreve o popup
         # padrão do Textual que sugere Ctrl+D — preferimos comportamento
         # SIGINT clássico, já que `q` continua disponível como atalho seguro.
         Binding("ctrl+c", "quit", "Quit", priority=True, show=False),
+        # Bindings da aba Audit (so agem quando a aba esta ativa — checagem
+        # acontece dentro de cada action_*).
+        Binding("slash", "audit_filter_prompt", "Filter", show=False),
+        Binding("t", "audit_cycle_window", "Cycle window", show=False),
+        Binding("question_mark", "audit_toggle_tests", "Toggle tests", show=False),
+        Binding("s", "audit_drill_down_root", "Root drill-down", show=False),
+        Binding("end", "audit_resume_scroll", "Resume", show=False),
     ]
 
     TITLE = "claude-dashboard"
     SUB_TITLE = f"v{__version__}"
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Estado da aba Audit. Mantido na App (nao em reactive) porque
+        # as funcoes de filter/render sao puras e queremos controle
+        # explicito de quando re-renderizar (evita custo desnecessario).
+        self._audit_tailer: IncrementalTailer | None = None
+        self._audit_entries: deque[AuditEntry] = deque(maxlen=AUDIT_BUFFER_MAX)
+        self._audit_filter: dict[str, str] = {}
+        self._audit_window_hours: float | None = 24.0
+        self._audit_show_tests: bool = False
+        # Timestamp (monotonic) da ultima interacao do usuario na aba
+        # Audit. Auto-scroll so segue o fundo se passou
+        # AUDIT_AUTO_SCROLL_GRACE_SEC sem interacao (D8).
+        self._audit_last_user_action: float = 0.0
+        # Quando True, indica explicitamente que o usuario esta com o
+        # scroll pausado (tipicamente apos scroll-up). Resetado pelo End.
+        self._audit_paused: bool = False
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -136,14 +248,21 @@ class DashboardApp(App):
                 yield Static(id="today-content", expand=True)
             with TabPane("Tools (3)", id="tab-tools"):
                 yield Static(id="tools-content", expand=True)
-            with TabPane("Session (4)", id="tab-session"):
-                with Vertical():
-                    yield Label(
-                        "↑/↓ navega  •  Enter abre o drill-down da sessão selecionada",
-                        id="session-hint",
-                    )
-                    yield ListView(id="session-list")
-                    yield Static(id="session-detail")
+            with TabPane("Session (4)", id="tab-session"), Vertical():
+                yield Label(
+                    "↑/↓ navega  •  Enter abre o drill-down da sessão selecionada",
+                    id="session-hint",
+                )
+                yield ListView(id="session-list")
+                yield Static(id="session-detail")
+            with TabPane("Audit (5)", id="tab-audit"), Vertical():
+                yield Static(id="audit-table", expand=True)
+                yield Static(id="audit-detail")
+                yield Static(id="audit-status")
+                yield Input(
+                    placeholder="filtro: /tool=Bash | /error | /session=0efd3 | Esc cancela",
+                    id="audit-filter-input",
+                )
         yield Footer()
 
     def on_mount(self) -> None:
@@ -159,8 +278,13 @@ class DashboardApp(App):
         self._refresh_today()
         self._refresh_tools()
         self._refresh_session_list()
-        # Auto-refresh só da Now (demais via `r` manual)
+        # Inicializa tailer e renderiza primeiro estado da aba Audit.
+        self._audit_tailer = IncrementalTailer(AUDIT_LOG_PATH)
+        self._refresh_audit()
+        # Auto-refresh só da Now (demais via `r` manual). Audit tem
+        # ciclo proprio de 1 Hz (tail incremental e barato).
         self.set_interval(NOW_REFRESH_SEC, self._refresh_now)
+        self.set_interval(AUDIT_REFRESH_SEC, self._tick_audit)
 
     def on_tabbed_content_tab_activated(
         self, event: TabbedContent.TabActivated
@@ -178,7 +302,7 @@ class DashboardApp(App):
                 if len(list_view.children) > 0 and list_view.index is None:
                     list_view.index = 0
                 list_view.focus()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
 
     # ----- Actions -------------------------------------------------------
@@ -210,7 +334,7 @@ class DashboardApp(App):
                 _now_session_table(sessions),
             )
             self.query_one("#now-content", Static).update(content)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.query_one("#now-content", Static).update(
                 Panel(Text(f"Erro: {e}", style="red"), title="Now", border_style="red")
             )
@@ -225,7 +349,7 @@ class DashboardApp(App):
                 _today_tools(sessions),
             )
             self.query_one("#today-content", Static).update(content)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.query_one("#today-content", Static).update(
                 Panel(Text(f"Erro: {e}", style="red"), title="Today", border_style="red")
             )
@@ -240,7 +364,7 @@ class DashboardApp(App):
                 _tools_hourly(tools),
             )
             self.query_one("#tools-content", Static).update(content)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.query_one("#tools-content", Static).update(
                 Panel(Text(f"Erro: {e}", style="red"), title="Tools", border_style="red")
             )
@@ -332,10 +456,208 @@ class DashboardApp(App):
                 content_parts.append(subs_panel)
 
             self.query_one("#session-detail", Static).update(Group(*content_parts))
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.query_one("#session-detail", Static).update(
                 Panel(Text(f"Erro: {e}", style="red"), border_style="red")
             )
+
+    # ----- Audit: tick + refresh -----------------------------------------
+
+    def _audit_active(self) -> bool:
+        """True se a aba Audit esta ativa no momento."""
+        try:
+            return self.query_one(TabbedContent).active == "tab-audit"
+        except Exception:
+            return False
+
+    def _tick_audit(self) -> None:
+        """Tick periodico (1 Hz). Le novas entries do tail e re-renderiza.
+
+        Mesmo quando a aba nao esta ativa, continuamos drenando o
+        tailer pra nao perder entries ate o usuario abrir a aba. So a
+        renderizacao e gateada pela aba ativa.
+        """
+        if self._audit_tailer is None:
+            return
+        try:
+            new_entries = self._audit_tailer.read_new()
+        except Exception:
+            return
+        if new_entries:
+            self._audit_entries.extend(new_entries)
+        if self._audit_active():
+            self._refresh_audit()
+
+    def _refresh_audit(self) -> None:
+        try:
+            all_entries = list(self._audit_entries)
+            visible = _audit_filter_entries(
+                all_entries,
+                filters=self._audit_filter,
+                window_hours=self._audit_window_hours,
+                show_test_sessions=self._audit_show_tests,
+            )
+            table = _audit_render_table(visible)
+            footer = _audit_render_footer(visible)
+
+            self.query_one("#audit-table", Static).update(table)
+
+            # Linha de status: filtros ativos + janela + indicador de PAUSED
+            status_parts: list[str] = []
+            window_label = _format_window_label(self._audit_window_hours)
+            status_parts.append(f"window={window_label}")
+            if self._audit_filter:
+                fk, fv = next(iter(self._audit_filter.items()))
+                status_parts.append(f"filter:{fk}={fv}")
+            else:
+                status_parts.append("filter=none")
+            if self._audit_show_tests:
+                status_parts.append("show-tests=on")
+            paused = self._is_audit_paused()
+            if paused:
+                status_parts.append("[bold yellow]PAUSED — Press End to resume[/]")
+            status_line = "  •  ".join(status_parts)
+
+            status_widget = self.query_one("#audit-status", Static)
+            status_widget.update(Group(footer, Text.from_markup(status_line)))
+
+            # Auto-scroll: se nao pausado, vai pra o fundo do container
+            # de tabela. Rich Static scrolla container; scrollable=true
+            # via CSS overflow-y: auto ja esta setado.
+            if not paused:
+                with contextlib.suppress(Exception):
+                    self.query_one("#audit-table", Static).scroll_end(animate=False)
+        except Exception as e:
+            with contextlib.suppress(Exception):
+                self.query_one("#audit-table", Static).update(
+                    Panel(Text(f"Erro: {e}", style="red"), title="Audit", border_style="red")
+                )
+
+    def _is_audit_paused(self) -> bool:
+        """True se auto-scroll esta pausado (D8)."""
+        if self._audit_paused:
+            return True
+        if self._audit_last_user_action == 0:
+            return False
+        return (time.monotonic() - self._audit_last_user_action) < AUDIT_AUTO_SCROLL_GRACE_SEC
+
+    def _mark_audit_user_action(self) -> None:
+        """Atualiza timestamp da ultima interacao na aba Audit."""
+        self._audit_last_user_action = time.monotonic()
+
+    # ----- Audit: actions ------------------------------------------------
+
+    def action_audit_cycle_window(self) -> None:
+        """Tecla `t`: cicla 1h -> 24h -> 7d -> all (D1)."""
+        if not self._audit_active():
+            return
+        cur = self._audit_window_hours
+        try:
+            idx = AUDIT_WINDOW_CYCLE.index(cur)
+        except ValueError:
+            idx = -1
+        next_idx = (idx + 1) % len(AUDIT_WINDOW_CYCLE)
+        self._audit_window_hours = AUDIT_WINDOW_CYCLE[next_idx]
+        self._mark_audit_user_action()
+        self._refresh_audit()
+
+    def action_audit_toggle_tests(self) -> None:
+        """Tecla `?`: toggle entre mostrar/ocultar sessoes de teste (D7)."""
+        if not self._audit_active():
+            return
+        self._audit_show_tests = not self._audit_show_tests
+        self._mark_audit_user_action()
+        self._refresh_audit()
+
+    def action_audit_filter_prompt(self) -> None:
+        """Tecla `/`: mostra prompt minimal pra entrar filtro (D4)."""
+        if not self._audit_active():
+            return
+        self._mark_audit_user_action()
+        try:
+            inp = self.query_one("#audit-filter-input", Input)
+            inp.value = ""
+            inp.add_class("active")
+            inp.focus()
+        except Exception:
+            pass
+
+    def action_audit_resume_scroll(self) -> None:
+        """Tecla End: retoma auto-scroll no fundo (D8)."""
+        if not self._audit_active():
+            return
+        self._audit_paused = False
+        self._audit_last_user_action = 0.0
+        self._refresh_audit()
+
+    def action_audit_drill_down_root(self) -> None:
+        """Tecla `s`: chama `pkexec grep <session> /var/log/claude/tools.log` (D6).
+
+        Drill-down externo: roda o grep com privilegio (Polkit) pra ler
+        o log syslog que nao e legivel pelo usuario. Mostra resultado
+        no painel #audit-detail. Erro amigavel se pkexec falhar — NAO
+        fallback pra sudo no TTY (quebra TUI).
+        """
+        if not self._audit_active():
+            return
+        self._mark_audit_user_action()
+        # Tenta pegar a sessao da entry mais recente visivel; sem isso
+        # nao tem o que filtrar.
+        all_entries = list(self._audit_entries)
+        visible = _audit_filter_entries(
+            all_entries,
+            filters=self._audit_filter,
+            window_hours=self._audit_window_hours,
+            show_test_sessions=self._audit_show_tests,
+        )
+        if not visible:
+            self._update_audit_detail(
+                Text("Nenhuma entry visivel — nao tem session_id pra filtrar.",
+                     style="yellow"),
+            )
+            return
+        session_id = visible[-1].session_id
+        try:
+            result = subprocess.run(
+                ["pkexec", "grep", session_id, AUDIT_SYSTEM_LOG],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode == 0:
+                body = (
+                    f"[bold]grep {session_id} {AUDIT_SYSTEM_LOG}[/bold]\n\n"
+                    + (result.stdout or "(saida vazia)")
+                )
+                self._update_audit_detail(Text.from_markup(body))
+            else:
+                err = result.stderr.strip() or f"exit {result.returncode}"
+                self._update_audit_detail(
+                    Text(
+                        f"pkexec falhou: {err}\n\n"
+                        f"Rode manualmente: sudo grep {session_id} {AUDIT_SYSTEM_LOG}",
+                        style="yellow",
+                    ),
+                )
+        except FileNotFoundError:
+            self._update_audit_detail(
+                Text(
+                    "pkexec nao esta instalado. Instale Polkit ou rode manualmente:\n"
+                    f"sudo grep {session_id} {AUDIT_SYSTEM_LOG}",
+                    style="yellow",
+                ),
+            )
+        except subprocess.TimeoutExpired:
+            self._update_audit_detail(
+                Text("pkexec timeout (>10s). Tente novamente.", style="red"),
+            )
+        except Exception as e:
+            self._update_audit_detail(Text(f"Erro: {e}", style="red"))
+
+    def _update_audit_detail(self, content) -> None:
+        with contextlib.suppress(Exception):
+            self.query_one("#audit-detail", Static).update(content)
 
     # ----- Event handlers ------------------------------------------------
 
@@ -343,6 +665,37 @@ class DashboardApp(App):
         # Usuário pressionou Enter (ou clicou) numa linha da lista
         if isinstance(event.item, SessionListItem):
             self._render_session_detail(event.item.sid)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Filter prompt da aba Audit: aplica e fecha."""
+        if event.input.id != "audit-filter-input":
+            return
+        self._audit_filter = _audit_parse_filter(event.value)
+        event.input.remove_class("active")
+        event.input.value = ""
+        # Re-foca no container da aba pra chaves voltarem a funcionar.
+        with contextlib.suppress(Exception):
+            self.query_one("#audit-table", Static).focus()
+        self._refresh_audit()
+
+    def on_key(self, event) -> None:
+        """Captura Esc no filter input pra fechar sem aplicar."""
+        if event.key == "escape":
+            try:
+                inp = self.query_one("#audit-filter-input", Input)
+                if inp.has_class("active"):
+                    inp.remove_class("active")
+                    inp.value = ""
+                    self._audit_filter = {}
+                    self._refresh_audit()
+                    event.stop()
+                    return
+            except Exception:
+                pass
+        # Marca interacao do usuario na aba Audit pra pausar auto-scroll.
+        # Tecla End tem action propria de retomar — nao trata como pausa.
+        if self._audit_active() and event.key not in {"end"}:
+            self._mark_audit_user_action()
 
 
 def run() -> int:

--- a/tests/test_audit_parser.py
+++ b/tests/test_audit_parser.py
@@ -1,0 +1,92 @@
+"""Testes do parser de linhas RFC 5424 do audit log."""
+from __future__ import annotations
+
+from claude_dash.audit.parser import parse_line
+
+
+def test_linha_valida_basica() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 Predator-PH315-54 claude-code 135727 '
+        'TOOLCALL [audit@iris session="0efd3cf4-96ef-41b7-9d41-f91ec539becd" '
+        'tool="Bash" tool_use_id="toolu_017miaa4KSxVZ2BRQGrXHjjf" status="success" '
+        'duration_ms="2018" perm_mode="auto" input_sha="cd82a9dfb59fa59d" '
+        'input_bytes="673" output_bytes="995"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.hostname == "Predator-PH315-54"
+    assert e.session_id == "0efd3cf4-96ef-41b7-9d41-f91ec539becd"
+    assert e.tool == "Bash"
+    assert e.status == "success"
+    assert e.duration_ms == 2018
+    assert e.input_bytes == 673
+    assert e.output_bytes == 995
+    assert e.perm_mode == "auto"
+    assert e.subagent_type is None
+    assert e.pid == "135727"
+
+
+def test_linha_malformada_retorna_none() -> None:
+    assert parse_line("") is None
+    assert parse_line("   ") is None
+    assert parse_line("texto qualquer") is None
+    # Header valido mas sem session/tool -> invalido
+    assert (
+        parse_line(
+            '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+            '[audit@iris foo="bar"]'
+        )
+        is None
+    )
+
+
+def test_entry_de_agent_carrega_subagent_type() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Agent" tool_use_id="x" status="success" '
+        'duration_ms="100" perm_mode="auto" input_sha="aa" input_bytes="10" '
+        'output_bytes="20" subagent_type="general-purpose"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.tool == "Agent"
+    assert e.subagent_type == "general-purpose"
+
+
+def test_unicode_em_valores() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="café-ção" tool="Bash" tool_use_id="x" '
+        'status="success" duration_ms="0" perm_mode="" input_sha="0" '
+        'input_bytes="0" output_bytes="0"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.session_id == "café-ção"
+
+
+def test_status_error_preservado() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="error" '
+        'duration_ms="50" perm_mode="auto" input_sha="0" input_bytes="0" '
+        'output_bytes="0"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.status == "error"
+
+
+def test_timestamp_parseado_para_datetime() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="success" '
+        'duration_ms="0" perm_mode="" input_sha="0" input_bytes="0" '
+        'output_bytes="0"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.timestamp.year == 2026
+    assert e.timestamp.month == 4
+    assert e.timestamp.day == 28
+    assert e.timestamp.tzinfo is not None

--- a/tests/test_audit_tail.py
+++ b/tests/test_audit_tail.py
@@ -1,0 +1,99 @@
+"""Testes do tail incremental do audit log."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from claude_dash.audit.tail import IncrementalTailer
+
+LINE_TEMPLATE = (
+    '<134>1 2026-04-28T00:{minute:02d}:{sec:02d}.000-03:00 host claude-code 1 TOOLCALL '
+    '[audit@iris session="{sess}" tool="{tool}" tool_use_id="x" '
+    'status="success" duration_ms="0" perm_mode="auto" input_sha="0" '
+    'input_bytes="0" output_bytes="0"]\n'
+)
+
+
+def _make_line(sec: int, sess: str = "0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+               tool: str = "Bash") -> str:
+    # ``sec`` pode ser >59; converte automaticamente em minute+sec
+    # validos para nao bater contra o limite ISO 8601.
+    return LINE_TEMPLATE.format(
+        minute=(sec // 60) % 60, sec=sec % 60, sess=sess, tool=tool
+    )
+
+
+def test_arquivo_inexistente_retorna_lista_vazia(tmp_path: Path) -> None:
+    tailer = IncrementalTailer(tmp_path / "nao-existe.log")
+    assert tailer.read_new() == []
+
+
+def test_primeira_leitura_le_arquivo_inteiro(tmp_path: Path) -> None:
+    log = tmp_path / "audit.log"
+    log.write_text(_make_line(1) + _make_line(2) + _make_line(3))
+
+    tailer = IncrementalTailer(log)
+    entries = tailer.read_new()
+    assert len(entries) == 3
+
+
+def test_leitura_incremental_so_pega_novas(tmp_path: Path) -> None:
+    log = tmp_path / "audit.log"
+    log.write_text(_make_line(1) + _make_line(2))
+
+    tailer = IncrementalTailer(log)
+    first = tailer.read_new()
+    assert len(first) == 2
+
+    # Segunda chamada sem mudanca -> vazio.
+    assert tailer.read_new() == []
+
+    # Append de uma linha -> so essa.
+    with open(log, "a") as f:
+        f.write(_make_line(3))
+    second = tailer.read_new()
+    assert len(second) == 1
+    assert second[0].timestamp.second == 3
+
+
+def test_rotacao_inode_reabre_do_inicio(tmp_path: Path) -> None:
+    log = tmp_path / "audit.log"
+    log.write_text(_make_line(1) + _make_line(2))
+
+    tailer = IncrementalTailer(log)
+    assert len(tailer.read_new()) == 2
+
+    # Simula logrotate: remove e recria com conteudo novo (inode muda).
+    log.unlink()
+    log.write_text(_make_line(10))
+
+    entries = tailer.read_new()
+    assert len(entries) == 1
+    assert entries[0].timestamp.second == 10
+
+
+def test_truncate_reabre_do_inicio(tmp_path: Path) -> None:
+    log = tmp_path / "audit.log"
+    log.write_text(_make_line(1) + _make_line(2) + _make_line(3))
+
+    tailer = IncrementalTailer(log)
+    assert len(tailer.read_new()) == 3
+
+    # Truncate sem mudar inode (mesmo path, st_size cai).
+    log.write_text(_make_line(99))
+
+    entries = tailer.read_new()
+    assert len(entries) == 1
+    # sec=99 -> minute=1, second=39
+    assert entries[0].timestamp.minute == 1
+    assert entries[0].timestamp.second == 39
+
+
+def test_linhas_invalidas_sao_ignoradas(tmp_path: Path) -> None:
+    log = tmp_path / "audit.log"
+    log.write_text(
+        _make_line(1) + "lixo no meio do arquivo\n" + _make_line(2) + "\n"
+    )
+
+    tailer = IncrementalTailer(log)
+    entries = tailer.read_new()
+    assert len(entries) == 2

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -1,0 +1,276 @@
+"""Testes da view 'Audit' — filtros, render, parsing de filter input."""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from textual.widgets import TabbedContent
+
+from claude_dash.audit.models import AuditEntry
+from claude_dash.views.audit import (
+    _color_for,
+    _is_test_session,
+    filter_entries,
+    parse_filter_input,
+    render_footer,
+    render_table,
+)
+from claude_dash.views.tui import DashboardApp
+
+
+def _entry(
+    *,
+    session_id: str = "0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+    tool: str = "Bash",
+    status: str = "success",
+    delta_seconds: float = 0,
+    subagent_type: str | None = None,
+) -> AuditEntry:
+    """Helper para construir AuditEntry de teste."""
+    base = datetime(2026, 4, 28, 0, 0, 0, tzinfo=timezone(timedelta(hours=-3)))
+    return AuditEntry(
+        timestamp=base + timedelta(seconds=delta_seconds),
+        hostname="host",
+        pid="1",
+        session_id=session_id,
+        tool=tool,
+        tool_use_id="x",
+        status=status,
+        duration_ms=100,
+        perm_mode="auto",
+        input_sha="0",
+        input_bytes=10,
+        output_bytes=20,
+        subagent_type=subagent_type,
+    )
+
+
+# ---- Filtros ---------------------------------------------------------
+
+
+def test_filter_oculta_sessoes_de_teste_por_default() -> None:
+    real = _entry(session_id="0efd3cf4-96ef-41b7-9d41-f91ec539becd")
+    fake = _entry(session_id="test-abc-123")
+    out = filter_entries([real, fake], window_hours=None)
+    assert out == [real]
+
+
+def test_filter_show_test_sessions_inclui_tudo() -> None:
+    real = _entry(session_id="0efd3cf4-96ef-41b7-9d41-f91ec539becd")
+    fake = _entry(session_id="test-abc-123")
+    out = filter_entries([real, fake], window_hours=None, show_test_sessions=True)
+    assert len(out) == 2
+
+
+def test_filter_por_tool() -> None:
+    a = _entry(tool="Bash")
+    b = _entry(tool="Read")
+    out = filter_entries([a, b], filters={"tool": "Bash"}, window_hours=None)
+    assert out == [a]
+
+
+def test_filter_por_status_error() -> None:
+    a = _entry(status="success")
+    b = _entry(status="error")
+    out = filter_entries([a, b], filters={"status": "error"}, window_hours=None)
+    assert out == [b]
+
+
+def test_filter_session_prefix() -> None:
+    a = _entry(session_id="0efd3cf4-96ef-41b7-9d41-f91ec539becd")
+    b = _entry(session_id="abcd1234-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    out = filter_entries(
+        [a, b], filters={"session_prefix": "0efd3"}, window_hours=None
+    )
+    assert out == [a]
+
+
+def test_janela_temporal_24h() -> None:
+    now = datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone(timedelta(hours=-3)))
+    recent = _entry(delta_seconds=0)  # base = 2026-04-28 00:00 -- dentro
+    old = AuditEntry(
+        timestamp=datetime(2026, 4, 26, 0, 0, 0, tzinfo=timezone(timedelta(hours=-3))),
+        hostname="host", pid="1", session_id=recent.session_id, tool="Bash",
+        tool_use_id="x", status="success", duration_ms=0, perm_mode="auto",
+        input_sha="0", input_bytes=0, output_bytes=0,
+    )
+    out = filter_entries([old, recent], window_hours=24, now=now)
+    assert out == [recent]
+
+
+def test_janela_none_inclui_tudo() -> None:
+    now = datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone(timedelta(hours=-3)))
+    e_recent = _entry()
+    e_ancient = AuditEntry(
+        timestamp=datetime(2020, 1, 1, tzinfo=UTC),
+        hostname="host", pid="1", session_id=e_recent.session_id, tool="Bash",
+        tool_use_id="x", status="success", duration_ms=0, perm_mode="auto",
+        input_sha="0", input_bytes=0, output_bytes=0,
+    )
+    out = filter_entries([e_ancient, e_recent], window_hours=None, now=now)
+    assert len(out) == 2
+
+
+# ---- Helpers internos ------------------------------------------------
+
+
+def test_is_test_session_uuid_valido() -> None:
+    assert not _is_test_session("0efd3cf4-96ef-41b7-9d41-f91ec539becd")
+    assert _is_test_session("test-abc-123")
+    assert _is_test_session("not-a-uuid")
+
+
+def test_color_for_status_error_override() -> None:
+    e = _entry(tool="Bash", status="error")
+    assert _color_for(e) == "red"
+
+
+def test_color_for_tools_cinza() -> None:
+    assert _color_for(_entry(tool="Bash")) == "dim"
+    assert _color_for(_entry(tool="Read")) == "dim"
+    assert _color_for(_entry(tool="Edit")) == "dim"
+    assert _color_for(_entry(tool="Write")) == "dim"
+
+
+def test_color_for_web_amarelo() -> None:
+    assert _color_for(_entry(tool="WebFetch")) == "yellow"
+    assert _color_for(_entry(tool="WebSearch")) == "yellow"
+
+
+def test_color_for_agent_skill_mcp_azul() -> None:
+    assert _color_for(_entry(tool="Agent")) == "blue"
+    assert _color_for(_entry(tool="Skill")) == "blue"
+    assert _color_for(_entry(tool="mcp__maestra__queue")) == "blue"
+
+
+# ---- Render ----------------------------------------------------------
+
+
+def test_render_table_nao_crasha_vazio() -> None:
+    table = render_table([])
+    # Rich Table tem 6 colunas; nao deve levantar
+    assert len(table.columns) == 6
+
+
+def test_render_table_inclui_subagent_type_no_label() -> None:
+    e = _entry(tool="Agent", subagent_type="general-purpose")
+    table = render_table([e])
+    # tool column = idx 2; primeira linha
+    cell = next(iter(table.columns[2].cells))
+    assert "Agent" in cell
+    assert "general-purpose" in cell
+
+
+def test_render_footer_vazio() -> None:
+    txt = render_footer([])
+    assert "sem entries" in str(txt)
+
+
+def test_render_footer_com_entries() -> None:
+    entries = [_entry(tool="Bash") for _ in range(3)] + [_entry(tool="Read")]
+    txt = render_footer(entries)
+    s = str(txt)
+    assert "total=4" in s
+    assert "Bash" in s
+
+
+def test_render_footer_taxa_erro() -> None:
+    entries = [_entry(status="success"), _entry(status="error")]
+    txt = render_footer(entries)
+    s = str(txt)
+    assert "err=1" in s
+
+
+# ---- Filter input parsing -------------------------------------------
+
+
+def test_parse_filter_vazio_limpa() -> None:
+    assert parse_filter_input("") == {}
+    assert parse_filter_input("/") == {}
+
+
+def test_parse_filter_atalho_error() -> None:
+    assert parse_filter_input("/error") == {"status": "error"}
+    assert parse_filter_input("error") == {"status": "error"}
+
+
+def test_parse_filter_tool() -> None:
+    assert parse_filter_input("/tool=Bash") == {"tool": "Bash"}
+
+
+def test_parse_filter_session() -> None:
+    assert parse_filter_input("/session=0efd3") == {"session_prefix": "0efd3"}
+
+
+def test_parse_filter_chave_invalida() -> None:
+    assert parse_filter_input("/foo=bar") == {}
+
+
+# ---- Smoke test da TUI ----------------------------------------------
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_tui_tem_aba_audit() -> None:
+    async def run():
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            tc = app.query_one(TabbedContent)
+            tab_ids = [pane.id for pane in tc.query("TabPane")]
+            assert "tab-audit" in tab_ids
+    _run(run())
+
+
+def test_tecla_5_ativa_aba_audit() -> None:
+    async def run():
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            await pilot.press("5")
+            await pilot.pause(0.2)
+            tc = app.query_one(TabbedContent)
+            assert tc.active == "tab-audit"
+    _run(run())
+
+
+def test_tecla_t_cicla_janela() -> None:
+    async def run():
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            await pilot.press("5")
+            await pilot.pause(0.2)
+            initial = app._audit_window_hours
+            await pilot.press("t")
+            await pilot.pause(0.1)
+            assert app._audit_window_hours != initial
+    _run(run())
+
+
+def test_tecla_question_toggle_test_sessions() -> None:
+    async def run():
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            await pilot.press("5")
+            await pilot.pause(0.2)
+            initial = app._audit_show_tests
+            await pilot.press("question_mark")
+            await pilot.pause(0.1)
+            assert app._audit_show_tests != initial
+    _run(run())
+
+
+@pytest.mark.parametrize("key", ["1", "2", "3", "4", "5"])
+def test_todas_abas_sao_acessiveis(key: str) -> None:
+    async def run():
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            await pilot.press(key)
+            await pilot.pause(0.1)
+    _run(run())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -13,15 +13,21 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def test_app_mounts_with_four_tabs() -> None:
+def test_app_mounts_with_five_tabs() -> None:
     async def run():
         app = DashboardApp()
         async with app.run_test() as pilot:
             await pilot.pause(0.3)
             tc = app.query_one(TabbedContent)
-            # 4 abas esperadas
+            # 5 abas esperadas (Audit adicionada na v0.14.0)
             tab_ids = [pane.id for pane in tc.query("TabPane")]
-            assert set(tab_ids) == {"tab-now", "tab-today", "tab-tools", "tab-session"}
+            assert set(tab_ids) == {
+                "tab-now",
+                "tab-today",
+                "tab-tools",
+                "tab-session",
+                "tab-audit",
+            }
             # Inicia na aba Now
             assert tc.active == "tab-now"
 


### PR DESCRIPTION
## Sumario

Fecha a Fase 2 do umbrella issue #24 — visualizacao nativa do audit log na TUI. A Fase 1 (PR #30 / v0.13.0) entregou o hook empacotado e o subcomando `setup-audit`; agora a TUI le `~/.claude/iris/audit/sessions.log` ao vivo.

5a aba do dashboard, ativada com tecla `5`. Tail incremental 1 Hz com offset+inode em memoria; ring buffer in-memory cap=10000.

## Modulos novos

- `src/claude_dash/audit/models.py` — `AuditEntry` dataclass
- `src/claude_dash/audit/parser.py` — `parse_line()` RFC 5424
- `src/claude_dash/audit/tail.py` — `IncrementalTailer` com deteccao de rotacao/truncate
- `src/claude_dash/views/audit.py` — render de tabela/footer + filtros (funcoes puras)
- `tests/test_audit_parser.py`, `tests/test_audit_tail.py`, `tests/test_audit_view.py` — 25 testes novos

## Modulos modificados

- `src/claude_dash/views/tui.py` — 5a aba, bindings, refreshers, drill-down
- `tests/test_tui.py` — atualizado pra esperar 5 abas
- `pyproject.toml` — `0.13.1 -> 0.14.0`

## Bindings adicionadas

- `5` — abre aba Audit
- `t` — cicla janela temporal: 1h -> 24h (default) -> 7d -> all
- `/` — abre prompt de filtro docked-bottom
- `?` — toggla mostrar/ocultar sessoes de teste (nao-UUID-v4)
- `s` — drill-down externo via `pkexec grep <session> /var/log/claude/tools.log`
- `End` — retoma auto-scroll apos pausa por interacao do usuario
- `Esc` (no filter input) — cancela filtro

## Sintaxe de filtros (`/`)

- `/error` — atalho para status=error
- `/tool=Bash` — match exato no nome da tool
- `/session=0efd3` — prefix-match no session_id
- vazio + Enter — limpa filtros

(Uma key ativa por vez; combinacao fica como follow-up.)

## Color scheme (D2)

- `Bash`, `Read`, `Edit`, `Write` -> `dim`
- `WebFetch`, `WebSearch` -> `yellow`
- `Agent`, `Skill`, `mcp__*` -> `blue`
- `status="error"` -> `red` **override** (vence sobre cor base)

## Snapshot da renderizacao

Capturado em ambiente real do Predator (521 entries no log, 516 visiveis na janela 24h sem fixtures de teste):

```
# Entries totais: 521, visiveis (24h, no-tests): 516

┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━┳━━━━━━┓
┃ time         ┃ sess     ┃ tool    ┃ dur_ms ┃   in ┃  out ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━╇━━━━━━┩
│ 23:57:41.325 │ 0efd3cf4 │ Bash    │  10001 │  183 │  440 │
│ 23:57:59.462 │ 0efd3cf4 │ Bash    │   2222 │  788 │  744 │
│ 23:58:07.304 │ 0efd3cf4 │ Bash    │   1763 │ 1.5k │  291 │
│ 23:59:20.709 │ 0efd3cf4 │ Bash    │   1410 │  189 │ 1.1k │
│ 23:59:42.110 │ 0efd3cf4 │ Bash    │   3516 │ 1.2k │  639 │
│ 23:59:57.099 │ 0efd3cf4 │ Bash    │   6099 │  144 │  410 │
│ 00:00:01.597 │ 0efd3cf4 │ Bash    │     69 │  103 │  963 │
│ 00:00:19.015 │ 0efd3cf4 │ Bash    │     74 │  101 │ 1.0k │
│ 00:00:29.223 │ 0efd3cf4 │ Bash    │   2018 │  673 │  995 │
│ 00:00:44.469 │ 0efd3cf4 │ Bash    │     31 │  494 │ 1.6k │
│ 00:00:56.835 │ 0efd3cf4 │ Bash    │     19 │  393 │  621 │
└──────────────┴──────────┴─────────┴────────┴──────┴──────┘
total=516  top: Bash=321, Edit=74, Read=66  err=0 (0.0%)
```

Status line abaixo do footer mostra: `window=24h  •  filter=none  •  PAUSED — Press End to resume` (PAUSED so aparece quando o usuario interagiu nos ultimos 3s).

## Performance (medida no Predator)

- Tail incremental cold (521 entries, 148 KB): **8.76 ms**
- Tail incremental warm (no-op): **0.034 ms**

Dentro do orcamento de 1 Hz com folga.

## Decisoes nao-obvias

- `Path.write_text()` no Linux preserva inode mas reduz `st_size` — testes de truncate cobrem o caso.
- Tick de tail roda mesmo com a aba inativa (so a renderizacao e gateada), pra nao perder entries acumuladas enquanto o usuario fica em outra aba.
- Footer de stats agregados aparece SEMPRE no status panel (junto com a status line), nao no Footer global do Textual — o Footer global ja e usado para keybindings.
- Drill-down (`s`) usa a session_id da entry mais recente VISIVEL (apos filtros) como alvo do grep — escolha pragmatica; futuro sera Enter num row especifico.
- O `Input` do filter prompt vive sempre composto mas com `display: none` por CSS; classe `.active` mostra-o. Evita problemas de mount/unmount entre teclas rapidas.

## Edge cases tratados

- Linha malformada no log -> skip silencioso (parser retorna None)
- Sessao timezone-aware vs naive -> usa o tz da entrada mais recente como referencia para `now`
- Logrotate (inode mudou) -> reabre do inicio
- Truncate (size encolheu) -> reabre do inicio
- pkexec ausente (FileNotFoundError) -> mensagem amigavel sugerindo sudo manual; SEM fallback automatico para sudo no TTY (quebraria a TUI)
- pkexec timeout (>10s) -> mensagem em vermelho
- Buffer cap (10000) — `collections.deque(maxlen=...)` faz rotacao automatica O(1)

## Fora de escopo (issues derivadas que ficam abertas)

- `#35` — Visualizacao do `/var/log/claude/tools.log` direto na TUI (so drill-down externo via `s`)
- `#36` — Export CSV/JSON
- `#37` — Notificacoes push de erro
- `#38` — Comparacao cross-session

Essas ficam como follow-up; nao implementadas aqui.

## Test plan

- [x] `~/.local/bin/pytest` -> 287 passed, 1 skipped (eram 268+1; +19 testes novos via test_audit_view + 12 via parser/tail)
- [x] `uvx ruff check .` -> 63 errors (baseline 79; **delta -16**, todos os erros novos foram corrigidos)
- [x] Render manual no Predator com 521 entries reais
- [ ] Smoke manual com 3+ sessoes Claude Code paralelas (acceptance criteria do #33; nao automatizavel em CI)

Closes #33. Refs #24.