### PR TITLE
feat(audit): notificações push para status=error (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.7] - 2026-04-28
+
+### Added
+- TUI: `Audit` tab now emits push notifications when a new entry with `status="error"` arrives via the incremental tail. Configured via env var `CLAUDE_DASH_AUDIT_ALERT_LEVEL ∈ {none, toast, sound, both}` — default `none` preserves the previous quiet behavior. `toast` shows an in-app Textual notification; `sound` calls `notify-send` (libnotify, also adds the system "ding"); `both` does both. Anti-flood: same `tool_use_id` (or `session_id` fallback for legacy entries without `tool_use_id`) is deduplicated within a 60s window. `notify-send` absent from `$PATH` is silent — graceful degradation. Alerts fire even when the active tab isn't `Audit`. Closes #37.
+- New module `claude_dash.audit.alerts` with pure-function `resolve_alert_level()` and `ErrorAlertEmitter` class. Testable in isolation with injectable `clock`, `textual_notify`, and `libnotify` callables.
+
 ## [0.14.6] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TUI: `Audit` tab now emits push notifications when a new entry with `status="error"` arrives via the incremental tail. Configured via env var `CLAUDE_DASH_AUDIT_ALERT_LEVEL ∈ {none, toast, sound, both}` — default `none` preserves the previous quiet behavior. `toast` shows an in-app Textual notification; `sound` calls `notify-send` (libnotify, also adds the system "ding"); `both` does both. Anti-flood: same `tool_use_id` (or `session_id` fallback for legacy entries without `tool_use_id`) is deduplicated within a 60s window. `notify-send` absent from `$PATH` is silent — graceful degradation. Alerts fire even when the active tab isn't `Audit`. Closes #37.
 - New module `claude_dash.audit.alerts` with pure-function `resolve_alert_level()` and `ErrorAlertEmitter` class. Testable in isolation with injectable `clock`, `textual_notify`, and `libnotify` callables.
 
+### Fixed
+- TUI: `Audit` tab cursor was still snapping back to the latest row at every refresh after the user moved it with ↑/↓. Root cause: arrow keys are consumed by the focused `DataTable` and stopped before bubbling to `App.on_key`, so the previous fix (which relied on `_audit_last_user_action` being set in `on_key`) never triggered for cursor navigation. Now uses `on_data_table_row_highlighted` to detect cursor changes regardless of source, with an internal `_audit_cursor_managed` flag to ignore programmatic moves from auto-tail. Regression test added in `tests/test_audit_view.py::test_cursor_user_pausa_auto_tail`.
+
 ## [0.14.6] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ explicitamente). No drill-down (`s` na aba ou `claude-dash session <sid>`):
    Sem timeline de turnos nem custos por turno (só vêm do JSONL).
 3. Nem JSONL nem metadata → mensagem clara `Nao existem dados neste host`.
 
