### PR TITLE
release: v0.14.1 — drill-down audit não trava event loop (closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-04-28
+
+### Fixed
+- TUI: `Audit` tab drill-down (`s` key) no longer freezes the event loop while waiting for the Polkit password prompt. The `pkexec` call now runs in a background thread via `run_worker(thread=True)`, with an immediate placeholder ("Aguardando autorização...") shown to the user (closes [#45]).
+
 ## [0.14.0] - 2026-04-28
 
 ### Added
@@ -124,7 +129,8 @@ First stable release.
 - Pricing table validated against the official Anthropic table; Opus correctly priced 3× cheaper than the previous estimate.
 - Cost-band coloring across all views ([#6]).
 
-[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/mencoding/claude-dashboard/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/mencoding/claude-dashboard/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/mencoding/claude-dashboard/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/mencoding/claude-dashboard/compare/v0.12.0...v0.13.0
@@ -176,3 +182,4 @@ First stable release.
 [#34]: https://github.com/mencoding/claude-dashboard/pull/34
 [#33]: https://github.com/mencoding/claude-dashboard/issues/33
 [#41]: https://github.com/mencoding/claude-dashboard/pull/41
+[#45]: https://github.com/mencoding/claude-dashboard/issues/45

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.14.0"
+version = "0.14.1"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -11,6 +11,7 @@ import subprocess
 import time
 from collections import deque
 from pathlib import Path
+from typing import ClassVar
 
 from rich.console import Group
 from rich.panel import Panel
@@ -197,7 +198,7 @@ class DashboardApp(App):
     }
     """
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[Binding]] = [
         Binding("1", "show_tab('tab-now')", "Now"),
         Binding("2", "show_tab('tab-today')", "Today"),
         Binding("3", "show_tab('tab-tools')", "Tools"),

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -597,6 +597,10 @@ class DashboardApp(App):
         o log syslog que nao e legivel pelo usuario. Mostra resultado
         no painel #audit-detail. Erro amigavel se pkexec falhar — NAO
         fallback pra sudo no TTY (quebra TUI).
+
+        O subprocess roda em thread via `run_worker(thread=True)` para
+        nao bloquear o event loop do Textual durante o prompt do Polkit
+        (que pode levar varios segundos enquanto o usuario digita senha).
         """
         if not self._audit_active():
             return
@@ -617,6 +621,29 @@ class DashboardApp(App):
             )
             return
         session_id = visible[-1].session_id
+        # Placeholder imediato: usuario ve feedback enquanto Polkit pede
+        # senha. Sem isso, pareceria que a tecla `s` nao fez nada.
+        self._update_audit_detail(
+            Text(
+                f"Aguardando autorizacao (Polkit) para grep {session_id}...",
+                style="dim cyan",
+            ),
+        )
+        # `exclusive=True` cancela worker anterior se usuario apertar `s`
+        # de novo antes do primeiro terminar.
+        self.run_worker(
+            lambda: self._audit_drill_down_run(session_id),
+            thread=True,
+            exclusive=True,
+            name="audit-drill-down",
+        )
+
+    def _audit_drill_down_run(self, session_id: str) -> None:
+        """Worker thread: roda pkexec sem travar event loop.
+
+        Resultado enviado de volta ao painel via `call_from_thread`
+        (obrigatorio quando atualiza widget da thread principal).
+        """
         try:
             result = subprocess.run(
                 ["pkexec", "grep", session_id, AUDIT_SYSTEM_LOG],
@@ -630,30 +657,25 @@ class DashboardApp(App):
                     f"[bold]grep {session_id} {AUDIT_SYSTEM_LOG}[/bold]\n\n"
                     + (result.stdout or "(saida vazia)")
                 )
-                self._update_audit_detail(Text.from_markup(body))
+                content = Text.from_markup(body)
             else:
                 err = result.stderr.strip() or f"exit {result.returncode}"
-                self._update_audit_detail(
-                    Text(
-                        f"pkexec falhou: {err}\n\n"
-                        f"Rode manualmente: sudo grep {session_id} {AUDIT_SYSTEM_LOG}",
-                        style="yellow",
-                    ),
+                content = Text(
+                    f"pkexec falhou: {err}\n\n"
+                    f"Rode manualmente: sudo grep {session_id} {AUDIT_SYSTEM_LOG}",
+                    style="yellow",
                 )
         except FileNotFoundError:
-            self._update_audit_detail(
-                Text(
-                    "pkexec nao esta instalado. Instale Polkit ou rode manualmente:\n"
-                    f"sudo grep {session_id} {AUDIT_SYSTEM_LOG}",
-                    style="yellow",
-                ),
+            content = Text(
+                "pkexec nao esta instalado. Instale Polkit ou rode manualmente:\n"
+                f"sudo grep {session_id} {AUDIT_SYSTEM_LOG}",
+                style="yellow",
             )
         except subprocess.TimeoutExpired:
-            self._update_audit_detail(
-                Text("pkexec timeout (>10s). Tente novamente.", style="red"),
-            )
+            content = Text("pkexec timeout (>10s). Tente novamente.", style="red")
         except Exception as e:
-            self._update_audit_detail(Text(f"Erro: {e}", style="red"))
+            content = Text(f"Erro: {e}", style="red")
+        self.call_from_thread(self._update_audit_detail, content)
 
     def _update_audit_detail(self, content) -> None:
         with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary

Patch bump 0.14.0 → 0.14.1.

Refatora a action `s` da aba Audit para rodar `pkexec` em thread separada via `run_worker(thread=True)`. Resolve MAJOR-2 do code review da v0.14.0.

## Antes

```python
result = subprocess.run(["pkexec", ...], timeout=10)  # SÍNCRONO
```

Event loop do Textual trava enquanto Polkit pede senha (até 10s no pior caso).

## Depois

```python
self._update_audit_detail(Text("Aguardando autorizacao..."))  # placeholder imediato
self.run_worker(lambda: self._audit_drill_down_run(sid), thread=True, exclusive=True)
```

Worker em thread roda `subprocess.run`, callback via `call_from_thread` atualiza o painel quando termina. TUI permanece responsiva durante o prompt.

## Decisões

- **`thread=True`** ao invés de async coroutine — mais simples, `subprocess.run` em thread é seguro
- **`exclusive=True`** — se usuário apertar `s` de novo antes do primeiro terminar, cancela o anterior (evita acumular workers)
- **Placeholder imediato** — sem ele, parecia que `s` não fez nada durante o prompt do Polkit
- **Mesmo tratamento de erro** — `FileNotFoundError`, `TimeoutExpired`, generic — só agora o erro chega via `call_from_thread`

## Test plan

- [x] `pytest`: 287 passed + 1 skipped (sem regressão)
- [x] `ruff`: paridade com baseline (7)
- [ ] Validação manual pós-merge: pressionar `s` na aba Audit, navegar entre abas durante o prompt do Polkit — TUI deve responder

Closes #45