### PR TITLE
release: v0.14.4 — audit drill-down filtra por tool_use_id, cache alinhado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.14.3] - 2026-04-28
+## [0.14.4] - 2026-04-28
+
+### Fixed
+- TUI: `Audit` tab drill-down (`s` key) was filtering by `session_id`, so all rows of the same session showed identical content (looked like "nothing changed" when moving the cursor between Bash/Edit/Read of the same session). Now filters by `tool_use_id` (unique per call) — each row drills into its specific entry. Header gained `HH:MM:SS tool` context. Falls back to `session_id` for legacy entries (e.g., Agent calls without `tool_use_id`).
+- TUI: `_audit_visible_cache` now stores the same slice that's rendered in the `DataTable` (last `AUDIT_TABLE_MAX_ROWS=500` entries) instead of the full filtered list. Previously, `cursor_row` (a DataTable index) was used to index into the full list, picking the wrong entry whenever the filter produced more than 500 results.
+
+### Changed
+- Added `AUDIT_TABLE_MAX_ROWS = 500` constant (was hardcoded inline in `_populate_audit_table`).
 
 ### Changed
 - TUI: `Audit` tab drill-down (`s` key) now reads `/var/log/claude/tools.log` directly instead of going through `pkexec`. The log file is `0640` with group `adm`, and users on Debian-family systems are typically in that group already, so direct read works without any password prompt. Falls back to a helpful message suggesting `sudo usermod -aG adm $USER` for users not in the group. No more Polkit dependency, no more hangs, no more password prompts.
