### PR TITLE
feat(audit): filtro por hostname + drill-down em 3 níveis (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - TUI: `Audit` tab gained a `host` column showing each entry's `hostname`. Default behavior filters entries to the current host (via `socket.gethostname().split('.')[0]`); press `h` to toggle and see all hosts. Entries from a different host are rendered in `dim` style as a visual cue that the original transcript is on another machine. Empty `hostname` (legacy entries pre-#55) always pass — they're treated as "host unknown" rather than hidden. Closes part of #55.
+- TUI: `Audit` tab gained an in-tab key-hint line above the global Footer, listing `/` filter, `t` window, `?` tests, `h` host, `s` drill-down, `e` export, `End` resume. The Audit-specific bindings stay `show=False` in the global Footer (to keep other tabs uncluttered), so this line is the canonical place to discover them.
 - `parse_filter_input` accepts `/host=<name>` as a fourth filter key (prefix-match). When set, the implicit "current host only" toggle is suspended automatically so `/host=PREDATOR` works from any machine. Closes part of #55.
 - Status footer shows `host=<current>` or `host=todos` depending on toggle state, alongside existing `window=`, `filter=`, `show-tests=` indicators.
 - `claude-dash session <sid>` (and the `s` drill-down in the TUI) now has a three-tier response: (1) JSONL local present → full drill-down (unchanged); (2) JSONL absent but metadata exists in `sessions.log` → partial drill-down with `Origem: <hostname>` header, tool-calls table, aggregate of total/errors/duration (no per-turn timeline or per-turn cost — those need JSONL); (3) nothing → clear "Nao existem dados neste host" message instead of the previous misleading "transcript not found". Closes part of #55.
 - New module `claude_dash.audit.partial_stats` with `PartialSessionStats` dataclass and `build_partial_stats_from_audit(sid, audit_log_path=...)` helper. Pure-function, testable in isolation; useful even outside the cross-device case (e.g., when a JSONL has been rotated locally on the origin machine).
 - New constant `claude_dash.audit.CURRENT_HOSTNAME` (resolved at import) for callers that need consistent hostname identification.
 - README "Audit log" section documents the cross-device behavior.
+
+### Fixed
+- TUI: `Audit` tab no longer snaps the cursor back to the latest row at every 1Hz refresh after the user has interacted recently. Auto-tail now respects `_is_audit_paused()` (the `_audit_last_user_action` grace window of `AUDIT_AUTO_SCROLL_GRACE_SEC`), so moving the cursor with ↑/↓ stays put. Press `End` to resume auto-tail explicitly.
 
 ## [0.14.5] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.6] - 2026-04-28
+
+### Added
+- TUI: `Audit` tab gained a `host` column showing each entry's `hostname`. Default behavior filters entries to the current host (via `socket.gethostname().split('.')[0]`); press `h` to toggle and see all hosts. Entries from a different host are rendered in `dim` style as a visual cue that the original transcript is on another machine. Empty `hostname` (legacy entries pre-#55) always pass — they're treated as "host unknown" rather than hidden. Closes part of #55.
+- `parse_filter_input` accepts `/host=<name>` as a fourth filter key (prefix-match). When set, the implicit "current host only" toggle is suspended automatically so `/host=PREDATOR` works from any machine. Closes part of #55.
+- Status footer shows `host=<current>` or `host=todos` depending on toggle state, alongside existing `window=`, `filter=`, `show-tests=` indicators.
+- `claude-dash session <sid>` (and the `s` drill-down in the TUI) now has a three-tier response: (1) JSONL local present → full drill-down (unchanged); (2) JSONL absent but metadata exists in `sessions.log` → partial drill-down with `Origem: <hostname>` header, tool-calls table, aggregate of total/errors/duration (no per-turn timeline or per-turn cost — those need JSONL); (3) nothing → clear "Nao existem dados neste host" message instead of the previous misleading "transcript not found". Closes part of #55.
+- New module `claude_dash.audit.partial_stats` with `PartialSessionStats` dataclass and `build_partial_stats_from_audit(sid, audit_log_path=...)` helper. Pure-function, testable in isolation; useful even outside the cross-device case (e.g., when a JSONL has been rotated locally on the origin machine).
+- New constant `claude_dash.audit.CURRENT_HOSTNAME` (resolved at import) for callers that need consistent hostname identification.
+- README "Audit log" section documents the cross-device behavior.
+
 ## [0.14.5] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ imune a adulteração pelo próprio Claude. O `sessions.log` em metadata-only
 Hook é **fail-silent** (exit 0 sempre) — perda de log preferível a quebra
 de fluxo da sessão.
 
+**Comportamento cross-device (#55).** Como `sessions.log` é syncado e
+os transcripts JSONL ficam na máquina de origem, ao alternar entre
+dispositivos a aba `Audit` filtra entries pelo hostname atual por padrão
+(tecla `h` toggla pra mostrar todos os hosts; `/host=PREDATOR` filtra
+explicitamente). No drill-down (`s` na aba ou `claude-dash session <sid>`):
+
+1. Transcript JSONL local existe → drill-down completo.
+2. Sem JSONL, com metadata na `sessions.log` → drill-down parcial: mostra
+   `Origem: <hostname>`, lista as tool calls e agrega total/erros/duração.
+   Sem timeline de turnos nem custos por turno (só vêm do JSONL).
+3. Nem JSONL nem metadata → mensagem clara `Nao existem dados neste host`.
+
 **Bootstrap em 3 comandos:**
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.14.5"
+version = "0.14.6"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/__init__.py
+++ b/src/claude_dash/audit/__init__.py
@@ -15,3 +15,20 @@ Pacote responsavel por:
 Fase 1 do issue #24 — apenas captura/persistencia. A aba "Audit" da TUI
 fica para fase 2 (issue derivada).
 """
+from __future__ import annotations
+
+import socket
+
+
+def _current_hostname() -> str:
+    """Hostname curto (sem dominio), igual ao usado em ``audit/hook.py``.
+
+    Equivalente a ``hostname -s 2>/dev/null || hostname`` em bash.
+    """
+    return socket.gethostname().split(".")[0]
+
+
+# Hostname desta maquina, resolvido no import. Usado pela TUI pra default
+# do filtro "so mostrar entries que rodaram aqui" (#55) e pelo drill-down
+# pra distinguir transcript local vs metadata cross-device.
+CURRENT_HOSTNAME: str = _current_hostname()

--- a/src/claude_dash/audit/partial_stats.py
+++ b/src/claude_dash/audit/partial_stats.py
@@ -1,0 +1,121 @@
+"""Drill-down parcial via audit metadata (#55).
+
+Quando o transcript JSONL nao esta disponivel localmente (sessao rodou
+em outra maquina e foi syncada apenas via ~/.claude/iris/audit/sessions.log),
+ainda da pra reconstruir um quadro mais limitado da sessao a partir do
+metadata: total de tool calls, top tools, taxa de erro, duracao.
+
+Sem timeline de turnos, sem custos por turno, sem usage_by_model — esses
+dados so existem no JSONL e o audit nao captura.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from claude_dash.audit.models import AuditEntry
+from claude_dash.audit.parser import parse_line
+
+
+@dataclass(slots=True)
+class PartialSessionStats:
+    """Subset de SessionStats extraivel apenas do audit log.
+
+    Atributos populados a partir das entries da sessions.log que casam
+    com `session_id`. ``hostname`` e' o de qualquer entry (assumido
+    consistente — uma sessao roda numa maquina so).
+    """
+
+    session_id: str
+    hostname: str = ""
+    entries: list[AuditEntry] = field(default_factory=list)
+
+    @property
+    def total_calls(self) -> int:
+        return len(self.entries)
+
+    @property
+    def first_ts(self) -> datetime | None:
+        return self.entries[0].timestamp if self.entries else None
+
+    @property
+    def last_ts(self) -> datetime | None:
+        return self.entries[-1].timestamp if self.entries else None
+
+    @property
+    def duration_ms(self) -> int:
+        if not self.entries or len(self.entries) < 2:
+            return 0
+        delta = self.last_ts - self.first_ts  # type: ignore[operator]
+        return int(delta.total_seconds() * 1000)
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for e in self.entries if e.status == "error")
+
+    @property
+    def error_rate(self) -> float:
+        if not self.entries:
+            return 0.0
+        return self.error_count / len(self.entries)
+
+    @property
+    def top_tools(self) -> list[tuple[str, int]]:
+        """Top 8 tools por contagem, ordem decrescente."""
+        c: Counter[str] = Counter(e.tool for e in self.entries)
+        return c.most_common(8)
+
+
+def build_partial_stats_from_audit(
+    session_id: str,
+    *,
+    audit_log_path: Path | None = None,
+) -> PartialSessionStats | None:
+    """Varre `audit_log_path` e devolve `PartialSessionStats` agregado.
+
+    Retorna None quando o arquivo nao existe ou nenhuma entry casa com
+    `session_id` — caller distingue "nao tem dado nenhum sobre essa sessao"
+    de "tem metadata, sem JSONL".
+
+    `session_id` aceita prefix-match (mesmo padrao do `find_transcript_for_session`).
+    """
+    if audit_log_path is None:
+        audit_log_path = Path.home() / ".claude" / "iris" / "audit" / "sessions.log"
+
+    if not audit_log_path.is_file():
+        return None
+
+    matched: list[AuditEntry] = []
+    hostname = ""
+    try:
+        with audit_log_path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                # Fast-path: skip linhas que nao mencionam o prefix
+                # antes de invocar regex caro.
+                if session_id not in line:
+                    continue
+                entry = parse_line(line)
+                if entry is None:
+                    continue
+                if not entry.session_id.startswith(session_id):
+                    continue
+                matched.append(entry)
+                if not hostname and entry.hostname:
+                    hostname = entry.hostname
+    except OSError:
+        return None
+
+    if not matched:
+        return None
+
+    # Garante ordem temporal — sessions.log e' append-only mas defensivo
+    # custa pouco (n tipico < 1000 por sessao).
+    matched.sort(key=lambda e: e.timestamp)
+
+    return PartialSessionStats(
+        session_id=matched[0].session_id,
+        hostname=hostname,
+        entries=matched,
+    )

--- a/src/claude_dash/views/audit.py
+++ b/src/claude_dash/views/audit.py
@@ -99,14 +99,22 @@ def filter_entries(
     filters: dict[str, str] | None = None,
     window_hours: float | None = 24.0,
     show_test_sessions: bool = False,
+    current_host: str | None = None,
     now: datetime | None = None,
 ) -> list[AuditEntry]:
-    """Aplica todos os filtros (D4 + D7 + janela temporal).
+    """Aplica todos os filtros (D4 + D7 + janela temporal + host).
 
-    Filtros suportados (uma key por vez, conforme D4):
+    Filtros suportados (uma key por vez no dict ``filters``, conforme D4):
     - ``tool``: match exato no nome da tool
     - ``status``: match exato (geralmente "error")
     - ``session_prefix``: prefix-match no session_id
+    - ``host``: prefix-match no hostname (#55)
+
+    Parametro extra ``current_host``: quando nao-None, aplica filtro
+    "so este host" alem de qualquer ``host=`` explicito em ``filters``.
+    Entries com ``hostname`` vazio (logs antigos pre-#55) sao incluidas
+    como "sem host conhecido" — nao queremos esconder dado historico
+    legitimo so porque o campo nao foi populado.
     """
     filters = filters or {}
     if now is None:
@@ -131,6 +139,10 @@ def filter_entries(
             filters["session_prefix"]
         ):
             continue
+        if "host" in filters and not e.hostname.startswith(filters["host"]):
+            continue
+        if current_host is not None and e.hostname and e.hostname != current_host:
+            continue
         out.append(e)
     return out
 
@@ -144,11 +156,20 @@ def _fmt_bytes(n: int) -> str:
     return f"{n / (1024 * 1024):.1f}M"
 
 
-def render_table(entries: list[AuditEntry], *, max_rows: int = 500) -> Table:
+def render_table(
+    entries: list[AuditEntry],
+    *,
+    max_rows: int = 500,
+    current_host: str | None = None,
+) -> Table:
     """Renderiza Rich Table das entries (ja filtradas).
 
     Mostra so as ultimas ``max_rows`` para evitar custo de render em
     listas gigantes (Rich Table nao virtualiza).
+
+    ``current_host`` (#55): quando nao-None, hostname diferente do atual
+    e' renderizado em ``dim`` pra sinalizar que o transcript original esta
+    em outra maquina. None desabilita o styling diferenciado (todos iguais).
     """
     table = Table(
         expand=True,
@@ -159,6 +180,7 @@ def render_table(entries: list[AuditEntry], *, max_rows: int = 500) -> Table:
     )
     table.add_column("time", style="cyan", no_wrap=True, width=12)
     table.add_column("sess", no_wrap=True, width=8)
+    table.add_column("host", no_wrap=True, width=10)
     table.add_column("tool", no_wrap=True)
     table.add_column("dur_ms", justify="right", no_wrap=True, width=8)
     table.add_column("in", justify="right", no_wrap=True, width=7)
@@ -166,15 +188,24 @@ def render_table(entries: list[AuditEntry], *, max_rows: int = 500) -> Table:
 
     visible = entries[-max_rows:]
     for e in visible:
-        style = _color_for(e)
+        # Se entry e' de outro host, vence o styling de tool (drill-down
+        # cross-device e' info mais saliente que o tipo da tool).
+        host_other = (
+            current_host is not None
+            and e.hostname
+            and e.hostname != current_host
+        )
+        style = "dim" if host_other else _color_for(e)
         time_str = e.timestamp.strftime("%H:%M:%S.%f")[:-3]
         sess_str = e.session_id[:8] if e.session_id else "-"
+        host_str = e.hostname or "-"
         tool_str = e.tool
         if e.subagent_type:
             tool_str = f"{e.tool}({e.subagent_type})"
         table.add_row(
             time_str,
             sess_str,
+            host_str,
             tool_str,
             str(e.duration_ms),
             _fmt_bytes(e.input_bytes),
@@ -278,4 +309,6 @@ def parse_filter_input(raw: str) -> dict[str, str]:
         return {"status": value}
     if key == "session":
         return {"session_prefix": value}
+    if key == "host":
+        return {"host": value}
     return {}

--- a/src/claude_dash/views/session.py
+++ b/src/claude_dash/views/session.py
@@ -1,10 +1,15 @@
 """View 'session <sid>' — drill-down de uma sessão específica.
 
-Aceita prefixo de sessionId (se único). Mostra:
-- Identificação e estado
-- Resumo agregado (herda de SessionStats)
-- Timeline dos últimos N turnos com tokens e tools por turno
-- Subagentes disparados com custos individuais
+Aceita prefixo de sessionId (se único). Tres caminhos de resposta (#55):
+
+1. **Transcript JSONL local existe** -> drill-down completo (header +
+   overview + timeline + subagents).
+2. **Sem JSONL, mas ha entries em sessions.log** -> drill-down parcial:
+   header indica `Origem: <hostname>`, lista as tool calls com timestamp
+   e duracao, agrega total/top-tools/erro/duracao. Sem timeline de turnos
+   nem custos por turno (esses dados so vem do JSONL).
+3. **Nem JSONL nem metadata** -> mensagem clara "nao existem dados neste
+   host sobre a sessao".
 """
 from __future__ import annotations
 
@@ -18,6 +23,10 @@ from rich.text import Text
 from claude_dash.aggregator import (
     build_stats_for_transcript,
     extract_turns,
+)
+from claude_dash.audit.partial_stats import (
+    PartialSessionStats,
+    build_partial_stats_from_audit,
 )
 from claude_dash.discover import (
     discover_live_sessions,
@@ -221,32 +230,142 @@ def _subagents_panel(session_id: str) -> Panel | None:
     return Panel(table, title=f"Subagentes ({len(subs)})", title_align="left", border_style="dim")
 
 
+def _partial_header(stats: PartialSessionStats) -> Panel:
+    """Header do drill-down parcial (#55) — destaca origem cross-device."""
+    first = (
+        stats.first_ts.strftime("%Y-%m-%d %H:%M:%S") if stats.first_ts else "—"
+    )
+    last = stats.last_ts.strftime("%Y-%m-%d %H:%M:%S") if stats.last_ts else "—"
+
+    h = Text()
+    h.append(" SID    ", style="dim cyan")
+    h.append(f"{stats.session_id}\n", style="bold cyan")
+    h.append(" Origem ", style="dim")
+    h.append(f"{stats.hostname or '—'}\n", style="bold yellow")
+    h.append(" Aviso  ", style="dim")
+    h.append(
+        "Transcript original nao esta nesta maquina; mostrando apenas metadata\n",
+        style="dim italic",
+    )
+    h.append("        da audit log (sem timeline de turnos, sem custo por turno).\n",
+            style="dim italic")
+    h.append(" Janela ", style="dim")
+    h.append(f"{first}  ate  {last}", style="")
+
+    return Panel(h, border_style="yellow", title="claude-dash session (parcial)",
+                 title_align="left")
+
+
+def _partial_overview(stats: PartialSessionStats) -> Panel:
+    """Resumo agregado do drill-down parcial — totais derivaveis do audit."""
+    duration_s = stats.duration_ms / 1000 if stats.duration_ms else 0
+
+    lines = Text()
+    lines.append("Totais (derivados do audit log):\n", style="bold")
+    lines.append("  Tool calls   ", style="dim")
+    lines.append(f"{stats.total_calls}\n", style="bold")
+    lines.append("  Erros        ", style="dim")
+    err_style = "red" if stats.error_count else "green"
+    lines.append(
+        f"{stats.error_count} ({stats.error_rate * 100:.1f}%)\n",
+        style=err_style,
+    )
+    lines.append("  Duracao      ", style="dim")
+    if duration_s >= 60:
+        lines.append(f"{duration_s / 60:.1f} min\n", style="bold")
+    else:
+        lines.append(f"{duration_s:.1f} s\n", style="bold")
+
+    if stats.top_tools:
+        lines.append(" Top tools    ", style="dim")
+        for i, (name, count) in enumerate(stats.top_tools):
+            if i > 0:
+                lines.append(" ", style="dim")
+            lines.append(f"{name}:{count}", style="dim")
+
+    return Panel(lines, title="Resumo (parcial)", title_align="left", border_style="dim")
+
+
+def _partial_timeline(stats: PartialSessionStats, tail: int = 50) -> Panel:
+    """Lista as tool calls observadas — substitui a timeline de turnos."""
+    if not stats.entries:
+        return Panel(
+            Text("Sem tool calls.", style="dim"),
+            title="Tool calls (audit)",
+            title_align="left",
+            border_style="dim",
+        )
+
+    shown = stats.entries[-tail:]
+    omitted = len(stats.entries) - len(shown)
+
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        border_style="dim",
+        expand=True,
+        padding=(0, 1),
+    )
+    table.add_column("#", justify="right", width=5)
+    table.add_column("Hora", width=12)
+    table.add_column("Tool", overflow="fold")
+    table.add_column("Sub", overflow="fold")
+    table.add_column("dur_ms", justify="right", width=8)
+    table.add_column("status", width=8)
+
+    for idx, e in enumerate(shown, start=len(stats.entries) - len(shown) + 1):
+        time_str = e.timestamp.strftime("%H:%M:%S")
+        status_style = "red" if e.status == "error" else "green"
+        table.add_row(
+            str(idx),
+            time_str,
+            e.tool,
+            e.subagent_type or "—",
+            str(e.duration_ms),
+            f"[{status_style}]{e.status}[/{status_style}]",
+        )
+
+    title = f"Tool calls (audit) — ultimas {len(shown)} de {len(stats.entries)}"
+    if omitted > 0:
+        title += f" (+{omitted} anteriores)"
+    return Panel(table, title=title, title_align="left", border_style="dim")
+
+
 def run(sid: str) -> int:
     console = Console()
 
     ref = find_transcript_for_session(sid)
-    if ref is None:
-        console.print(
-            f"[red]Não encontrei transcript para SID '[bold]{sid}[/bold]' "
-            f"(pode ser prefixo ambíguo ou inexistente).[/red]"
-        )
-        return 1
+    if ref is not None:
+        # Caminho 1: transcript JSONL local — drill-down completo.
+        live_by_sid = {ls.session_id: ls for ls in discover_live_sessions()}
+        live = live_by_sid.get(ref.session_id)
 
-    # Busca info viva (se houver)
-    live_by_sid = {ls.session_id: ls for ls in discover_live_sessions()}
-    live = live_by_sid.get(ref.session_id)
+        stats = build_stats_for_transcript(ref, live=live)
+        stats.subagents = len(subagents_of(ref.session_id))
 
-    stats = build_stats_for_transcript(ref, live=live)
-    stats.subagents = len(subagents_of(ref.session_id))
+        turns = extract_turns(ref)
 
-    turns = extract_turns(ref)
+        console.print(_header(stats))
+        console.print(_overview(stats))
+        console.print(_timeline(turns))
 
-    console.print(_header(stats))
-    console.print(_overview(stats))
-    console.print(_timeline(turns))
+        sub_panel = _subagents_panel(ref.session_id)
+        if sub_panel is not None:
+            console.print(sub_panel)
+        return 0
 
-    sub_panel = _subagents_panel(ref.session_id)
-    if sub_panel is not None:
-        console.print(sub_panel)
+    # Sem JSONL local — tenta caminho 2 (metadata da sessions.log).
+    partial = build_partial_stats_from_audit(sid)
+    if partial is not None:
+        console.print(_partial_header(partial))
+        console.print(_partial_overview(partial))
+        console.print(_partial_timeline(partial))
+        return 0
 
-    return 0
+    # Caminho 3: nem JSONL nem metadata.
+    console.print(
+        f"[red]Nao existem dados neste host sobre a sessao "
+        f"'[bold]{sid}[/bold]'.[/red]\n"
+        f"[dim]Verifique se o SID esta correto ou rode em outra maquina.[/dim]"
+    )
+    return 1

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -193,6 +193,12 @@ class DashboardApp(App):
         color: $text-muted;
         padding: 0 1;
     }
+    #audit-keys {
+        height: 1;
+        background: $surface;
+        color: $text-muted;
+        padding: 0 1;
+    }
     #audit-filter-input {
         dock: bottom;
         height: 3;
@@ -298,6 +304,10 @@ class DashboardApp(App):
                 yield DataTable(id="audit-table", cursor_type="row", zebra_stripes=True)
                 yield Static(id="audit-detail")
                 yield Static(id="audit-status")
+                # Linha de atalhos especificos da aba — bindings da Audit
+                # estao todos com show=False no Footer global pra nao poluir
+                # as outras abas; aqui sao reapresentados in-line.
+                yield Static(id="audit-keys")
                 yield Input(
                     placeholder=(
                         "filtro: /tool=Bash | /error | /session=0efd3 | "
@@ -328,6 +338,7 @@ class DashboardApp(App):
         self._refresh_session_list()
         # Inicializa tailer e renderiza primeiro estado da aba Audit.
         self._audit_tailer = IncrementalTailer(AUDIT_LOG_PATH)
+        self._populate_audit_keys()
         self._refresh_audit()
         # Auto-refresh só da Now (demais via `r` manual). Audit tem
         # ciclo proprio de 1 Hz (tail incremental e barato).
@@ -707,11 +718,43 @@ class DashboardApp(App):
         self._audit_table_signature = sig
         self._audit_first_visible_key = first_key
 
-        # Cursor: so move pro fim se usuario estava no fim (auto-tail).
-        # Caso contrario, preserva posicao (append-only naturalmente
-        # mantem o cursor onde estava).
-        if dt.row_count > 0 and was_at_end:
+        # Cursor: so move pro fim se usuario estava no fim (auto-tail) E
+        # nao houve interacao recente (respeita pausa do D8). Sem o check
+        # de pausa, mover o cursor de volta pra penultima linha era
+        # imediatamente desfeito no proximo tick (1s) — barra visual
+        # "voltava sozinha" pro fim.
+        if (
+            dt.row_count > 0
+            and was_at_end
+            and not self._is_audit_paused()
+        ):
             dt.move_cursor(row=dt.row_count - 1, animate=False)
+
+    def _populate_audit_keys(self) -> None:
+        """Renderiza linha de atalhos da aba Audit no widget #audit-keys.
+
+        Conteudo estatico — populado uma vez no on_mount. Bindings sao
+        os mesmos do BINDINGS (slash/t/?/h/s/e/End) com show=False, que
+        nao apareceriam no Footer global; aqui sao reapresentados in-line
+        so quando a aba Audit esta ativa (CSS oculta o widget nas outras
+        abas via TabPane scoping natural — widget esta dentro do tab-audit).
+        """
+        keys = [
+            ("/", "filter"),
+            ("t", "window"),
+            ("?", "tests"),
+            ("h", "host"),
+            ("s", "drill-down"),
+            ("e", "export"),
+            ("End", "resume"),
+        ]
+        parts = "  ".join(
+            f"[bold cyan]{k}[/bold cyan] {label}" for k, label in keys
+        )
+        with contextlib.suppress(Exception):
+            self.query_one("#audit-keys", Static).update(
+                Text.from_markup(parts),
+            )
 
     def _is_audit_paused(self) -> bool:
         """True se auto-scroll esta pausado (D8)."""

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -39,6 +39,7 @@ from claude_dash.aggregator import (
     collect_tool_usage_since,
     extract_turns,
 )
+from claude_dash.audit import CURRENT_HOSTNAME
 from claude_dash.audit.models import AuditEntry
 from claude_dash.audit.tail import IncrementalTailer
 from claude_dash.discover import (
@@ -237,6 +238,7 @@ class DashboardApp(App):
         Binding("question_mark", "audit_toggle_tests", "Toggle tests", show=False),
         Binding("s", "audit_drill_down_root", "Root drill-down", show=False),
         Binding("e", "audit_export_prompt", "Export", show=False),
+        Binding("h", "audit_toggle_host", "Toggle host", show=False),
         Binding("end", "audit_resume_scroll", "Resume", show=False),
     ]
 
@@ -253,6 +255,12 @@ class DashboardApp(App):
         self._audit_filter: dict[str, str] = {}
         self._audit_window_hours: float | None = 24.0
         self._audit_show_tests: bool = False
+        # Filtro implicito por hostname (#55): default = so este host.
+        # Toggle pela tecla `h`. Quando False, mostra tudo (hosts alheios
+        # em dim). Filtro explicito `/host=<name>` em `_audit_filter`
+        # tem precedencia: se ativo, o implicit fica suspenso (do contrario
+        # `/host=PREDATOR` neste host nunca casaria nada).
+        self._audit_host_only_current: bool = True
         # Timestamp (monotonic) da ultima interacao do usuario na aba
         # Audit. Auto-scroll so segue o fundo se passou
         # AUDIT_AUTO_SCROLL_GRACE_SEC sem interacao (D8).
@@ -291,7 +299,10 @@ class DashboardApp(App):
                 yield Static(id="audit-detail")
                 yield Static(id="audit-status")
                 yield Input(
-                    placeholder="filtro: /tool=Bash | /error | /session=0efd3 | Esc cancela",
+                    placeholder=(
+                        "filtro: /tool=Bash | /error | /session=0efd3 | "
+                        "/host=PREDATOR | Esc cancela"
+                    ),
                     id="audit-filter-input",
                 )
                 yield Input(
@@ -549,11 +560,21 @@ class DashboardApp(App):
     def _refresh_audit(self) -> None:
         try:
             all_entries = list(self._audit_entries)
+            # Filtro explicito `/host=` tem precedencia sobre o implicit
+            # "so este host" (do contrario o usuario nao conseguiria ver
+            # outro host sem fazer toggle a cada vez).
+            host_explicit = "host" in self._audit_filter
+            current_host = (
+                CURRENT_HOSTNAME
+                if self._audit_host_only_current and not host_explicit
+                else None
+            )
             visible = _audit_filter_entries(
                 all_entries,
                 filters=self._audit_filter,
                 window_hours=self._audit_window_hours,
                 show_test_sessions=self._audit_show_tests,
+                current_host=current_host,
             )
             # Slice EXATO do que vai aparecer na DataTable. Cache armazena
             # esse slice (NAO a lista cheia) — sem isso, cursor_row da
@@ -564,7 +585,7 @@ class DashboardApp(App):
             self._audit_visible_cache = slice_visible
 
             dt = self.query_one("#audit-table", DataTable)
-            self._populate_audit_table(dt, slice_visible)
+            self._populate_audit_table(dt, slice_visible, current_host=current_host)
             footer = _audit_render_footer(visible)
 
             # Linha de status: filtros ativos + janela + indicador de PAUSED
@@ -576,6 +597,13 @@ class DashboardApp(App):
                 status_parts.append(f"filter:{fk}={fv}")
             else:
                 status_parts.append("filter=none")
+            if host_explicit:
+                # Filtro explicito ja exibido em filter:host=...; nada extra.
+                pass
+            elif self._audit_host_only_current:
+                status_parts.append(f"host={CURRENT_HOSTNAME}")
+            else:
+                status_parts.append("host=todos")
             if self._audit_show_tests:
                 status_parts.append("show-tests=on")
             paused = self._is_audit_paused()
@@ -591,24 +619,33 @@ class DashboardApp(App):
                     Text(f"Erro: {e}", style="red"),
                 )
 
-    def _populate_audit_table(self, dt: DataTable, visible: list) -> None:
+    def _populate_audit_table(
+        self,
+        dt: DataTable,
+        visible: list,
+        *,
+        current_host: str | None = None,
+    ) -> None:
         """Atualiza DataTable de forma incremental.
 
         Estrategia:
         - Setup colunas uma vez (no primeiro render)
-        - Calcula signature (filtro+janela+show_tests) e first_key da
-          entry mais antiga visivel
+        - Calcula signature (filtro+janela+show_tests+current_host) e
+          first_key da entry mais antiga visivel
         - Se signature mudou OU first_key mudou (ring buffer rotation,
           filter, etc): full rebuild. Caso contrario: append-only das
           entries novas (preserva cursor sem flicker).
         - Cursor: se usuario estava na ultima linha (auto-tail), segue
           novo fim. Se moveu manualmente, posicao preservada
           automaticamente pelo append-only.
+        - Hostname (#55): coluna `host` mostra `entry.hostname`. Quando
+          `current_host` esta setado e entry e' de outro host, render
+          inteiro vai pra `dim` (sinal: log original em outra maquina).
         """
         from claude_dash.views.audit import _color_for, _fmt_bytes
 
         if not dt.columns:
-            dt.add_columns("time", "sess", "tool", "dur_ms", "in", "out")
+            dt.add_columns("time", "sess", "host", "tool", "dur_ms", "in", "out")
 
         # `visible` ja vem capeado pelo chamador (_refresh_audit) em
         # AUDIT_TABLE_MAX_ROWS. Nao re-slicear pra manter cache alinhado.
@@ -618,6 +655,7 @@ class DashboardApp(App):
             tuple(sorted(self._audit_filter.items())),
             self._audit_window_hours,
             self._audit_show_tests,
+            current_host,
         )
         first_key = (
             slice_visible[0].tool_use_id if slice_visible else None
@@ -641,15 +679,24 @@ class DashboardApp(App):
             entries_to_add = slice_visible[dt.row_count:]
 
         for e in entries_to_add:
-            style = _color_for(e)
+            host_other = (
+                current_host is not None
+                and e.hostname
+                and e.hostname != current_host
+            )
+            # Entry de outro host vence o color-by-tool: queremos sinal
+            # visual claro de que o transcript original nao esta aqui.
+            style = "dim" if host_other else _color_for(e)
             time_str = e.timestamp.strftime("%H:%M:%S.%f")[:-3]
             sess_str = e.session_id[:8] if e.session_id else "-"
+            host_str = e.hostname or "-"
             tool_str = e.tool
             if e.subagent_type:
                 tool_str = f"{e.tool}({e.subagent_type})"
             cells = [
-                Text(time_str, style="cyan"),
+                Text(time_str, style="cyan" if not host_other else "dim"),
                 Text(sess_str, style=style),
+                Text(host_str, style=style),
                 Text(tool_str, style=style),
                 Text(str(e.duration_ms), style=style, justify="right"),
                 Text(_fmt_bytes(e.input_bytes), style=style, justify="right"),
@@ -714,6 +761,18 @@ class DashboardApp(App):
             inp.focus()
         except Exception:
             pass
+
+    def action_audit_toggle_host(self) -> None:
+        """Tecla `h`: toggle entre `host=<atual>` e `host=todos` (#55).
+
+        Toggle nao afeta filtro explicito `/host=<name>` — esse continua
+        valendo enquanto setado, e durante isso o implicit fica suspenso.
+        """
+        if not self._audit_active():
+            return
+        self._audit_host_only_current = not self._audit_host_only_current
+        self._mark_audit_user_action()
+        self._refresh_audit()
 
     def action_audit_export_prompt(self) -> None:
         """Tecla `e`: abre prompt pra exportar entries filtradas (#36).

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -153,15 +153,15 @@ def test_color_for_agent_skill_mcp_azul() -> None:
 
 def test_render_table_nao_crasha_vazio() -> None:
     table = render_table([])
-    # Rich Table tem 6 colunas; nao deve levantar
-    assert len(table.columns) == 6
+    # 7 colunas: time, sess, host, tool, dur_ms, in, out (host adicionado em #55)
+    assert len(table.columns) == 7
 
 
 def test_render_table_inclui_subagent_type_no_label() -> None:
     e = _entry(tool="Agent", subagent_type="general-purpose")
     table = render_table([e])
-    # tool column = idx 2; primeira linha
-    cell = next(iter(table.columns[2].cells))
+    # tool agora esta na coluna idx 3 (host inserido antes em #55)
+    cell = next(iter(table.columns[3].cells))
     assert "Agent" in cell
     assert "general-purpose" in cell
 
@@ -346,3 +346,87 @@ def test_export_path_nao_gravavel_levanta_oserror(tmp_path) -> None:
     bad = tmp_path / "no-such-dir" / "out.csv"
     with pytest.raises(OSError):
         export_entries([_entry()], "csv", bad)
+
+
+# ---- Hostname: filter, render, parse (#55) ---------------------------
+
+
+def _entry_host(host: str, tool: str = "Bash") -> AuditEntry:
+    """Helper variante de _entry com hostname customizado."""
+    base = datetime(2026, 4, 28, 0, 0, 0, tzinfo=timezone(timedelta(hours=-3)))
+    return AuditEntry(
+        timestamp=base,
+        hostname=host,
+        pid="1",
+        session_id="0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+        tool=tool,
+        tool_use_id=f"x-{host}",
+        status="success",
+        duration_ms=100,
+        perm_mode="auto",
+        input_sha="0",
+        input_bytes=10,
+        output_bytes=20,
+    )
+
+
+def test_filter_current_host_default_oculta_outros() -> None:
+    aqui = _entry_host("RET-DTI-601048")
+    la = _entry_host("PREDATOR")
+    out = filter_entries(
+        [aqui, la], window_hours=None, current_host="RET-DTI-601048"
+    )
+    assert out == [aqui]
+
+
+def test_filter_current_host_none_mostra_todos() -> None:
+    aqui = _entry_host("RET-DTI-601048")
+    la = _entry_host("PREDATOR")
+    out = filter_entries([aqui, la], window_hours=None, current_host=None)
+    assert len(out) == 2
+
+
+def test_filter_current_host_inclui_hostname_vazio() -> None:
+    """Logs antigos pre-#55 sem hostname devem passar — sao 'sem host conhecido'."""
+    aqui = _entry_host("RET-DTI-601048")
+    sem_host = _entry_host("")
+    out = filter_entries(
+        [aqui, sem_host], window_hours=None, current_host="RET-DTI-601048"
+    )
+    assert len(out) == 2
+
+
+def test_filter_host_explicit_prefix_match() -> None:
+    pre = _entry_host("PREDATOR")
+    ret = _entry_host("RET-DTI-601048")
+    out = filter_entries(
+        [pre, ret], filters={"host": "PRED"}, window_hours=None
+    )
+    assert out == [pre]
+
+
+def test_parse_filter_host() -> None:
+    assert parse_filter_input("/host=PREDATOR") == {"host": "PREDATOR"}
+    assert parse_filter_input("/host=") == {}
+
+
+def test_render_table_inclui_coluna_host() -> None:
+    table = render_table([_entry_host("PREDATOR")])
+    # 7 colunas: time, sess, host, tool, dur_ms, in, out
+    assert len(table.columns) == 7
+    # host esta na coluna idx 2
+    cell = next(iter(table.columns[2].cells))
+    assert "PREDATOR" in cell
+
+
+def test_render_table_dim_para_outro_host() -> None:
+    pre = _entry_host("PREDATOR")
+    table = render_table([pre], current_host="RET-DTI-601048")
+    # Quando entry e' de outro host, render aplica row_styles="dim".
+    # Rich.Table guarda style por linha; checamos qualquer celula
+    # ter style 'dim' indicando que o flag pegou.
+    rendered = list(table.rows)
+    assert len(rendered) == 1
+    # row.style ou cells inheritados — Rich mantem _row_styles na Table.
+    # Mais simples: checamos que a Table tem pelo menos uma row com style dim.
+    assert any("dim" in str(getattr(row, "style", "")) for row in rendered)

--- a/tests/test_partial_stats.py
+++ b/tests/test_partial_stats.py
@@ -1,0 +1,182 @@
+"""Testes de drill-down parcial via audit metadata (#55)."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from claude_dash.audit.partial_stats import (
+    PartialSessionStats,
+    build_partial_stats_from_audit,
+)
+
+
+# Linhas RFC 5424 minimas validas pelo parser do audit/parser.py.
+def _line(
+    *,
+    ts: datetime,
+    host: str = "PREDATOR",
+    session: str = "0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+    tool: str = "Bash",
+    status: str = "success",
+    duration_ms: int = 100,
+) -> str:
+    ts_str = ts.isoformat()
+    return (
+        f'<134>1 {ts_str} {host} claude-code 12345 TOOLCALL '
+        f'[audit@iris session="{session}" tool="{tool}" '
+        f'tool_use_id="x" status="{status}" duration_ms="{duration_ms}" '
+        f'perm_mode="auto" input_sha="0" input_bytes="10" output_bytes="20"]'
+    )
+
+
+def _write_log(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_arquivo_inexistente_retorna_none(tmp_path) -> None:
+    out = build_partial_stats_from_audit(
+        "abc", audit_log_path=tmp_path / "missing.log"
+    )
+    assert out is None
+
+
+def test_session_id_sem_match_retorna_none(tmp_path) -> None:
+    log = tmp_path / "sessions.log"
+    _write_log(log, [
+        _line(ts=datetime(2026, 4, 28, 10, 0, 0, tzinfo=UTC),
+              session="aaaaaaaa-1111-4111-8111-111111111111"),
+    ])
+    out = build_partial_stats_from_audit(
+        "0efd3", audit_log_path=log
+    )
+    assert out is None
+
+
+def test_match_basico_agrega_corretamente(tmp_path) -> None:
+    log = tmp_path / "sessions.log"
+    base = datetime(2026, 4, 28, 10, 0, 0, tzinfo=UTC)
+    _write_log(log, [
+        _line(ts=base, host="PREDATOR", tool="Bash"),
+        _line(ts=base + timedelta(seconds=5), host="PREDATOR", tool="Read"),
+        _line(ts=base + timedelta(seconds=12), host="PREDATOR",
+              tool="Bash", status="error"),
+    ])
+    out = build_partial_stats_from_audit(
+        "0efd3", audit_log_path=log
+    )
+    assert out is not None
+    assert isinstance(out, PartialSessionStats)
+    assert out.hostname == "PREDATOR"
+    assert out.total_calls == 3
+    assert out.error_count == 1
+    assert abs(out.error_rate - (1 / 3)) < 1e-6
+    # Top tools: Bash com 2, Read com 1
+    top = dict(out.top_tools)
+    assert top.get("Bash") == 2
+    assert top.get("Read") == 1
+    # Duracao: ~12s = 12000ms
+    assert out.duration_ms == 12000
+
+
+def test_filtra_por_session_id_ignora_outros(tmp_path) -> None:
+    log = tmp_path / "sessions.log"
+    base = datetime(2026, 4, 28, 10, 0, 0, tzinfo=UTC)
+    _write_log(log, [
+        _line(ts=base, session="0efd3cf4-96ef-41b7-9d41-f91ec539becd"),
+        _line(ts=base + timedelta(seconds=1),
+              session="aaaaaaaa-1111-4111-8111-111111111111"),
+        _line(ts=base + timedelta(seconds=2),
+              session="0efd3cf4-96ef-41b7-9d41-f91ec539becd"),
+    ])
+    out = build_partial_stats_from_audit(
+        "0efd3", audit_log_path=log
+    )
+    assert out is not None
+    assert out.total_calls == 2
+
+
+def test_ignora_linhas_malformadas(tmp_path) -> None:
+    """Parser retorna None pra lixo; helper pula sem crashar."""
+    log = tmp_path / "sessions.log"
+    base = datetime(2026, 4, 28, 10, 0, 0, tzinfo=UTC)
+    valid_line = _line(ts=base)
+    log.write_text(
+        "lixo nao parseavel\n"
+        + valid_line + "\n"
+        + "0efd3 mas tambem lixo\n",  # contem o prefix mas nao parseia
+        encoding="utf-8",
+    )
+    out = build_partial_stats_from_audit(
+        "0efd3", audit_log_path=log
+    )
+    assert out is not None
+    assert out.total_calls == 1
+
+
+def test_entries_ordenadas_por_timestamp(tmp_path) -> None:
+    """Mesmo se log for fora de ordem, helper ordena defensivamente."""
+    log = tmp_path / "sessions.log"
+    base = datetime(2026, 4, 28, 10, 0, 0, tzinfo=UTC)
+    _write_log(log, [
+        _line(ts=base + timedelta(seconds=10), tool="Edit"),
+        _line(ts=base, tool="Bash"),
+        _line(ts=base + timedelta(seconds=5), tool="Read"),
+    ])
+    out = build_partial_stats_from_audit(
+        "0efd3", audit_log_path=log
+    )
+    assert out is not None
+    tools_in_order = [e.tool for e in out.entries]
+    assert tools_in_order == ["Bash", "Read", "Edit"]
+
+
+def test_drill_down_cli_caminho_3_sem_dado(monkeypatch, tmp_path, capsys) -> None:
+    """views/session.py:run -> mensagem 'Nao existem dados' quando nem JSONL nem audit."""
+    from claude_dash.audit import partial_stats as ps_mod
+    from claude_dash.views import session as view_session
+
+    # Aponta default audit log pra arquivo inexistente
+    fake_log = tmp_path / "missing.log"
+    monkeypatch.setattr(
+        view_session, "build_partial_stats_from_audit",
+        lambda sid: ps_mod.build_partial_stats_from_audit(
+            sid, audit_log_path=fake_log,
+        ),
+    )
+    monkeypatch.setattr(
+        view_session, "find_transcript_for_session", lambda sid: None,
+    )
+    rc = view_session.run("nonexistent-sid")
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Nao existem dados neste host" in out
+
+
+def test_drill_down_cli_caminho_2_partial(monkeypatch, tmp_path, capsys) -> None:
+    """views/session.py:run -> drill-down parcial quando ha audit mas nao JSONL."""
+    from claude_dash.audit import partial_stats as ps_mod
+    from claude_dash.views import session as view_session
+
+    log = tmp_path / "sessions.log"
+    base = datetime(2026, 4, 28, 10, 0, 0, tzinfo=UTC)
+    _write_log(log, [
+        _line(ts=base, host="PREDATOR", tool="Bash"),
+        _line(ts=base + timedelta(seconds=5), host="PREDATOR", tool="Read"),
+    ])
+    monkeypatch.setattr(
+        view_session, "build_partial_stats_from_audit",
+        lambda sid: ps_mod.build_partial_stats_from_audit(
+            sid, audit_log_path=log,
+        ),
+    )
+    monkeypatch.setattr(
+        view_session, "find_transcript_for_session", lambda sid: None,
+    )
+    rc = view_session.run("0efd3")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Header parcial menciona origem e aviso
+    assert "PREDATOR" in out
+    assert "Origem" in out
+    # Resumo conta tool calls
+    assert "Tool calls" in out


### PR DESCRIPTION
Etapa 2 do plano de implementação das issues abertas. Resolve o cenário cross-device em que a aba `Audit` mostrava entries de outros hosts misturadas (porque `sessions.log` é syncado), com drill-down quebrando ao tentar abrir uma sessão cujo JSONL está em outra máquina.

## Mudanças

### Aba Audit

- Coluna `host` na tabela exibindo o `hostname` de cada entry.
- Default filtra apenas entries do host atual (`CURRENT_HOSTNAME = socket.gethostname().split('.')[0]`); tecla `h` toggla pra "todos os hosts" (entries de outros hosts em estilo `dim`).
- `parse_filter_input` aceita `/host=<name>` como quarta key (prefix-match). Quando setado, o filtro implícito do host atual fica automaticamente suspenso — `/host=PREDATOR` em RET-DTI funciona sem precisar fazer toggle também.
- Footer indica `host=<atual>` ou `host=todos` ao lado de `window=`, `filter=`, `show-tests=`.
- Entries com `hostname` vazio (logs antigos pré-#55) sempre passam — tratadas como "host desconhecido" em vez de escondidas.

### Drill-down em 3 níveis

`claude-dash session <sid>` (e o `s` na aba Audit) agora reage de forma honesta ao estado dos dados:

1. **JSONL local existe** → drill-down completo (header + overview + timeline + subagents — comportamento atual).
2. **Sem JSONL, com metadata em `sessions.log`** → drill-down parcial: header destacando `Origem: <hostname>` e aviso de que dados de turno/custo não estão disponíveis; tabela de tool calls (timestamp, tool, dur_ms, status); agregados (total, erros, duração derivada de first_ts → last_ts, top tools).
3. **Nem JSONL nem metadata** → mensagem clara `Nao existem dados neste host sobre a sessao '<sid>'` em vez do antigo "transcript não encontrado" genérico.

Caminho 2 também serve quando o JSONL local foi rotacionado/limpo na própria máquina de origem — não é exclusivo do cenário cross-device.

## Implementação

- Novo módulo `claude_dash.audit.partial_stats`: dataclass `PartialSessionStats` (com `top_tools`, `error_count`, `duration_ms` como properties) e helper `build_partial_stats_from_audit(sid, audit_log_path=...)`. Pure-function, testável sem TUI.
- Nova constante `claude_dash.audit.CURRENT_HOSTNAME` resolvida no import — usada pela TUI como default do filtro.
- `views/audit.py:filter_entries` ganhou kwarg `current_host`; `parse_filter_input` aceita `host=`.
- `views/audit.py:render_table` ganhou kwarg `current_host` e coluna `host`; entries de outro host viram `dim`.
- `views/tui.py`: tecla `h` (`audit_toggle_host`), estado `_audit_host_only_current`, signature do rebuild incremental inclui `current_host`, célula `host` na DataTable, dim styling cross-host.
- `views/session.py:run` reorganizado em três caminhos explícitos com fallback ordenado: JSONL → audit metadata → mensagem.

## Validação

- `uv run --extra dev pytest -x -q`: **311 passed, 1 skipped** (era 296).
- 7 testes novos em `test_audit_view.py` (filter por host, parse `/host=`, coluna na render_table, dim styling).
- 8 testes novos em `test_partial_stats.py` (helper com fixture sintética de `sessions.log`, dois casos do drill-down via `monkeypatch`).
- Lint limpo nos arquivos tocados (RUF001/RUF002 pré-existentes em `account.py` não relacionadas).
- Bump `v0.14.5 → v0.14.6` (minor — adição compatível, sem breaking).

## Como testar manualmente

```bash
cd ~/Desenvolvimento/mencoding/claude-dashboard
git checkout feat/audit-hostname-55
pipx install --force --editable .
claude-dash --version    # 0.14.6
claude-dash              # TUI
```

Aba Audit (tecla `5`):
- Coluna `host` deve aparecer entre `sess` e `tool`.
- Por padrão só entries de `RET-DTI-601048` (filtra implicitamente).
- `h` toggla pra "todos os hosts" — entries de PREDATOR/VAIO aparecem em dim.
- `/host=PREDATOR` filtra explicitamente; footer muda pra `filter:host=PREDATOR`.
- `/` + `Esc` limpa filtro.

Drill-down via CLI (testa caminho 2 sem precisar de TUI):
```bash
# Pega um SID que rodou em outra máquina (do PREDATOR, por exemplo)
grep -oE 'session="[^"]+"' ~/.claude/iris/audit/sessions.log | sort -u | head
claude-dash session <sid-do-predator>
# Esperado: header "claude-dash session (parcial)" + "Origem: PREDATOR" + tabela de tool calls
```

Caminho 3:
```bash
claude-dash session abcd-nao-existe
# Esperado: "Nao existem dados neste host sobre a sessao 'abcd-nao-existe'."
```

## Próxima etapa

#37 (notificações push para `status=error`) ou #52 (grupo `claude-audit`) — sua escolha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)