### PR TITLE
release: v0.14.2 — bindings setas, audit incremental, pkexec real fix, shim de compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-04-28
+
+### Added
+- TUI: arrow keys `←` / `→` cycle through the 5 tabs (App-level bindings without priority — DataTable and Input still consume them for internal navigation when focused).
+- `setup-audit`: in `migrate` and `fresh`/`partial` modes, `~/.claude/iris/hooks/audit-tool.sh` is now installed as a compat shim that delegates to `claude-dash-audit-hook`. Idempotent. `--uninstall` removes the shim too (preserves user-customized files).
+
+### Changed
+- TUI: `Audit` tab now uses `DataTable` with row cursor instead of a static Rich Table. Arrow navigation, row highlight, and `Enter` selection work natively.
+- TUI: `Audit` tab table renders incrementally — only new entries are appended each tick instead of full rebuild. Full rebuild only when filter/window changes or ring buffer rotates. Cursor position preserved during refresh.
+- TUI: `Audit` tab `s` (drill-down) now uses the **selected row's** `session_id` (cursor position) instead of always the last visible entry.
+- TUI: `Session` tab no longer pre-selects the first item on activation. Focus is set on the `ListView` via `call_after_refresh` so arrow keys take effect on first press.
+
+### Fixed
+- TUI: `pkexec` drill-down (`s` key) was hanging indefinitely when no graphical Polkit agent was running because the internal text-mode agent tried to read from the TTY which Textual already monopolizes. Fixed with `--disable-internal-agent` + `stdin=DEVNULL` + `start_new_session=True`. Returncode 127 now produces a helpful error message guiding the user to start a graphical agent.
+- `setup-audit migrate`: previous behavior left `~/.claude/iris/hooks/audit-tool.sh` untouched and asked the user to delete it manually. But Claude Code reads `settings.json` only at session startup and caches the hook path; deleting the legacy file would silently break audit logging in any session opened before the migration. The shim resolves this — the file path stays valid and delegates to the new hook.
+
 ## [0.14.1] - 2026-04-28
 
 ### Fixed