@@ -151,7 +158,8 @@ First stable release.
 - Pricing table validated against the official Anthropic table; Opus correctly priced 3× cheaper than the previous estimate.
 - Cost-band coloring across all views ([#6]).
 
-[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.14.3...HEAD
+[Unreleased]: https://github.com/mencoding/claude-dashboard/compare/v0.14.4...HEAD
+[0.14.4]: https://github.com/mencoding/claude-dashboard/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/mencoding/claude-dashboard/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/mencoding/claude-dashboard/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/mencoding/claude-dashboard/compare/v0.14.0...v0.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.14.3"
+version = "0.14.4"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -117,6 +117,9 @@ NOW_REFRESH_SEC = 2.0
 AUDIT_REFRESH_SEC = 1.0
 # Cap do ring buffer in-memory de entries do audit
 AUDIT_BUFFER_MAX = 10_000
+# Cap de linhas exibidas na DataTable da aba Audit (cursor mapeia 1:1
+# nesse slice; cache de drill-down precisa estar alinhado).
+AUDIT_TABLE_MAX_ROWS = 500
 # Janelas temporais ciclicas (D1). None = "all".
 AUDIT_WINDOW_CYCLE: tuple[float | None, ...] = (1.0, 24.0, 24.0 * 7, None)
 # Path do audit log (mantem em sync com audit/hook.py).
@@ -530,12 +533,16 @@ class DashboardApp(App):
                 window_hours=self._audit_window_hours,
                 show_test_sessions=self._audit_show_tests,
             )
-            # Cache para drill-down: linha selecionada -> entry corresponde
-            # a `_audit_visible_cache[cursor_row]`.
-            self._audit_visible_cache = visible
+            # Slice EXATO do que vai aparecer na DataTable. Cache armazena
+            # esse slice (NAO a lista cheia) — sem isso, cursor_row da
+            # DataTable nao bate com o indice no cache quando filter
+            # produz mais que AUDIT_TABLE_MAX_ROWS entries (drill-down
+            # selecionaria entry errada — bug v0.14.3).
+            slice_visible = visible[-AUDIT_TABLE_MAX_ROWS:]
+            self._audit_visible_cache = slice_visible
 
             dt = self.query_one("#audit-table", DataTable)
-            self._populate_audit_table(dt, visible)
+            self._populate_audit_table(dt, slice_visible)
             footer = _audit_render_footer(visible)
 
             # Linha de status: filtros ativos + janela + indicador de PAUSED
@@ -581,8 +588,9 @@ class DashboardApp(App):
         if not dt.columns:
             dt.add_columns("time", "sess", "tool", "dur_ms", "in", "out")
 
-        max_rows = 500
-        slice_visible = visible[-max_rows:]
+        # `visible` ja vem capeado pelo chamador (_refresh_audit) em
+        # AUDIT_TABLE_MAX_ROWS. Nao re-slicear pra manter cache alinhado.
+        slice_visible = visible
 
         sig = (
             tuple(sorted(self._audit_filter.items())),
@@ -719,12 +727,14 @@ class DashboardApp(App):
             return
         visible = list(getattr(self, "_audit_visible_cache", []))
         cursor_row = dt.cursor_row
-        if not visible:
+        if not visible or dt.row_count == 0:
             self._update_audit_detail(
                 Text("Nenhuma entry visivel — nada para filtrar.", style="yellow"),
             )
             return
-        if cursor_row < 0 or cursor_row >= len(visible):
+        # Cache deve estar alinhado com a DataTable (ambos sao o mesmo
+        # slice em _refresh_audit). Validar igualdade defensiva.
+        if cursor_row < 0 or cursor_row >= dt.row_count:
             self._update_audit_detail(
                 Text(
                     "Selecione uma linha (setas ↑/↓) antes de pressionar 's'.",
@@ -732,13 +742,26 @@ class DashboardApp(App):
                 ),
             )
             return
-        session_id = visible[cursor_row].session_id
+        if cursor_row >= len(visible):
+            self._update_audit_detail(
+                Text(
+                    "Cache desalinhado com tabela — espera proximo refresh (1s).",
+                    style="yellow",
+                ),
+            )
+            return
+        entry = visible[cursor_row]
+        # Filtra por tool_use_id (unico por chamada) — cada row mostra a
+        # SUA entry especifica. Filtrar por session_id mostraria sempre
+        # o mesmo conteudo pra rows da mesma sessao (bug v0.14.3).
+        # Fallback: algumas entries antigas (Agent sem tool_use_id) usam
+        # session_id como chave de busca, com aviso.
+        filter_key = entry.tool_use_id or entry.session_id
+        filter_label = "tool_use_id" if entry.tool_use_id else "session"
 
-        # Cap em 50 ultimas linhas pra nao sobrecarregar o painel.
-        max_lines = 50
         try:
             with open(AUDIT_SYSTEM_LOG, encoding="utf-8", errors="replace") as f:
-                matching = [line for line in f if session_id in line]
+                matching = [line for line in f if filter_key in line]
         except FileNotFoundError:
             self._update_audit_detail(
                 Text(
@@ -752,7 +775,7 @@ class DashboardApp(App):
                 "[bold yellow]Sem permissao pra ler /var/log/claude/tools.log[/bold yellow]\n"
                 "Adicione seu usuario ao grupo `adm` (re-login depois):\n\n"
                 "  sudo usermod -aG adm $USER\n\n"
-                f"Ou leia manualmente como root:\n  sudo grep {session_id} {AUDIT_SYSTEM_LOG}"
+                f"Ou leia manualmente como root:\n  sudo grep {filter_key} {AUDIT_SYSTEM_LOG}"
             ))
             return
         except Exception as e:
@@ -762,17 +785,25 @@ class DashboardApp(App):
         if not matching:
             self._update_audit_detail(
                 Text(
-                    f"Nenhuma entry para session={session_id} em {AUDIT_SYSTEM_LOG}.",
+                    f"Nenhuma entry para {filter_label}={filter_key} em {AUDIT_SYSTEM_LOG}.",
                     style="dim",
                 ),
             )
             return
 
+        # Cap em 50 ultimas linhas pra nao sobrecarregar (relevante so pro
+        # fallback session_id; tool_use_id deve dar 1 linha so).
+        max_lines = 50
         truncated = len(matching) > max_lines
         shown = matching[-max_lines:]
+        # Header informa qual chave foi usada e o contexto da entry.
+        ts = entry.timestamp.strftime("%H:%M:%S")
         header = (
-            f"[bold]grep {session_id} {AUDIT_SYSTEM_LOG}[/bold]  "
-            f"({len(matching)} linhas{', ultimas ' + str(max_lines) if truncated else ''})\n\n"
+            f"[bold]{ts} {entry.tool}[/bold]  "
+            f"[dim]session={entry.session_id[:8]}…[/dim]\n"
+            f"[bold]grep {filter_key} {AUDIT_SYSTEM_LOG}[/bold]  "
+            f"({len(matching)} linhas"
+            f"{', ultimas ' + str(max_lines) if truncated else ''})\n\n"
         )
         # Text.from_markup interpretaria colchetes do log como markup;
         # constrói Text manual: header em markup, body como texto plano.


### PR DESCRIPTION
## Summary

Patch bump 0.14.3 → 0.14.4.

## Bugs

### 1. Drill-down filtrava por `session_id`

Todas as rows da mesma sessão (Bash, Edit, Read, etc.) drillavam pra mesma coisa — o output não mudava ao mover cursor. Sintoma reportado: "selecionei row 02:08 Read mas o painel mostrou 23:54 Bash".

**Fix:** filtrar por `tool_use_id` (único por chamada). Cada row → entry específica daquela tool call.

Fallback: se `entry.tool_use_id` é vazio (algumas Agent calls antigas), usa `session_id` com label informativo.

### 2. Cache desalinhado com DataTable

`_audit_visible_cache` armazenava a lista filtrada inteira (potencialmente milhares), mas `DataTable` só renderiza as últimas 500. `cursor_row` (índice na DataTable) era usado pra indexar o cache cheio → pegava entry errada.

Exemplo concreto: 800 entries filtradas, 500 na tela. Cursor na row 5 → cache pegava `visible[5]` (entry MUITO antiga) em vez de `visible[305]` (a real exibida na row 5).

**Fix:** cache armazena o mesmo slice exibido (`visible[-AUDIT_TABLE_MAX_ROWS:]`).

## Outras mudanças

- Constante `AUDIT_TABLE_MAX_ROWS = 500` (era hardcoded inline)
- Header do drill-down ganhou contexto: `HH:MM:SS tool session=xxxxxx…`
- Validação defensiva extra: se cache estiver desalinhado, mensagem helpful em vez de IndexError

## Test plan

- [x] `pytest`: 288 passed
- [x] `ruff`: paridade com baseline (6)
- [x] Validação manual: row de 02:08 Read drilla pra entry específica daquele tool_use_id (não mais a Bash de 23:54)