### PR TITLE
feat(audit): tecla `e` pra export CSV/JSON + fix shim no modo installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.5] - 2026-04-28
+
+### Added
+- TUI: `Audit` tab gained an `e` key for export. Opens an inline prompt for an output path; empty path defaults to `~/audit-export-<ts>.csv`. Path extension picks format (`.json` → JSON, otherwise CSV). Schema is the same for both formats: `timestamp, hostname, session_id, tool, subagent_type, tool_use_id, status, duration_ms, perm_mode, input_sha, input_bytes, output_bytes, pid`. Writes are atomic via `<path>.tmp` + `os.replace`. Closes #36.
+
+### Fixed
+- `claude-dash setup-audit` in `installed` mode no longer prints the contradictory "delete `audit-tool.sh` manually" warning when the legacy file is already the compat shim installed by v0.14.2 (PR #48). It now detects the shim via the `exec claude-dash-audit-hook` marker and stays silent. If a real legacy bash script is still in place under an otherwise `installed` state, the command auto-installs the shim instead of just complaining. Closes #49.
+
 ## [0.14.4] - 2026-04-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.14.4"
+version = "0.14.5"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/setup.py
+++ b/src/claude_dash/audit/setup.py
@@ -266,6 +266,23 @@ def _ensure_user_artifacts(plan: Plan, dry_run: bool) -> None:
         _action(plan, f"escrever {SYSTEMD_TIMER}", dry_run, _write_tmr)
 
 
+def _is_compat_shim(path: Path) -> bool:
+    """True se ``path`` ja e' o shim de compat (vs bash legado de 120 linhas).
+
+    Detecta pelo marcador ``exec claude-dash-audit-hook``. Usado por:
+    - ``_install_legacy_shim`` pra short-circuit no caso ja-instalado.
+    - Modo ``installed`` pra decidir entre silenciar o aviso (shim correto)
+      ou re-instalar o shim (bash legado ainda presente).
+    """
+    if not path.is_file():
+        return False
+    try:
+        current = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "claude-dash-audit-hook" in current and "exec" in current
+
+
 def _install_legacy_shim(plan: Plan, dry_run: bool) -> None:
     """Garante que ``~/.claude/iris/hooks/audit-tool.sh`` existe como shim
     delegando pro entry point novo.
@@ -275,13 +292,8 @@ def _install_legacy_shim(plan: Plan, dry_run: bool) -> None:
     1 linha; em ``fresh``: cria do zero pra cobrir sessoes pre-existentes
     que talvez ja tenham configurado audit-tool.sh manualmente).
     """
-    if LEGACY_HOOK.is_file():
-        try:
-            current = LEGACY_HOOK.read_text(encoding="utf-8")
-            if "claude-dash-audit-hook" in current and "exec" in current:
-                return  # Ja eh shim valido — no-op
-        except OSError:
-            pass
+    if _is_compat_shim(LEGACY_HOOK):
+        return
 
     def _write_shim() -> None:
         LEGACY_HOOK.parent.mkdir(parents=True, exist_ok=True)
@@ -603,12 +615,14 @@ def main_setup_audit(args: argparse.Namespace) -> int:
         return 0
 
     if mode == "installed":
+        if state.legacy_hook_file_exists and not _is_compat_shim(LEGACY_HOOK):
+            # Bash legado ainda presente (sessoes pre-migrate). Re-instala
+            # shim pra delegar pro entry point novo. Resto do estado ja OK.
+            print("\nModo: INSTALLED (com bash legado — instalando shim)")
+            _install_legacy_shim(plan, args.dry_run)
+            _print_plan(plan)
+            return 0
         print("\nTudo OK — nada a fazer.")
-        if state.legacy_hook_file_exists:
-            print(
-                f"\nAviso: arquivo legado ainda existe em {LEGACY_HOOK} — "
-                f"delete manualmente apos validar."
-            )
         return 0
 
     print(f"\nModo: {mode.upper()}")

--- a/src/claude_dash/views/audit.py
+++ b/src/claude_dash/views/audit.py
@@ -12,14 +12,41 @@ Color scheme (D2):
 """
 from __future__ import annotations
 
+import csv
+import json
+import os
 import re
 from collections import Counter
+from dataclasses import asdict
 from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Literal
 
 from rich.table import Table
 from rich.text import Text
 
 from claude_dash.audit.models import AuditEntry
+
+ExportFormat = Literal["csv", "json"]
+
+# Ordem dos campos no export — fixa pra reprodutibilidade do CSV.
+# Mantem em sync com AuditEntry; mudancas aqui devem refletir tambem em
+# tests/test_audit_view.py::test_export_csv_schema.
+_EXPORT_FIELDS: tuple[str, ...] = (
+    "timestamp",
+    "hostname",
+    "session_id",
+    "tool",
+    "subagent_type",
+    "tool_use_id",
+    "status",
+    "duration_ms",
+    "perm_mode",
+    "input_sha",
+    "input_bytes",
+    "output_bytes",
+    "pid",
+)
 
 # Sessao de teste = qualquer session_id que nao seja UUID v4 valido.
 # Mantemos hide-by-default por que o hook foi exercitado com fixtures
@@ -176,6 +203,56 @@ def render_footer(entries: list[AuditEntry]) -> Text:
     txt.append(f"top: {top3_str}  ")
     txt.append(f"err={errors} ({err_pct:.1f}%)", style=err_style)
     return txt
+
+
+def _entry_to_row(e: AuditEntry) -> dict[str, str | int | None]:
+    """Converte AuditEntry pro shape exportavel (timestamp em ISO 8601)."""
+    d = asdict(e)
+    d["timestamp"] = e.timestamp.isoformat()
+    return {k: d[k] for k in _EXPORT_FIELDS}
+
+
+def default_export_path(fmt: ExportFormat, now: datetime | None = None) -> Path:
+    """Path default `~/audit-export-<ts>.<ext>` com timestamp ISO local."""
+    if now is None:
+        now = datetime.now()
+    # ISO compacto sem microssegundos: 2026-04-28T143052
+    ts = now.strftime("%Y-%m-%dT%H%M%S")
+    return Path.home() / f"audit-export-{ts}.{fmt}"
+
+
+def export_entries(
+    entries: list[AuditEntry],
+    fmt: ExportFormat,
+    path: Path,
+) -> Path:
+    """Escreve `entries` em `path` no formato `fmt` ('csv' ou 'json').
+
+    Escrita atomica via `<path>.tmp` -> `os.replace` pra evitar arquivo
+    parcial em caso de erro. Retorna o path final escrito.
+
+    Schema (mesmo p/ csv e json): _EXPORT_FIELDS na ordem definida.
+    `subagent_type` e' None pra entries que nao sao Agent — escapa como
+    string vazia em CSV, null em JSON.
+    """
+    if fmt not in ("csv", "json"):
+        raise ValueError(f"Formato invalido: {fmt!r} (use 'csv' ou 'json').")
+
+    rows = [_entry_to_row(e) for e in entries]
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    if fmt == "csv":
+        with tmp.open("w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=list(_EXPORT_FIELDS))
+            writer.writeheader()
+            for r in rows:
+                # CSV nao tem null nativo; None vira "".
+                writer.writerow({k: ("" if v is None else v) for k, v in r.items()})
+    else:
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(rows, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+    os.replace(tmp, path)
+    return path
 
 
 def parse_filter_input(raw: str) -> dict[str, str]:

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -47,6 +47,12 @@ from claude_dash.discover import (
     subagents_of,
 )
 from claude_dash.views.audit import (
+    default_export_path as _audit_default_export_path,
+)
+from claude_dash.views.audit import (
+    export_entries as _audit_export_entries,
+)
+from claude_dash.views.audit import (
     filter_entries as _audit_filter_entries,
 )
 from claude_dash.views.audit import (
@@ -195,6 +201,15 @@ class DashboardApp(App):
     #audit-filter-input.active {
         display: block;
     }
+    #audit-export-input {
+        dock: bottom;
+        height: 3;
+        display: none;
+        border: solid $accent;
+    }
+    #audit-export-input.active {
+        display: block;
+    }
     """
 
     BINDINGS: ClassVar[list[Binding]] = [
@@ -221,6 +236,7 @@ class DashboardApp(App):
         Binding("t", "audit_cycle_window", "Cycle window", show=False),
         Binding("question_mark", "audit_toggle_tests", "Toggle tests", show=False),
         Binding("s", "audit_drill_down_root", "Root drill-down", show=False),
+        Binding("e", "audit_export_prompt", "Export", show=False),
         Binding("end", "audit_resume_scroll", "Resume", show=False),
     ]
 
@@ -277,6 +293,12 @@ class DashboardApp(App):
                 yield Input(
                     placeholder="filtro: /tool=Bash | /error | /session=0efd3 | Esc cancela",
                     id="audit-filter-input",
+                )
+                yield Input(
+                    placeholder=(
+                        "export: caminho .csv ou .json (vazio = default em ~) | Esc cancela"
+                    ),
+                    id="audit-export-input",
                 )
         yield Footer()
 
@@ -693,6 +715,23 @@ class DashboardApp(App):
         except Exception:
             pass
 
+    def action_audit_export_prompt(self) -> None:
+        """Tecla `e`: abre prompt pra exportar entries filtradas (#36).
+
+        Path vazio -> default em `~/audit-export-<ts>.<ext>`. Extensao
+        determina formato (`.csv` -> CSV, `.json` -> JSON). Default e' csv.
+        """
+        if not self._audit_active():
+            return
+        self._mark_audit_user_action()
+        try:
+            inp = self.query_one("#audit-export-input", Input)
+            inp.value = ""
+            inp.add_class("active")
+            inp.focus()
+        except Exception:
+            pass
+
     def action_audit_resume_scroll(self) -> None:
         """Tecla End: retoma auto-scroll no fundo (D8)."""
         if not self._audit_active():
@@ -823,19 +862,58 @@ class DashboardApp(App):
             self._render_session_detail(event.item.sid)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Filter prompt da aba Audit: aplica e fecha."""
-        if event.input.id != "audit-filter-input":
+        """Prompts da aba Audit: filter aplica filtro; export grava arquivo."""
+        if event.input.id == "audit-filter-input":
+            self._audit_filter = _audit_parse_filter(event.value)
+            event.input.remove_class("active")
+            event.input.value = ""
+            with contextlib.suppress(Exception):
+                self.query_one("#audit-table", Static).focus()
+            self._refresh_audit()
             return
-        self._audit_filter = _audit_parse_filter(event.value)
-        event.input.remove_class("active")
-        event.input.value = ""
-        # Re-foca no container da aba pra chaves voltarem a funcionar.
-        with contextlib.suppress(Exception):
-            self.query_one("#audit-table", Static).focus()
-        self._refresh_audit()
+        if event.input.id == "audit-export-input":
+            self._handle_audit_export(event.value.strip())
+            event.input.remove_class("active")
+            event.input.value = ""
+            with contextlib.suppress(Exception):
+                self.query_one("#audit-table", Static).focus()
+            return
+
+    def _handle_audit_export(self, raw_path: str) -> None:
+        """Resolve path + formato, exporta conjunto filtrado atual.
+
+        Sem path -> default em `~/audit-export-<ts>.csv`. Extensao do path
+        manda no formato (.json -> JSON; senao CSV). Erros de IO viram
+        mensagem no painel #audit-detail; sucesso idem com path final.
+        """
+        visible = list(getattr(self, "_audit_visible_cache", []))
+        if not visible:
+            self._update_audit_detail(
+                Text("Nada a exportar — filtro produziu zero entries.", style="yellow"),
+            )
+            return
+        if raw_path:
+            path = Path(raw_path).expanduser()
+            fmt = "json" if path.suffix.lower() == ".json" else "csv"
+        else:
+            fmt = "csv"
+            path = _audit_default_export_path(fmt)
+        try:
+            written = _audit_export_entries(visible, fmt, path)
+        except (OSError, ValueError) as e:
+            self._update_audit_detail(
+                Text(f"Erro ao exportar: {e}", style="red"),
+            )
+            return
+        self._update_audit_detail(
+            Text.from_markup(
+                f"[green]Exportado:[/green] {written}  "
+                f"([bold]{len(visible)}[/bold] entries, formato {fmt})"
+            ),
+        )
 
     def on_key(self, event) -> None:
-        """Captura Esc no filter input pra fechar sem aplicar."""
+        """Captura Esc nos input prompts pra fechar sem aplicar."""
         if event.key == "escape":
             try:
                 inp = self.query_one("#audit-filter-input", Input)
@@ -844,6 +922,15 @@ class DashboardApp(App):
                     inp.value = ""
                     self._audit_filter = {}
                     self._refresh_audit()
+                    event.stop()
+                    return
+            except Exception:
+                pass
+            try:
+                inp = self.query_one("#audit-export-input", Input)
+                if inp.has_class("active"):
+                    inp.remove_class("active")
+                    inp.value = ""
                     event.stop()
                     return
             except Exception:

--- a/tests/test_audit_setup.py
+++ b/tests/test_audit_setup.py
@@ -328,8 +328,8 @@ def test_root_uninstall_script_preserves_log():
 # Modo installed: no-op
 # ---------------------------------------------------------------------------
 
-def test_installed_is_noop(tmp_path, monkeypatch, capsys):
-    p = _patch_paths(monkeypatch, tmp_path)
+def _make_installed_state(p: dict) -> None:
+    """Helper: cria estado completo do modo `installed` em tmp_path."""
     settings = {"hooks": {"PostToolUse": [{
         "matcher": ".*",
         "hooks": [{"type": "command", "command": "claude-dash-audit-hook"}],
@@ -350,7 +350,58 @@ def test_installed_is_noop(tmp_path, monkeypatch, capsys):
     au.VAR_LOG_DIR.mkdir(parents=True, exist_ok=True)
     au.VAR_LOG_FILE.touch()
 
+
+def test_installed_is_noop(tmp_path, monkeypatch, capsys):
+    p = _patch_paths(monkeypatch, tmp_path)
+    _make_installed_state(p)
+
     rc = au.main_setup_audit(_args())
     assert rc == 0
     out = capsys.readouterr().out
     assert "Tudo OK" in out
+
+
+def test_installed_silent_when_legacy_hook_is_compat_shim(tmp_path, monkeypatch, capsys):
+    """Issue #49: estado correto (shim instalado) nao deve imprimir aviso."""
+    p = _patch_paths(monkeypatch, tmp_path)
+    _make_installed_state(p)
+    p["legacy_hook"].write_text(au.LEGACY_SHIM_CONTENT)
+
+    rc = au.main_setup_audit(_args())
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Tudo OK" in out
+    assert "delete manualmente" not in out
+
+
+def test_installed_reinstalls_shim_when_legacy_bash_present(tmp_path, monkeypatch, capsys):
+    """Issue #49: bash legado em estado `installed` -> instala shim em vez de avisar."""
+    p = _patch_paths(monkeypatch, tmp_path)
+    _make_installed_state(p)
+    # Bash legado de 120 linhas (nao contem 'exec claude-dash-audit-hook')
+    p["legacy_hook"].write_text("#!/bin/bash\n# script legado\necho old\n")
+
+    rc = au.main_setup_audit(_args())
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "delete manualmente" not in out
+    # Shim foi instalado: arquivo agora contem o marcador
+    assert au._is_compat_shim(p["legacy_hook"])
+    assert "claude-dash-audit-hook" in p["legacy_hook"].read_text()
+
+
+def test_is_compat_shim_helper():
+    """Helper detecta shim valido vs bash legado vs ausente."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        # Arquivo ausente
+        assert not au._is_compat_shim(td_path / "missing")
+        # Shim valido
+        shim = td_path / "shim.sh"
+        shim.write_text(au.LEGACY_SHIM_CONTENT)
+        assert au._is_compat_shim(shim)
+        # Bash legado
+        legacy = td_path / "legacy.sh"
+        legacy.write_text("#!/bin/bash\necho old\n")
+        assert not au._is_compat_shim(legacy)

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 from textual.widgets import TabbedContent
 
 from claude_dash.audit.models import AuditEntry
 from claude_dash.views.audit import (
+    _EXPORT_FIELDS,
     _color_for,
     _is_test_session,
+    default_export_path,
+    export_entries,
     filter_entries,
     parse_filter_input,
     render_footer,
@@ -274,3 +278,71 @@ def test_todas_abas_sao_acessiveis(key: str) -> None:
             await pilot.press(key)
             await pilot.pause(0.1)
     _run(run())
+
+
+# ---- Export CSV/JSON (#36) -------------------------------------------
+
+
+def test_export_csv_schema_e_roundtrip(tmp_path) -> None:
+    import csv as _csv
+    e1 = _entry(tool="Bash")
+    e2 = _entry(tool="Agent", subagent_type="general-purpose", delta_seconds=5)
+    out = tmp_path / "audit.csv"
+    written = export_entries([e1, e2], "csv", out)
+    assert written == out
+    assert out.is_file()
+
+    with out.open(encoding="utf-8") as f:
+        reader = _csv.DictReader(f)
+        assert list(reader.fieldnames or []) == list(_EXPORT_FIELDS)
+        rows = list(reader)
+    assert len(rows) == 2
+    # ISO 8601 do timestamp
+    assert rows[0]["timestamp"].startswith("2026-04-28T")
+    # subagent_type=None vira string vazia em CSV
+    assert rows[0]["subagent_type"] == ""
+    assert rows[1]["subagent_type"] == "general-purpose"
+    assert rows[0]["tool"] == "Bash"
+    assert rows[1]["tool"] == "Agent"
+
+
+def test_export_json_schema_e_null_para_subagent_type(tmp_path) -> None:
+    import json as _json
+    e1 = _entry(tool="Bash")
+    e2 = _entry(tool="Agent", subagent_type="general-purpose", delta_seconds=5)
+    out = tmp_path / "audit.json"
+    export_entries([e1, e2], "json", out)
+    data = _json.loads(out.read_text())
+    assert isinstance(data, list) and len(data) == 2
+    # JSON preserva None como null (vs "" do CSV)
+    assert data[0]["subagent_type"] is None
+    assert data[1]["subagent_type"] == "general-purpose"
+    # Schema bate com _EXPORT_FIELDS
+    assert set(data[0].keys()) == set(_EXPORT_FIELDS)
+
+
+def test_export_atomico_nao_deixa_tmp_em_caso_de_sucesso(tmp_path) -> None:
+    out = tmp_path / "audit.csv"
+    export_entries([_entry()], "csv", out)
+    assert out.is_file()
+    assert not (tmp_path / "audit.csv.tmp").exists()
+
+
+def test_export_formato_invalido_levanta() -> None:
+    with pytest.raises(ValueError, match="Formato"):
+        export_entries([_entry()], "xml", Path("/tmp/x.xml"))  # type: ignore[arg-type]
+
+
+def test_default_export_path_inclui_timestamp_iso() -> None:
+    now = datetime(2026, 4, 28, 14, 30, 52)
+    p_csv = default_export_path("csv", now=now)
+    p_json = default_export_path("json", now=now)
+    assert p_csv.name == "audit-export-2026-04-28T143052.csv"
+    assert p_json.name == "audit-export-2026-04-28T143052.json"
+
+
+def test_export_path_nao_gravavel_levanta_oserror(tmp_path) -> None:
+    # Diretorio nao-existente -> OSError no open
+    bad = tmp_path / "no-such-dir" / "out.csv"
+    with pytest.raises(OSError):
+        export_entries([_entry()], "csv", bad)


### PR DESCRIPTION
Quick wins da Etapa 1 do plano de implementação das issues abertas — 2 fixes pequenos, baixo risco, em commits atômicos.

## Mudanças

### `fix(setup-audit)` — Closes #49

Modo `installed` deixou de imprimir o aviso contraditório "delete `audit-tool.sh` manualmente" quando o arquivo já é o shim de compat (instalado por v0.14.2 / PR #48).

- Helper novo `_is_compat_shim(path)` extraído em `audit/setup.py` (DRY com `_install_legacy_shim`).
- Modo `installed` + shim correto → "Tudo OK", silencioso.
- Modo `installed` + bash legado → instala shim em vez de avisar (converge pra `migrate`).
- 3 testes novos em `tests/test_audit_setup.py`.

### `feat(audit)` — Closes #36

Aba `Audit` da TUI ganhou tecla `e` pra exportar o conjunto filtrado.

- Path vazio → default `~/audit-export-<ts>.csv`.
- Extensão `.json` → JSON; qualquer outra → CSV.
- Schema fixo de 13 campos: `timestamp, hostname, session_id, tool, subagent_type, tool_use_id, status, duration_ms, perm_mode, input_sha, input_bytes, output_bytes, pid`.
- Escrita atômica via `<path>.tmp` + `os.replace`.
- Funções puras `export_entries()` + `default_export_path()` testáveis sem TUI.
- 7 testes novos em `tests/test_audit_view.py`.

## Validação

- `uv run --extra dev pytest -x -q`: **296 passed, 1 skipped**.
- `uv run --extra dev ruff check`: limpo nos arquivos tocados (RUF001/RUF002 pré-existentes em `account.py` não relacionadas).
- Bump `v0.14.4 → v0.14.5` (patch — bug fix + feature aditiva sem breaking).

## Como testar manualmente

### #49

```bash
claude-dash setup-audit
# Esperado: "Tudo OK — nada a fazer." sem mensagem sobre deletar arquivo.
```

### #36

```bash
claude-dash         # TUI
# Pressione 5 (aba Audit), espere entries aparecerem
# Pressione e
# Enter (path vazio = default) → arquivo em ~/audit-export-<ts>.csv
# Esc cancela
```

## Próximas etapas do plano

#55 (filtro hostname + drill-down 3 níveis) → #37 (notif erro) → #52 (grupo claude-audit) → #50 (PreToolUse) → #54 (review MCP) → #38 (comparison) → #35 (sudo TUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)