### PR TITLE
ci: comentários de SHA inline (auto-atualizados pelo Dependabot)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout@v4 (v4.3.1)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Necessário para `git diff origin/main...HEAD` no job de ruff (PRs).
           fetch-depth: 0
 
       - name: Setup Python 3.12
-        # actions/setup-python@v5 (v5.6.0)
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: "pip"


### PR DESCRIPTION
## Problema observado

PRs Dependabot #43 e #44 atualizaram as SHAs das actions mas **não atualizaram os comentários de versão** (que ficaram em linha separada acima do \`uses:\`). Resultado: comentário diz \`v4.3.1\` enquanto SHA aponta pra \`v6.0.2\`. Débito recorrente a cada bump.

## Causa

Dependabot só atualiza comentários **inline na mesma linha do \`uses:\`**, formato:

\`\`\`yaml
uses: actions/checkout@<sha>  # v6.0.2
\`\`\`

Comentários em linha separada acima ficam fora do regex do Dependabot.

## Fix

Move o comentário de versão para inline. A partir do próximo bump automático, o label fica sempre coerente com a SHA — sem intervenção manual.

## Test plan

- [x] Diff visualmente correto
- [ ] Próximo bump do Dependabot (week +1) atualiza tanto SHA quanto label inline