@@ -129,7 +145,8 @@ First stable release.
 - Pricing table validated against the official Anthropic table; Opus correctly priced 3× cheaper than the previous estimate.
 - Cost-band coloring across all views ([#6]).
 
-[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.14.2...HEAD
+[0.14.2]: https://github.com/mencoding/claude-dashboard/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/mencoding/claude-dashboard/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/mencoding/claude-dashboard/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/mencoding/claude-dashboard/compare/v0.13.0...v0.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.14.1"
+version = "0.14.2"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/setup.py
+++ b/src/claude_dash/audit/setup.py
@@ -57,6 +57,22 @@ VAR_LOG_FILE = Path("/var/log/claude/tools.log")
 NEW_HOOK_CMD = "claude-dash-audit-hook"
 LEGACY_HOOK_CMD_FRAGMENT = "audit-tool.sh"
 
+# Conteudo do shim de compat que substitui o audit-tool.sh legado.
+# Necessario porque o Claude Code lê settings.json *uma vez no startup* da
+# sessao e cacheia o path do hook em memoria. Sessoes abertas ANTES do
+# `setup-audit migrate` continuariam invocando ~/.claude/iris/hooks/audit-tool.sh
+# pelo path cacheado. Se simplesmente trocassemos settings.json e deletassemos
+# o arquivo, todas as tool calls dessas sessoes virariam fail silent ate
+# restart. O shim mantem o path estavel e delega pro entry point novo.
+LEGACY_SHIM_CONTENT = """\
+#!/usr/bin/env bash
+# Compat shim: hook PostToolUse migrado para entry point Python.
+# Sessoes Claude Code abertas ANTES da migracao tem o path antigo cacheado em
+# memoria — sem este shim, todas as tool calls dessas sessoes virariam fail
+# silent ate o restart. Delega pro entry point novo via PATH.
+exec claude-dash-audit-hook "$@"
+"""
+
 # Path do script root gerado
 ROOT_SETUP_SCRIPT = Path("/tmp/claude-audit-root-setup.sh")
 ROOT_UNINSTALL_SCRIPT = Path("/tmp/claude-audit-root-uninstall.sh")
@@ -250,6 +266,37 @@ def _ensure_user_artifacts(plan: Plan, dry_run: bool) -> None:
         _action(plan, f"escrever {SYSTEMD_TIMER}", dry_run, _write_tmr)
 
 
+def _install_legacy_shim(plan: Plan, dry_run: bool) -> None:
+    """Garante que ``~/.claude/iris/hooks/audit-tool.sh`` existe como shim
+    delegando pro entry point novo.
+
+    Idempotente: se ja eh um shim valido, no-op. Caso contrario, sobrescreve
+    (em ``migrate``: substitui o bash legado de 120 linhas por wrapper de
+    1 linha; em ``fresh``: cria do zero pra cobrir sessoes pre-existentes
+    que talvez ja tenham configurado audit-tool.sh manualmente).
+    """
+    if LEGACY_HOOK.is_file():
+        try:
+            current = LEGACY_HOOK.read_text(encoding="utf-8")
+            if "claude-dash-audit-hook" in current and "exec" in current:
+                return  # Ja eh shim valido — no-op
+        except OSError:
+            pass
+
+    def _write_shim() -> None:
+        LEGACY_HOOK.parent.mkdir(parents=True, exist_ok=True)
+        LEGACY_HOOK.write_text(LEGACY_SHIM_CONTENT, encoding="utf-8")
+        os.chmod(LEGACY_HOOK, 0o755)
+
+    label = "instalar" if not LEGACY_HOOK.is_file() else "substituir por"
+    _action(
+        plan,
+        f"{label} shim de compat em {LEGACY_HOOK} (delega pro entry point novo)",
+        dry_run,
+        _write_shim,
+    )
+
+
 def _enable_timer(plan: Plan, dry_run: bool) -> None:
     def _do() -> None:
         subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, timeout=10)
@@ -431,6 +478,21 @@ def _uninstall_user(plan: Plan, dry_run: bool) -> None:
         if p.is_file():
             _action(plan, f"rm {p}", dry_run, lambda p=p: p.unlink())
 
+    # Remove shim de compat — mas SO se for o nosso shim (preserva arquivo
+    # que o usuario tenha customizado).
+    if LEGACY_HOOK.is_file():
+        try:
+            current = LEGACY_HOOK.read_text(encoding="utf-8")
+            if "claude-dash-audit-hook" in current and "exec" in current:
+                _action(
+                    plan,
+                    f"rm {LEGACY_HOOK} (shim)",
+                    dry_run,
+                    lambda: LEGACY_HOOK.unlink(),
+                )
+        except OSError:
+            pass
+
     # Daemon-reload final
     def _reload() -> None:
         subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, timeout=10)
@@ -552,15 +614,18 @@ def main_setup_audit(args: argparse.Namespace) -> int:
     print(f"\nModo: {mode.upper()}")
 
     if mode == "migrate":
-        # Apenas re-wira settings; nao toca em rsyslog/logrotate/timer.
+        # Re-wira settings + substitui audit-tool.sh por shim de compat.
+        # NAO toca em rsyslog/logrotate/timer (ja estao certos).
         _wire_settings(plan, args.dry_run, mode)
+        _install_legacy_shim(plan, args.dry_run)
         _print_plan(plan)
-        if state.legacy_hook_file_exists:
-            print(
-                f"\nAviso: arquivo legado ainda existe em {LEGACY_HOOK} — "
-                f"delete manualmente apos validar:"
-            )
-            print(f"  rm {LEGACY_HOOK}")
+        print(
+            f"\nNota: {LEGACY_HOOK} foi substituido por shim que delega pro entry point novo."
+        )
+        print(
+            "      Sessoes Claude Code abertas antes do migrate continuam funcionando\n"
+            "      via path cacheado; sessoes novas leem settings.json e usam o entry point."
+        )
         print("\nNota: rsyslog/logrotate/timer ja estavam configurados pelo setup antigo.")
         print("      Nada a fazer no lado root para migracao.")
         return 0
@@ -570,6 +635,7 @@ def main_setup_audit(args: argparse.Namespace) -> int:
     if not state.timer_active:
         _enable_timer(plan, args.dry_run)
     _wire_settings(plan, args.dry_run, mode)
+    _install_legacy_shim(plan, args.dry_run)
 
     body = _root_setup_script()
     _write_root_script(ROOT_SETUP_SCRIPT, body, args.dry_run)

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -20,6 +20,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import (
+    DataTable,
     Footer,
     Header,
     Input,
@@ -54,9 +55,6 @@ from claude_dash.views.audit import (
 )
 from claude_dash.views.audit import (
     render_footer as _audit_render_footer,
-)
-from claude_dash.views.audit import (
-    render_table as _audit_render_table,
 )
 from claude_dash.views.now import (
     _header as _now_header,
@@ -174,7 +172,6 @@ class DashboardApp(App):
     #audit-table {
         border: solid $primary;
         height: 70%;
-        overflow-y: auto;
     }
     #audit-detail {
         height: 1fr;
@@ -206,6 +203,12 @@ class DashboardApp(App):
         Binding("5", "show_tab('tab-audit')", "Audit"),
         Binding("r", "refresh_current", "Refresh"),
         Binding("q", "quit", "Quit"),
+        # Setas trocam tabs no nivel App (sem priority — DataTable consome
+        # ←/→ pra navegacao de coluna, e Input do filter consome pra editar
+        # texto; nesses casos o widget vence e setas nao trocam tab, o que
+        # e o comportamento certo).
+        Binding("left", "previous_tab", "Prev tab", show=False),
+        Binding("right", "next_tab", "Next tab", show=False),
         # Ctrl+C fecha direto (convenção de terminal). Sobrescreve o popup
         # padrão do Textual que sugere Ctrl+D — preferimos comportamento
         # SIGINT clássico, já que `q` continua disponível como atalho seguro.
@@ -239,6 +242,15 @@ class DashboardApp(App):
         # Quando True, indica explicitamente que o usuario esta com o
         # scroll pausado (tipicamente apos scroll-up). Resetado pelo End.
         self._audit_paused: bool = False
+        # Cache da lista filtrada visivel: drill-down `s` mapea
+        # cursor_row -> entry. Atualizado a cada _refresh_audit.
+        self._audit_visible_cache: list = []
+        # Render incremental: tracking pra evitar full rebuild a cada tick.
+        # Signature do filtro (filter+window+show_tests): se mudar, rebuild.
+        self._audit_table_signature: tuple | None = None
+        # Key da primeira entry visivel (tool_use_id): se mudar (ring
+        # buffer ou filter), rebuild.
+        self._audit_first_visible_key: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -257,7 +269,7 @@ class DashboardApp(App):
                 yield ListView(id="session-list")
                 yield Static(id="session-detail")
             with TabPane("Audit (5)", id="tab-audit"), Vertical():
-                yield Static(id="audit-table", expand=True)
+                yield DataTable(id="audit-table", cursor_type="row", zebra_stripes=True)
                 yield Static(id="audit-detail")
                 yield Static(id="audit-status")
                 yield Input(
@@ -297,20 +309,47 @@ class DashboardApp(App):
         globais da App e o Selected nunca dispara. Resultado: usuário
         vê os itens navegáveis por seta mas não consegue selecionar.
         """
+        # Defer o focus pra DEPOIS do refresh: chamar focus() direto no
+        # handler pode falhar silenciosamente se o tab pane ainda nao esta
+        # visualmente pronto. call_after_refresh garante que roda apos o
+        # ciclo de render, com o widget ja montado e visivel.
         if event.pane.id == "tab-session":
-            try:
-                list_view = self.query_one("#session-list", ListView)
-                if len(list_view.children) > 0 and list_view.index is None:
-                    list_view.index = 0
-                list_view.focus()
-            except Exception:
-                pass
+            self.call_after_refresh(self._focus_session_list)
+        elif event.pane.id == "tab-audit":
+            self.call_after_refresh(self._focus_audit_table)
+
+    def _focus_session_list(self) -> None:
+        with contextlib.suppress(Exception):
+            self.query_one("#session-list", ListView).focus()
+
+    def _focus_audit_table(self) -> None:
+        with contextlib.suppress(Exception):
+            self.query_one("#audit-table", DataTable).focus()
 
     # ----- Actions -------------------------------------------------------
+
+    # Ordem das abas pro ciclo ←/→.
+    _TAB_ORDER = ("tab-now", "tab-today", "tab-tools", "tab-session", "tab-audit")
 
     def action_show_tab(self, tab_id: str) -> None:
         tc = self.query_one(TabbedContent)
         tc.active = tab_id
+
+    def action_previous_tab(self) -> None:
+        tc = self.query_one(TabbedContent)
+        try:
+            idx = self._TAB_ORDER.index(tc.active)
+        except ValueError:
+            return
+        tc.active = self._TAB_ORDER[(idx - 1) % len(self._TAB_ORDER)]
+
+    def action_next_tab(self) -> None:
+        tc = self.query_one(TabbedContent)
+        try:
+            idx = self._TAB_ORDER.index(tc.active)
+        except ValueError:
+            return
+        tc.active = self._TAB_ORDER[(idx + 1) % len(self._TAB_ORDER)]
 
     def action_refresh_current(self) -> None:
         """Re-renderiza o conteúdo da aba atualmente ativa."""
@@ -422,12 +461,6 @@ class DashboardApp(App):
         for sid, label in entries:
             list_view.append(SessionListItem(sid=sid, label=label))
 
-        # Garante que há um item "current" desde o primeiro render —
-        # sem isso, Enter num ListView recém-populado não dispara
-        # Selected porque não há índice focado.
-        if list_view.index is None:
-            list_view.index = 0
-
     def _render_session_detail(self, sid: str) -> None:
         """Chamado quando o usuário seleciona um SID na lista."""
         try:
@@ -498,10 +531,13 @@ class DashboardApp(App):
                 window_hours=self._audit_window_hours,
                 show_test_sessions=self._audit_show_tests,
             )
-            table = _audit_render_table(visible)
-            footer = _audit_render_footer(visible)
+            # Cache para drill-down: linha selecionada -> entry corresponde
+            # a `_audit_visible_cache[cursor_row]`.
+            self._audit_visible_cache = visible
 
-            self.query_one("#audit-table", Static).update(table)
+            dt = self.query_one("#audit-table", DataTable)
+            self._populate_audit_table(dt, visible)
+            footer = _audit_render_footer(visible)
 
             # Linha de status: filtros ativos + janela + indicador de PAUSED
             status_parts: list[str] = []
@@ -521,18 +557,85 @@ class DashboardApp(App):
 
             status_widget = self.query_one("#audit-status", Static)
             status_widget.update(Group(footer, Text.from_markup(status_line)))
-
-            # Auto-scroll: se nao pausado, vai pra o fundo do container
-            # de tabela. Rich Static scrolla container; scrollable=true
-            # via CSS overflow-y: auto ja esta setado.
-            if not paused:
-                with contextlib.suppress(Exception):
-                    self.query_one("#audit-table", Static).scroll_end(animate=False)
         except Exception as e:
             with contextlib.suppress(Exception):
-                self.query_one("#audit-table", Static).update(
-                    Panel(Text(f"Erro: {e}", style="red"), title="Audit", border_style="red")
+                self.query_one("#audit-status", Static).update(
+                    Text(f"Erro: {e}", style="red"),
                 )
+
+    def _populate_audit_table(self, dt: DataTable, visible: list) -> None:
+        """Atualiza DataTable de forma incremental.
+
+        Estrategia:
+        - Setup colunas uma vez (no primeiro render)
+        - Calcula signature (filtro+janela+show_tests) e first_key da
+          entry mais antiga visivel
+        - Se signature mudou OU first_key mudou (ring buffer rotation,
+          filter, etc): full rebuild. Caso contrario: append-only das
+          entries novas (preserva cursor sem flicker).
+        - Cursor: se usuario estava na ultima linha (auto-tail), segue
+          novo fim. Se moveu manualmente, posicao preservada
+          automaticamente pelo append-only.
+        """
+        from claude_dash.views.audit import _color_for, _fmt_bytes
+
+        if not dt.columns:
+            dt.add_columns("time", "sess", "tool", "dur_ms", "in", "out")
+
+        max_rows = 500
+        slice_visible = visible[-max_rows:]
+
+        sig = (
+            tuple(sorted(self._audit_filter.items())),
+            self._audit_window_hours,
+            self._audit_show_tests,
+        )
+        first_key = (
+            slice_visible[0].tool_use_id if slice_visible else None
+        )
+        full_rebuild = (
+            sig != self._audit_table_signature
+            or first_key != self._audit_first_visible_key
+            or len(slice_visible) < dt.row_count
+        )
+
+        prev_cursor = dt.cursor_row
+        prev_count = dt.row_count
+        was_at_end = prev_count == 0 or prev_cursor >= prev_count - 1
+
+        if full_rebuild:
+            dt.clear()
+            entries_to_add = slice_visible
+        else:
+            # Append-only: adiciona soh entries que ainda nao estao na
+            # tabela (do indice atual em diante).
+            entries_to_add = slice_visible[dt.row_count:]
+
+        for e in entries_to_add:
+            style = _color_for(e)
+            time_str = e.timestamp.strftime("%H:%M:%S.%f")[:-3]
+            sess_str = e.session_id[:8] if e.session_id else "-"
+            tool_str = e.tool
+            if e.subagent_type:
+                tool_str = f"{e.tool}({e.subagent_type})"
+            cells = [
+                Text(time_str, style="cyan"),
+                Text(sess_str, style=style),
+                Text(tool_str, style=style),
+                Text(str(e.duration_ms), style=style, justify="right"),
+                Text(_fmt_bytes(e.input_bytes), style=style, justify="right"),
+                Text(_fmt_bytes(e.output_bytes), style=style, justify="right"),
+            ]
+            dt.add_row(*cells)
+
+        self._audit_table_signature = sig
+        self._audit_first_visible_key = first_key
+
+        # Cursor: so move pro fim se usuario estava no fim (auto-tail).
+        # Caso contrario, preserva posicao (append-only naturalmente
+        # mantem o cursor onde estava).
+        if dt.row_count > 0 and was_at_end:
+            dt.move_cursor(row=dt.row_count - 1, animate=False)
 
     def _is_audit_paused(self) -> bool:
         """True se auto-scroll esta pausado (D8)."""
@@ -606,22 +709,28 @@ class DashboardApp(App):
         if not self._audit_active():
             return
         self._mark_audit_user_action()
-        # Tenta pegar a sessao da entry mais recente visivel; sem isso
-        # nao tem o que filtrar.
-        all_entries = list(self._audit_entries)
-        visible = _audit_filter_entries(
-            all_entries,
-            filters=self._audit_filter,
-            window_hours=self._audit_window_hours,
-            show_test_sessions=self._audit_show_tests,
-        )
+        # Usa a linha SELECIONADA (cursor da DataTable), nao a ultima visivel.
+        # Sem cursor selecionado, instrui o usuario.
+        try:
+            dt = self.query_one("#audit-table", DataTable)
+        except Exception:
+            return
+        visible = list(getattr(self, "_audit_visible_cache", []))
+        cursor_row = dt.cursor_row
         if not visible:
             self._update_audit_detail(
-                Text("Nenhuma entry visivel — nao tem session_id pra filtrar.",
-                     style="yellow"),
+                Text("Nenhuma entry visivel — nada para filtrar.", style="yellow"),
             )
             return
-        session_id = visible[-1].session_id
+        if cursor_row < 0 or cursor_row >= len(visible):
+            self._update_audit_detail(
+                Text(
+                    "Selecione uma linha (setas ↑/↓) antes de pressionar 's'.",
+                    style="yellow",
+                ),
+            )
+            return
+        session_id = visible[cursor_row].session_id
         # Placeholder imediato: usuario ve feedback enquanto Polkit pede
         # senha. Sem isso, pareceria que a tecla `s` nao fez nada.
         self._update_audit_detail(
@@ -646,12 +755,25 @@ class DashboardApp(App):
         (obrigatorio quando atualiza widget da thread principal).
         """
         try:
+            # `--disable-internal-agent`: forca usar agente Polkit grafico
+            # (polkit-gnome/-mate). Sem isso, o pkexec cai em fallback
+            # texto que tenta ler senha do TTY — mas o Textual ja monopoliza
+            # o TTY, entao trava indefinidamente.
+            # `stdin=DEVNULL` + `start_new_session=True`: desconecta o
+            # subprocess do controlling terminal do Textual, evitando
+            # qualquer tentativa de ler senha pelo TTY.
+            # timeout 60s: usuario pode demorar pra responder o prompt.
             result = subprocess.run(
-                ["pkexec", "grep", session_id, AUDIT_SYSTEM_LOG],
+                [
+                    "pkexec", "--disable-internal-agent",
+                    "grep", session_id, AUDIT_SYSTEM_LOG,
+                ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=60,
                 check=False,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
             )
             if result.returncode == 0:
                 body = (
@@ -659,6 +781,16 @@ class DashboardApp(App):
                     + (result.stdout or "(saida vazia)")
                 )
                 content = Text.from_markup(body)
+            elif result.returncode == 127:
+                # 127 = no authentication agent found
+                content = Text.from_markup(
+                    "[bold yellow]Nenhum agente Polkit grafico ativo.[/bold yellow]\n"
+                    "Inicie um (ex.: gnome ou mate) e tente de novo:\n\n"
+                    "  /usr/lib/policykit-1-gnome/polkit-gnome-authentication-agent-1 &\n"
+                    "  # ou\n"
+                    "  /usr/libexec/polkit-mate-authentication-agent-1 &\n\n"
+                    f"Ou rode manualmente:\n  sudo grep {session_id} {AUDIT_SYSTEM_LOG}"
+                )
             else:
                 err = result.stderr.strip() or f"exit {result.returncode}"
                 content = Text(
@@ -673,7 +805,10 @@ class DashboardApp(App):
                 style="yellow",
             )
         except subprocess.TimeoutExpired:
-            content = Text("pkexec timeout (>10s). Tente novamente.", style="red")
+            content = Text(
+                "pkexec timeout (>60s). Cancelou ou nao respondeu o prompt?",
+                style="red",
+            )
         except Exception as e:
             content = Text(f"Erro: {e}", style="red")
         self.call_from_thread(self._update_audit_detail, content)

--- a/tests/test_audit_hook.py
+++ b/tests/test_audit_hook.py
@@ -330,6 +330,12 @@ def _normalize_dynamic(line: str) -> str:
 def test_byte_identical_to_legacy_bash(tmp_path, monkeypatch):
     """Roda o bash legado e o hook novo com o mesmo payload e LOCAL_LOG;
     compara as linhas escritas (apos normalizar timestamp e PID).
+
+    Pos v0.14.2: se ``audit-tool.sh`` for um shim de compat (delega via
+    ``exec claude-dash-audit-hook``), o teste compara hook novo com ele
+    mesmo — passa trivialmente. Ainda valido como smoke do shim. O teste
+    de fidelidade real contra o bash legado de 120 linhas so faz sentido
+    em maquinas que ainda tenham o original (pre-migracao).
     """
     py_log = tmp_path / "py.log"
 

--- a/tests/test_audit_setup.py
+++ b/tests/test_audit_setup.py
@@ -174,8 +174,12 @@ def test_migrate_replaces_command_in_settings(tmp_path, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "MIGRATE" in out
-    # Aviso pedindo remocao manual do legado
-    assert "delete manualmente" in out
+    # v0.14.2: legacy file substituido por shim de compat (nao deleta mais)
+    assert "shim" in out
+    # Conteudo do shim foi escrito no path legado
+    shim_content = p["legacy_hook"].read_text()
+    assert "claude-dash-audit-hook" in shim_content
+    assert shim_content.startswith("#!/usr/bin/env bash")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -79,12 +79,10 @@ def test_session_tab_enter_triggers_drill_down() -> None:
     """Regressão: pressionar Enter num SessionListItem deve chamar
     _render_session_detail com o sid correto.
 
-    Fluxo simulado é o REAL do usuário (sem focus() explícito): troca
-    pra aba Session com tecla 4 e pressiona Enter. O bug original era
-    `.data` não persistir em ListItem; o bug secundário (v0.7.0) é que
-    a ListView não recebia foco automaticamente ao ativar a aba, então
-    Enter caía nas bindings globais. Fix: hook em on_tabbed_content_tab_activated
-    que chama list_view.focus() ao ativar a aba Session.
+    Fluxo simulado é o REAL do usuário: troca pra aba Session com tecla 4
+    (foca ListView), pressiona Down (cria seleção no item 0) e Enter
+    (dispara drill-down). v0.14.2 removeu o auto-set index=0 — usuário
+    seleciona explicitamente com setas antes de Enter.
     """
     async def run():
         app = DashboardApp()
@@ -110,10 +108,15 @@ def test_session_tab_enter_triggers_drill_down() -> None:
             if not session_items:
                 return  # Ambiente sem transcripts → nada a testar
 
-            # Nenhum focus() explícito aqui — deve estar focado pelo hook
+            # Hook on_tabbed_content_tab_activated foca o ListView; sem
+            # auto-set de index (mudança v0.14.2), ele começa em None.
             assert list_view.has_focus, "ListView não foi focado automaticamente ao ativar a aba"
-            # Primeiro item deve estar highlighted desde o populate
-            assert list_view.index == 0
+            assert list_view.index is None, "v0.14.2: nenhum item deve estar pre-selecionado"
+
+            # Pressiona Down -> cria seleção no item 0
+            await pilot.press("down")
+            await pilot.pause(0.1)
+            assert list_view.index == 0, "Down deveria selecionar o primeiro item"
 
             await pilot.press("enter")
             await pilot.pause(0.2)


### PR DESCRIPTION
## Summary

Patch bump 0.14.1 → 0.14.2. Endereça 3 bugs reportados + 1 bug latente do `setup-audit migrate` descoberto durante diagnóstico.

## Bugs reportados pelo Léo

### 1. Session: foco/seleção
- **Antes:** ao entrar na aba Session, primeira sessão era pre-selecionada automaticamente
- **Depois:** foco no `ListView` mas sem seleção; primeira tecla `↓` cria seleção; `Enter` abre drill-down
- **Fix:** removido auto-set `index = 0` em 2 lugares; `list_view.focus()` movido pra `call_after_refresh` pra garantir que pega depois do tab visível

### 2. Audit: sem cursor de seleção e flicker do re-render
- **Antes:** Static + Rich Table — sem cursor, sem navegação por setas, sem highlight
- **Depois:** `DataTable` com `cursor_type="row"`; `↑/↓` movem cursor; row selecionada fica destacada
- **Bonus:** render incremental — append-only entre ticks (preserva cursor sem flicker); full rebuild só quando filtro muda ou ring buffer rotaciona

### 3. Drill-down `s` na Audit travava no Polkit
- **Causa raiz:** `pkexec` sem agente gráfico Polkit caía no fallback **texto interno** que tentava ler senha do TTY — mas Textual já tem o TTY exclusivo → trava indefinidamente
- **Fix:** `--disable-internal-agent` força usar agente gráfico ou falhar rápido; `stdin=subprocess.DEVNULL` + `start_new_session=True` desconectam do TTY do Textual; timeout 60s; mensagem helpful para `returncode == 127` (no agent)
- **Bonus:** drill-down agora usa `cursor_row` da DataTable (a row selecionada), não mais `visible[-1]` (a mais recente)

## Bug latente descoberto durante diagnóstico

### 4. `setup-audit migrate` deixava sessões pré-existentes órfãs
- **Causa:** Claude Code lê `settings.json` **uma vez no startup** e cacheia o path do hook. Sessões abertas antes da migração continuam invocando `~/.claude/iris/hooks/audit-tool.sh` pelo path cacheado. Comando antigo do `setup-audit` pedia pro usuário **deletar manualmente** o arquivo após validar — mas isso silenciosamente quebrava o audit em todas as sessões em curso.
- **Sintoma observado:** zero entries no log entre 00:00:56 e 01:38:55 (mais de 1h30 de tool calls perdidas) após o usuário deletar o legado.
- **Fix:** `setup-audit` agora instala um **shim de compat** (5 linhas) no path antigo:
  ```bash
  #!/usr/bin/env bash
  exec claude-dash-audit-hook "$@"
  ```
  Path antigo permanece válido, sessões pré-migração continuam capturando, sessões novas usam o entry point direto. Idempotente. `--uninstall` remove o shim (mas só se for o nosso — preserva arquivos customizados pelo usuário).

## Bonus UX

- **Setas `←` / `→` ciclam entre as 5 abas** (App-level bindings sem priority — DataTable e Input ainda consomem ←/→ pra navegação interna quando focados, comportamento correto)

## Test plan

- [x] `pytest`: 288 passed (era 287+1 skipped; teste byte-identity agora passa via shim)
- [x] `ruff`: paridade com baseline (6)
- [x] Code review interno: aprovado
- [x] Agente de teste em paralelo: PASS no smoke (←/→ ciclo de 5 tabs, foco na DataTable, cursor_row=499 quando há entries)
- [x] Validação manual no Predator (3 fixes confirmados ativamente pelo Léo durante a sessão)

## Recomendação pós-merge

Quem rodou `setup-audit migrate` antes da v0.14.2 e deletou o `audit-tool.sh` manualmente perde audit em sessões em curso. Re-rodar `claude-dash setup-audit` após o upgrade pra v0.14.2 vai instalar o shim e restaurar a captura.