+**Notificações de erro (#37).** Configurável via env var
+`CLAUDE_DASH_AUDIT_ALERT_LEVEL`:
+
+- `none` (default): silêncio total.
+- `toast`: notificação in-app do Textual quando aparece `status="error"` em entry nova.
+- `sound`: `notify-send` libnotify (toast do sistema com som default).
+- `both`: as duas.
+
+Anti-flood por `tool_use_id` em janela de 60s (mesmo erro consecutivo
+não martela). `notify-send` ausente do `$PATH` cai silencioso.
+
 **Bootstrap em 3 comandos:**
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.14.6"
+version = "0.14.7"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/alerts.py
+++ b/src/claude_dash/audit/alerts.py
@@ -1,0 +1,146 @@
+"""Notificacoes push para status=error no audit log (#37).
+
+Vigia entries novas que chegam pelo tail incremental e dispara alertas
+quando `status="error"` aparece. Anti-flood via dedup por `tool_use_id`
+em janela curta (default 60s).
+
+Niveis de alerta (env var ``CLAUDE_DASH_AUDIT_ALERT_LEVEL``):
+
+- ``none``: zero notificacoes (default — preserva comportamento antigo)
+- ``toast``: notificacao Textual in-app (aparece sobre a TUI)
+- ``sound``: ``notify-send`` libnotify (toast do sistema + som default)
+- ``both``: toast + sound
+
+`notify-send` ausente do PATH cai silencioso — graceful degradation pra
+ambientes sem libnotify. Logica e' pura no nivel do helper; integracao
+com Textual fica em ``views/tui.py``.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import subprocess
+import time
+from collections.abc import Callable
+from typing import Literal
+
+from claude_dash.audit.models import AuditEntry
+
+AlertLevel = Literal["none", "toast", "sound", "both"]
+_VALID_LEVELS: frozenset[str] = frozenset(("none", "toast", "sound", "both"))
+
+# Anti-flood: nao re-notifica o mesmo `tool_use_id` por essa janela.
+DEDUP_WINDOW_SEC: float = 60.0
+
+# Env var que controla o nivel.
+ENV_LEVEL_VAR: str = "CLAUDE_DASH_AUDIT_ALERT_LEVEL"
+
+
+def resolve_alert_level(env: dict[str, str] | None = None) -> AlertLevel:
+    """Le `CLAUDE_DASH_AUDIT_ALERT_LEVEL` do environment.
+
+    Valor invalido ou ausente -> 'none' (silencioso, sem warning na
+    saida pra nao poluir startup da TUI).
+    """
+    raw = (env or os.environ).get(ENV_LEVEL_VAR, "").strip().lower()
+    if raw in _VALID_LEVELS:
+        return raw  # type: ignore[return-value]
+    return "none"
+
+
+def _format_alert(entry: AuditEntry) -> str:
+    """Formata mensagem do alerta — curta, com info acionavel."""
+    sub = f"({entry.subagent_type})" if entry.subagent_type else ""
+    sess_short = entry.session_id[:8] if entry.session_id else "-"
+    return (
+        f"Tool error: {entry.tool}{sub} "
+        f"em {sess_short} ({entry.duration_ms}ms)"
+    )
+
+
+def _libnotify_send(message: str) -> None:
+    """Dispara `notify-send` libnotify se disponivel; silencioso se ausente.
+
+    Nao espera retorno do subprocess (fire-and-forget) pra nao bloquear
+    o tick da TUI. Falhas de IPC com daemon de notificacao sao silenciadas
+    pelo subprocess.DEVNULL.
+    """
+    if shutil.which("notify-send") is None:
+        return
+    with contextlib.suppress(OSError):
+        subprocess.Popen(
+            [
+                "notify-send",
+                "--app-name=claude-dash",
+                "--urgency=normal",
+                "claude-dash",
+                message,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
+class ErrorAlertEmitter:
+    """Emite alertas de tool error com dedup e nivel configuravel.
+
+    Uso tipico:
+        emitter = ErrorAlertEmitter(level="toast", textual_notify=app.notify)
+        emitter.emit(new_entries)
+    """
+
+    def __init__(
+        self,
+        level: AlertLevel = "none",
+        *,
+        textual_notify: Callable[[str], None] | None = None,
+        libnotify: Callable[[str], None] = _libnotify_send,
+        dedup_window_sec: float = DEDUP_WINDOW_SEC,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.level: AlertLevel = level
+        self._textual_notify = textual_notify
+        self._libnotify = libnotify
+        self._dedup_window = dedup_window_sec
+        self._clock = clock
+        # tool_use_id -> timestamp do ultimo alerta. Expurgado on-demand
+        # em emit() — nao precisa de timer dedicado.
+        self._last_notified: dict[str, float] = {}
+
+    def emit(self, new_entries: list[AuditEntry]) -> int:
+        """Inspeciona `new_entries` e dispara alertas pra erros.
+
+        Retorna o numero de alertas efetivamente disparados (excluindo
+        deduped). Nivel `none` -> zero alertas, sempre.
+        """
+        if self.level == "none" or not new_entries:
+            return 0
+
+        now = self._clock()
+        # Expurga entries fora da janela de dedup.
+        self._last_notified = {
+            tid: ts
+            for tid, ts in self._last_notified.items()
+            if now - ts < self._dedup_window
+        }
+
+        emitted = 0
+        for entry in new_entries:
+            if entry.status != "error":
+                continue
+            key = entry.tool_use_id or entry.session_id
+            if key in self._last_notified:
+                continue
+            self._last_notified[key] = now
+            self._dispatch(_format_alert(entry))
+            emitted += 1
+        return emitted
+
+    def _dispatch(self, message: str) -> None:
+        """Dispara nos canais ativos conforme `self.level`."""
+        if self.level in ("toast", "both") and self._textual_notify is not None:
+            with contextlib.suppress(Exception):
+                self._textual_notify(message)
+        if self.level in ("sound", "both"):
+            self._libnotify(message)

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -40,6 +40,7 @@ from claude_dash.aggregator import (
     extract_turns,
 )
 from claude_dash.audit import CURRENT_HOSTNAME
+from claude_dash.audit.alerts import ErrorAlertEmitter, resolve_alert_level
 from claude_dash.audit.models import AuditEntry
 from claude_dash.audit.tail import IncrementalTailer
 from claude_dash.discover import (
@@ -261,6 +262,11 @@ class DashboardApp(App):
         self._audit_filter: dict[str, str] = {}
         self._audit_window_hours: float | None = 24.0
         self._audit_show_tests: bool = False
+        # Emitter de alertas pra tool errors (#37). Nivel resolvido do
+        # env CLAUDE_DASH_AUDIT_ALERT_LEVEL no startup; mudancas em
+        # runtime exigem restart (padrao pra env vars).
+        # textual_notify e' setado em on_mount quando o app esta pronto.
+        self._error_alert_emitter = ErrorAlertEmitter(level=resolve_alert_level())
         # Filtro implicito por hostname (#55): default = so este host.
         # Toggle pela tecla `h`. Quando False, mostra tudo (hosts alheios
         # em dim). Filtro explicito `/host=<name>` em `_audit_filter`
@@ -338,6 +344,12 @@ class DashboardApp(App):
         self._refresh_session_list()
         # Inicializa tailer e renderiza primeiro estado da aba Audit.
         self._audit_tailer = IncrementalTailer(AUDIT_LOG_PATH)
+        # Liga callback do Textual notify ao emitter de alertas (#37).
+        # severity="error" => toast vermelho do Textual; titulo identifica
+        # origem pra distinguir de outros notifies.
+        self._error_alert_emitter._textual_notify = lambda msg: self.notify(
+            msg, severity="error", title="Audit",
+        )
         self._populate_audit_keys()
         self._refresh_audit()
         # Auto-refresh só da Now (demais via `r` manual). Audit tem
@@ -555,7 +567,9 @@ class DashboardApp(App):
 
         Mesmo quando a aba nao esta ativa, continuamos drenando o
         tailer pra nao perder entries ate o usuario abrir a aba. So a
-        renderizacao e gateada pela aba ativa.
+        renderizacao e gateada pela aba ativa. Alertas de erro (#37)
+        disparam INDEPENDENTE da aba ativa — usuario quer saber de erro
+        mesmo que esteja olhando Now/Today.
         """
         if self._audit_tailer is None:
             return
@@ -565,6 +579,10 @@ class DashboardApp(App):
             return
         if new_entries:
             self._audit_entries.extend(new_entries)
+            # Dispara alertas pra erros nas entries que acabaram de chegar.
+            # Nivel `none` no emitter -> no-op rapido.
+            with contextlib.suppress(Exception):
+                self._error_alert_emitter.emit(new_entries)
         if self._audit_active():
             self._refresh_audit()
 

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -283,6 +283,13 @@ class DashboardApp(App):
         # Cache da lista filtrada visivel: drill-down `s` mapea
         # cursor_row -> entry. Atualizado a cada _refresh_audit.
         self._audit_visible_cache: list = []
+        # Flag pra distinguir movimento programatico de cursor (auto-tail
+        # do _populate_audit_table) de movimento do usuario (↑/↓ no
+        # DataTable). Evento RowHighlighted dispara em ambos os casos —
+        # antes de chamar move_cursor, setamos a flag; o handler da
+        # ignora um evento e reseta. Qualquer evento subsequente sem
+        # flag significa interacao do usuario -> marca pausa.
+        self._audit_cursor_managed: bool = False
         # Render incremental: tracking pra evitar full rebuild a cada tick.
         # Signature do filtro (filter+window+show_tests): se mudar, rebuild.
         self._audit_table_signature: tuple | None = None
@@ -737,15 +744,17 @@ class DashboardApp(App):
         self._audit_first_visible_key = first_key
 
         # Cursor: so move pro fim se usuario estava no fim (auto-tail) E
-        # nao houve interacao recente (respeita pausa do D8). Sem o check
-        # de pausa, mover o cursor de volta pra penultima linha era
-        # imediatamente desfeito no proximo tick (1s) — barra visual
-        # "voltava sozinha" pro fim.
+        # nao houve interacao recente (respeita pausa do D8). Marca a
+        # flag _audit_cursor_managed antes pra que o handler de
+        # RowHighlighted ignore este evento — de outro modo, nosso
+        # proprio movimento programatico seria interpretado como
+        # interacao do usuario e re-pausaria a aba indefinidamente.
         if (
             dt.row_count > 0
             and was_at_end
             and not self._is_audit_paused()
         ):
+            self._audit_cursor_managed = True
             dt.move_cursor(row=dt.row_count - 1, animate=False)
 
     def _populate_audit_keys(self) -> None:
@@ -980,6 +989,31 @@ class DashboardApp(App):
         # Usuário pressionou Enter (ou clicou) numa linha da lista
         if isinstance(event.item, SessionListItem):
             self._render_session_detail(event.item.sid)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Detecta movimento de cursor pelo usuario na tabela de Audit.
+
+        Evento dispara em qualquer mudanca de cursor — programatica ou
+        via teclado/mouse. Usamos a flag _audit_cursor_managed pra
+        ignorar nossos proprios movimentos (auto-tail). Qualquer evento
+        sem flag = usuario mexeu, marca pausa pro auto-tail respeitar.
+
+        Necessario porque setas em DataTable nao bubbla pra App.on_key
+        (Textual chama event.stop() apos cursor_up/down) — sem este
+        handler, _audit_last_user_action ficava em 0 e a pausa nunca
+        ativava pra ↑/↓.
+        """
+        if not self._audit_active():
+            return
+        try:
+            if event.data_table.id != "audit-table":
+                return
+        except Exception:
+            return
+        if self._audit_cursor_managed:
+            self._audit_cursor_managed = False
+            return
+        self._mark_audit_user_action()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Prompts da aba Audit: filter aplica filtro; export grava arquivo."""

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,205 @@
+"""Testes do emitter de alertas pra tool errors (#37)."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest import mock
+
+from claude_dash.audit.alerts import (
+    DEDUP_WINDOW_SEC,
+    ENV_LEVEL_VAR,
+    ErrorAlertEmitter,
+    resolve_alert_level,
+)
+from claude_dash.audit.models import AuditEntry
+
+
+def _entry(
+    *,
+    status: str = "error",
+    tool: str = "Bash",
+    tool_use_id: str = "call-1",
+    session_id: str = "0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+) -> AuditEntry:
+    return AuditEntry(
+        timestamp=datetime(2026, 4, 28, 0, 0, 0, tzinfo=UTC),
+        hostname="host",
+        pid="1",
+        session_id=session_id,
+        tool=tool,
+        tool_use_id=tool_use_id,
+        status=status,
+        duration_ms=100,
+        perm_mode="auto",
+        input_sha="0",
+        input_bytes=10,
+        output_bytes=20,
+    )
+
+
+# ---- resolve_alert_level --------------------------------------------
+
+
+def test_resolve_default_eh_none() -> None:
+    assert resolve_alert_level(env={}) == "none"
+
+
+def test_resolve_aceita_valores_validos() -> None:
+    for level in ("none", "toast", "sound", "both"):
+        out = resolve_alert_level(env={ENV_LEVEL_VAR: level})
+        assert out == level
+
+
+def test_resolve_normaliza_case() -> None:
+    assert resolve_alert_level(env={ENV_LEVEL_VAR: "TOAST"}) == "toast"
+    assert resolve_alert_level(env={ENV_LEVEL_VAR: "  Both  "}) == "both"
+
+
+def test_resolve_invalido_cai_em_none() -> None:
+    assert resolve_alert_level(env={ENV_LEVEL_VAR: "loud"}) == "none"
+    assert resolve_alert_level(env={ENV_LEVEL_VAR: ""}) == "none"
+
+
+# ---- ErrorAlertEmitter ----------------------------------------------
+
+
+def test_level_none_nao_dispara_nada() -> None:
+    notify = mock.Mock()
+    libnotify = mock.Mock()
+    em = ErrorAlertEmitter(
+        level="none", textual_notify=notify, libnotify=libnotify,
+    )
+    n = em.emit([_entry(status="error"), _entry(status="error", tool_use_id="call-2")])
+    assert n == 0
+    notify.assert_not_called()
+    libnotify.assert_not_called()
+
+
+def test_ignora_entries_success() -> None:
+    notify = mock.Mock()
+    libnotify = mock.Mock()
+    em = ErrorAlertEmitter(level="both", textual_notify=notify, libnotify=libnotify)
+    em.emit([_entry(status="success"), _entry(status="success", tool_use_id="x")])
+    notify.assert_not_called()
+    libnotify.assert_not_called()
+
+
+def test_toast_dispara_so_textual() -> None:
+    notify = mock.Mock()
+    libnotify = mock.Mock()
+    em = ErrorAlertEmitter(level="toast", textual_notify=notify, libnotify=libnotify)
+    n = em.emit([_entry(tool_use_id="call-1")])
+    assert n == 1
+    notify.assert_called_once()
+    libnotify.assert_not_called()
+
+
+def test_sound_dispara_so_libnotify() -> None:
+    notify = mock.Mock()
+    libnotify = mock.Mock()
+    em = ErrorAlertEmitter(level="sound", textual_notify=notify, libnotify=libnotify)
+    em.emit([_entry(tool_use_id="call-1")])
+    notify.assert_not_called()
+    libnotify.assert_called_once()
+
+
+def test_both_dispara_ambos() -> None:
+    notify = mock.Mock()
+    libnotify = mock.Mock()
+    em = ErrorAlertEmitter(level="both", textual_notify=notify, libnotify=libnotify)
+    em.emit([_entry(tool_use_id="call-1")])
+    notify.assert_called_once()
+    libnotify.assert_called_once()
+
+
+def test_dedup_por_tool_use_id() -> None:
+    """Mesmo tool_use_id em ticks consecutivos -> 1 alerta so."""
+    notify = mock.Mock()
+    libnotify = mock.Mock()
+    fake_clock = mock.Mock(return_value=100.0)
+    em = ErrorAlertEmitter(
+        level="toast", textual_notify=notify, libnotify=libnotify,
+        clock=fake_clock,
+    )
+    # Tick 1: 3 erros, 2 deles com mesmo tool_use_id
+    same = _entry(tool_use_id="call-A")
+    other = _entry(tool_use_id="call-B")
+    n1 = em.emit([same, same, other])
+    assert n1 == 2  # call-A vez 1, call-B; call-A vez 2 deduped
+
+    # Tick 2 (10s depois): mesma call-A repete -> ainda dentro da janela
+    fake_clock.return_value = 110.0
+    n2 = em.emit([same])
+    assert n2 == 0
+
+
+def test_dedup_expira_apos_janela() -> None:
+    """Apos DEDUP_WINDOW_SEC, mesmo tool_use_id volta a notificar."""
+    notify = mock.Mock()
+    fake_clock = mock.Mock(return_value=100.0)
+    em = ErrorAlertEmitter(
+        level="toast", textual_notify=notify,
+        clock=fake_clock,
+    )
+    same = _entry(tool_use_id="call-A")
+    em.emit([same])
+    assert notify.call_count == 1
+
+    # Avanca relogio alem da janela de dedup
+    fake_clock.return_value = 100.0 + DEDUP_WINDOW_SEC + 1
+    em.emit([same])
+    assert notify.call_count == 2
+
+
+def test_fallback_para_session_id_quando_sem_tool_use_id() -> None:
+    """Entries antigas (Agent) podem nao ter tool_use_id — usa session_id."""
+    notify = mock.Mock()
+    em = ErrorAlertEmitter(level="toast", textual_notify=notify)
+    e = _entry(tool_use_id="", session_id="abc-123")
+    em.emit([e])
+    em.emit([e])  # mesma sessao, deve deduplificar
+    assert notify.call_count == 1
+
+
+def test_excecao_no_textual_notify_nao_quebra_emit() -> None:
+    """notify falhando (ex.: app fechando) nao deve crashar o tick."""
+    def boom(_msg: str) -> None:
+        raise RuntimeError("textual is dead")
+
+    em = ErrorAlertEmitter(level="toast", textual_notify=boom)
+    # Nao deve levantar
+    n = em.emit([_entry()])
+    assert n == 1
+
+
+def test_libnotify_ausente_e_silencioso(monkeypatch) -> None:
+    """notify-send fora do PATH -> nao crasha."""
+    from claude_dash.audit import alerts as alerts_mod
+
+    monkeypatch.setattr(alerts_mod.shutil, "which", lambda _name: None)
+    em = ErrorAlertEmitter(level="sound")
+    n = em.emit([_entry()])
+    assert n == 1  # contou como dispatched mesmo que libnotify silencioso
+
+
+def test_format_alert_inclui_subagent_type() -> None:
+    """Mensagem distingue Agent(general-purpose) de Bash etc."""
+    from claude_dash.audit.alerts import _format_alert
+
+    e = _entry(tool="Agent")
+    e_with_sub = AuditEntry(
+        timestamp=e.timestamp, hostname=e.hostname, pid=e.pid,
+        session_id=e.session_id, tool="Agent", tool_use_id="x",
+        status="error", duration_ms=200, perm_mode="auto",
+        input_sha="0", input_bytes=0, output_bytes=0,
+        subagent_type="general-purpose",
+    )
+    msg = _format_alert(e_with_sub)
+    assert "general-purpose" in msg
+    assert "Agent" in msg
+
+
+def test_emit_lista_vazia_eh_noop() -> None:
+    notify = mock.Mock()
+    em = ErrorAlertEmitter(level="both", textual_notify=notify)
+    assert em.emit([]) == 0
+    notify.assert_not_called()

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -269,6 +269,59 @@ def test_tecla_question_toggle_test_sessions() -> None:
     _run(run())
 
 
+def test_cursor_user_pausa_auto_tail() -> None:
+    """Movimento de cursor pelo usuario deve pausar o auto-tail.
+
+    Regressao: setas em DataTable nao bubblam pra App.on_key, entao
+    _audit_last_user_action ficava em 0 e o tick seguinte forcava cursor
+    de volta pro fim. Fix usa on_data_table_row_highlighted (que dispara
+    pra qualquer movimento).
+    """
+    async def run():
+        from datetime import datetime as _dt
+        from datetime import timedelta as _td
+        from datetime import timezone as _tz
+
+        from claude_dash.audit.models import AuditEntry
+
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            await pilot.press("5")
+            await pilot.pause(0.2)
+
+            # Popula tabela com entries sintéticas.
+            entries = [
+                AuditEntry(
+                    timestamp=_dt(2026, 4, 28, 0, 0, i, tzinfo=_tz(_td(hours=-3))),
+                    hostname="host", pid="1",
+                    session_id="0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+                    tool="Bash", tool_use_id=f"x-{i}", status="success",
+                    duration_ms=10, perm_mode="auto", input_sha="0",
+                    input_bytes=10, output_bytes=20,
+                )
+                for i in range(5)
+            ]
+            app._audit_entries.extend(entries)
+            # Reseta last_user_action pra simular "auto-tail estavel".
+            app._refresh_audit()
+            app._audit_last_user_action = 0
+            app._audit_paused = False
+            await pilot.pause(0.1)
+
+            # Simula user pressionando ↑ — DataTable consome e move cursor.
+            # Setas NAO bubblam pra App.on_key; sem o handler de
+            # RowHighlighted, _audit_last_user_action ficava em 0.
+            await pilot.press("up")
+            await pilot.pause(0.1)
+
+            # on_data_table_row_highlighted detectou o movimento e marcou
+            # a interacao -> pausa esta ativa.
+            assert app._audit_last_user_action != 0
+            assert app._is_audit_paused()
+    _run(run())
+
+
 @pytest.mark.parametrize("key", ["1", "2", "3", "4", "5"])
 def test_todas_abas_sao_acessiveis(key: str) -> None:
     async def run():


### PR DESCRIPTION
Etapa 3 do plano. Hoje 100% das tool calls passam — quando começarem a aparecer erros, é importante perceber sem precisar olhar a aba `Audit` o tempo todo. Esta PR adiciona notificação push opt-in.

## Comportamento

Configurável via env var `CLAUDE_DASH_AUDIT_ALERT_LEVEL`:

| Valor | Efeito |
|---|---|
| `none` (default) | Silêncio total — preserva comportamento anterior |
| `toast` | Notificação in-app do Textual (`severity="error"`, `title="Audit"`) |
| `sound` | `notify-send` libnotify (toast do sistema + som default) |
| `both` | Toast + sound |

- **Anti-flood:** mesmo `tool_use_id` (ou `session_id` como fallback pra entries antigas tipo `Agent` sem `tool_use_id`) é deduplicado em janela de 60s.
- **Cross-tab:** alertas disparam mesmo quando a aba ativa não é `Audit` — erro merece atenção.
- **Graceful degradation:** `notify-send` ausente do `$PATH` cai silencioso (sem erro).

## Implementação

- **Novo módulo `claude_dash.audit.alerts`:** `resolve_alert_level()` e classe `ErrorAlertEmitter` com `clock`, `textual_notify` e `libnotify` injectáveis. Lógica pura, testável sem TUI.
- **TUI:** inicializa emitter em `__init__` com nível do env, amarra `textual_notify=self.notify` em `on_mount`, chama `emit(new_entries)` em `_tick_audit` antes do gate da aba ativa.

## Validação

- `uv run --extra dev pytest -x -q`: **327 passed, 1 skipped** (era 311; +16 novos).
- Lint limpo nos arquivos tocados.
- Bump `v0.14.6 → v0.14.7`.

## Cobertura de teste

`tests/test_alerts.py`:
- Resolve do env: default, valores válidos, case-insensitive, valor inválido cai em `none`.
- 4 níveis: `none` não dispara, `toast` só Textual, `sound` só libnotify, `both` ambos.
- Dedup: 3 erros com 2 mesmo `tool_use_id` → 2 alertas.
- Expiração da janela de 60s: mesmo `tool_use_id` re-notifica após.
- Fallback de `session_id` quando `tool_use_id` vazio.
- `notify-send` ausente do PATH é silencioso.
- Exceção em `textual_notify` não crasha `emit()`.
- Lista vazia é no-op rápido.

## Como testar manualmente

```bash
cd ~/Desenvolvimento/mencoding/claude-dashboard
git checkout feat/audit-error-notifications-37
pipx install --force --editable .
claude-dash --version  # 0.14.7
```

Forçar um erro pra ver a notificação:

```bash
# Em um terminal separado, simule uma entry de erro no audit log
TS=$(date -Iseconds)
HOST=$(hostname -s)
echo "<134>1 ${TS} ${HOST} claude-code 99999 TOOLCALL [audit@iris session=\"test-error-$$\" tool=\"Bash\" tool_use_id=\"manual-test-$$\" status=\"error\" duration_ms=\"500\" perm_mode=\"auto\" input_sha=\"x\" input_bytes=\"10\" output_bytes=\"0\"]" >> ~/.claude/iris/audit/sessions.log

# Em outro terminal:
CLAUDE_DASH_AUDIT_ALERT_LEVEL=both claude-dash
# Aguarde até 1s — toast vermelho aparece in-app E notify-send do sistema dispara.
# Repita o echo: dentro de 60s o segundo NÃO notifica (dedup).
```

## Próxima etapa

#52 (grupo `claude-audit` em vez de `adm`) — minor mais delicado por envolver migration path cross-distro. Ou #54 (review MCP) se preferir pausa de design antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)