### PR TITLE
feat(audit): grupo dedicado `claude-audit` em vez de `adm` (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-04-28
+
+### Changed
+- **Audit log group migrated from `adm` to dedicated `claude-audit`.** `/var/log/claude/tools.log` is now `syslog:claude-audit 0640` instead of `syslog:adm 0640`. Templates `rsyslog-30-claude-audit.conf` (`fileGroup="claude-audit"`) and `logrotate-system-claude-audit` (`create 0640 syslog claude-audit`) updated accordingly. Closes #52.
+
+### Added
+- `claude-dash setup-audit` root script now creates the `claude-audit` group via `groupadd -f` (idempotent), adds the invoking user (`SUDO_USER`) via `usermod -aG`, and `chown`s `/var/log/claude/` plus existing rotated `.gz` files to `syslog:claude-audit`. Migration is automatic on re-run.
+- State detector reports three new lines in `_print_state`: `grupo claude-audit`, `user no grupo`, `tools.log no grupo` — useful to verify migration completion at a glance.
+- `claude_dash.audit.setup.CLAUDE_AUDIT_GROUP` exported as `"claude-audit"` constant; helpers `_claude_audit_group_exists()`, `_user_in_claude_audit_group()`, `_var_log_owned_by_claude_audit()` for state detection (testable).
+
+### Migration
+
+Re-run `claude-dash setup-audit` after upgrade:
+
+```bash
+claude-dash setup-audit
+sudo bash /tmp/claude-audit-root-setup.sh
+# Re-login (or `newgrp claude-audit` in a fresh shell) for group membership to take effect.
+```
+
+The script is idempotent — running it twice produces the same state. Existing v0.14.x installs that were on the `adm` group continue working until the script is re-run, but the TUI drill-down (`s` key) will fail with a permission error until the user is in `claude-audit`.
+
+### Cross-distro
+
+`adm` is a Debian-family convention; Fedora/Arch may lack it or use it differently. `claude-audit` is portable across distros via `groupadd`/`usermod` (shadow-utils, ubiquitous on mainstream Linux). Validated on Debian-family; not yet validated on RHEL/Fedora/Arch — please report if you run setup-audit on a non-Debian distro.
+
+### Reasoning
+
+- **Least privilege**: membership in `claude-audit` grants access only to Claude audit logs, not all of `/var/log/`.
+- **Auditability**: `getent group claude-audit` lists exactly who has visibility.
+- **Revocability**: removing a user from `claude-audit` revokes audit-only access without affecting other system roles.
+
 ## [0.14.7] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ escreve em **dois destinos**, cada um com um propósito distinto:
 
 | Destino | Conteúdo | Permissão | Sync Drive |
 |:---|:---|:---|:---:|
-| `/var/log/claude/tools.log` | **Completo** (cmd, path, url, query até 4 KB) | `syslog:adm 0640` | não |
+| `/var/log/claude/tools.log` | **Completo** (cmd, path, url, query até 4 KB) | `syslog:claude-audit 0640` | não |
 | `~/.claude/iris/audit/sessions.log` | **Metadata-only** (timestamp, session, tool, status, hash, bytes) | `menzani 0600` | sim |
 
 **Threat model.** A motivação foi um incidente de prompt injection
@@ -136,6 +136,28 @@ imune a adulteração pelo próprio Claude. O `sessions.log` em metadata-only
 é syncado para o Drive — timeline cross-device sem vazar `cmd`/`path`/`url`.
 Hook é **fail-silent** (exit 0 sempre) — perda de log preferível a quebra
 de fluxo da sessão.
+
+**Grupo dedicado `claude-audit` (#52).** A partir da v0.15 o
+`/var/log/claude/tools.log` pertence ao grupo `claude-audit` (era `adm`
+até a v0.14.x). Razões:
+
+- **Cross-distro**: `adm` é convenção Debian-family; Fedora/Arch
+  podem não ter ou ter convenção diferente. `claude-audit` é dedicado.
+- **Princípio do menor privilégio**: pertencer ao grupo `claude-audit`
+  dá acesso só ao audit log do Claude, não a `/var/log/` inteiro.
+- **Auditabilidade**: `getent group claude-audit` lista exatamente
+  quem tem visibilidade.
+
+`claude-dash setup-audit` é idempotente — ao re-rodar em uma instância
+v0.14.x existente, o script root cria o grupo, adiciona o invocador
+(`SUDO_USER`) via `usermod -aG`, faz `chown` dos arquivos atuais
+(`tools.log` + `.gz` rotacionados) pra `syslog:claude-audit`, e
+reinicia o `rsyslog`. **Re-login obrigatório** após o upgrade pra novo
+grupo entrar em vigor (ou `newgrp claude-audit` em shell nova).
+
+Pré-requisitos cross-distro: `groupadd`/`usermod` do shadow-utils
+(presente em qualquer distro Linux mainstream); rsyslog com suporte
+a `omfile`/`fileGroup` (default desde rsyslog 7).
 
 **Comportamento cross-device (#55).** Como `sessions.log` é syncado e
 os transcripts JSONL ficam na máquina de origem, ao alternar entre

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.14.7"
+version = "0.15.0"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/setup.py
+++ b/src/claude_dash/audit/setup.py
@@ -122,6 +122,12 @@ class State:
     var_log_dir_exists: bool = False
     var_log_file_exists: bool = False
 
+    # #52: grupo dedicado claude-audit (substitui adm pro acesso ao
+    # /var/log/claude/tools.log).
+    claude_audit_group_exists: bool = False
+    user_in_claude_audit_group: bool = False
+    var_log_owned_by_claude_audit: bool = False
+
     def mode(self) -> str:
         """fresh | migrate | partial | installed."""
         any_user = (
@@ -206,7 +212,59 @@ def _detect_state() -> State:
     s.logrotate_sys_exists = LOGROTATE_SYS_CONF.is_file()
     s.var_log_dir_exists = VAR_LOG_DIR.is_dir()
     s.var_log_file_exists = VAR_LOG_FILE.is_file()
+
+    # #52: estado do grupo claude-audit
+    s.claude_audit_group_exists = _claude_audit_group_exists()
+    s.user_in_claude_audit_group = _user_in_claude_audit_group()
+    s.var_log_owned_by_claude_audit = _var_log_owned_by_claude_audit()
     return s
+
+
+# Helpers de detecao do grupo (encapsulados pra mockagem em teste).
+
+CLAUDE_AUDIT_GROUP: str = "claude-audit"
+
+
+def _claude_audit_group_exists() -> bool:
+    """True se grupo `claude-audit` existe no sistema (resolvivel via getgrnam)."""
+    try:
+        import grp
+        grp.getgrnam(CLAUDE_AUDIT_GROUP)
+        return True
+    except (KeyError, ImportError):
+        return False
+
+
+def _user_in_claude_audit_group() -> bool:
+    """True se o usuario atual eh membro de `claude-audit`.
+
+    Le os.getgroups() — reflete grupos do shell em que o claude-dash foi
+    invocado. Importante: usermod -aG so afeta NOVAS sessoes; usuario
+    precisa re-login (ou newgrp) pra grupo entrar em vigor.
+    """
+    try:
+        import grp
+        gid = grp.getgrnam(CLAUDE_AUDIT_GROUP).gr_gid
+        return gid in os.getgroups()
+    except (KeyError, ImportError):
+        return False
+
+
+def _var_log_owned_by_claude_audit() -> bool:
+    """True se /var/log/claude/tools.log tem grupo `claude-audit`.
+
+    Permite distinguir cenario "post-migration completo" de "ainda em adm
+    porque rsyslog nao foi reiniciado" e similar. False quando arquivo
+    nao existe ainda.
+    """
+    if not VAR_LOG_FILE.is_file():
+        return False
+    try:
+        import grp
+        st = VAR_LOG_FILE.stat()
+        return grp.getgrgid(st.st_gid).gr_name == CLAUDE_AUDIT_GROUP
+    except (KeyError, OSError, ImportError):
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -408,32 +466,51 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# 1. /var/log/claude/ (owner syslog:adm, mode 0750)
+# 1. Grupo dedicado claude-audit (#52)
+# groupadd -f e' idempotente: nao falha se grupo ja existe.
+groupadd -f claude-audit
+
+# Adiciona o usuario invocador ao grupo (sudo conserva SUDO_USER).
+INVOKING_USER="${{SUDO_USER:-${{USER:-root}}}}"
+if [ "$INVOKING_USER" != "root" ]; then
+  usermod -aG claude-audit "$INVOKING_USER"
+  echo "Adicionei '$INVOKING_USER' ao grupo claude-audit."
+  echo "  ATENCAO: efeito so apos re-login (ou 'newgrp claude-audit' em shell nova)."
+fi
+
+# 2. /var/log/claude/ (owner syslog:claude-audit, mode 0750)
 if [ ! -d /var/log/claude ]; then
   mkdir -p /var/log/claude
 fi
-chown syslog:adm /var/log/claude
+chown syslog:claude-audit /var/log/claude
 chmod 0750 /var/log/claude
 
 if [ ! -f /var/log/claude/tools.log ]; then
   touch /var/log/claude/tools.log
 fi
-chown syslog:adm /var/log/claude/tools.log
+chown syslog:claude-audit /var/log/claude/tools.log
 chmod 0640 /var/log/claude/tools.log
 
-# 2. Regra rsyslog
+# Migracao: arquivos rotacionados (.gz) tambem migram pra novo grupo.
+shopt -s nullglob
+for f in /var/log/claude/tools.log-*.gz /var/log/claude/tools.log.[0-9]*; do
+  chown syslog:claude-audit "$f" 2>/dev/null || true
+done
+shopt -u nullglob
+
+# 3. Regra rsyslog
 cat > /etc/rsyslog.d/30-claude-audit.conf <<'RSYSLOG_EOF'
 {rsyslog_body.rstrip()}
 RSYSLOG_EOF
 chmod 0644 /etc/rsyslog.d/30-claude-audit.conf
 
-# 3. Logrotate sistema
+# 4. Logrotate sistema
 cat > /etc/logrotate.d/claude-audit <<'LOGROTATE_EOF'
 {logrotate_body.rstrip()}
 LOGROTATE_EOF
 chmod 0644 /etc/logrotate.d/claude-audit
 
-# 4. Restart rsyslog para aplicar a nova regra
+# 5. Restart rsyslog para aplicar a nova regra
 systemctl restart rsyslog
 
 echo "OK — bootstrap root-mode concluido."
@@ -571,6 +648,9 @@ def _print_state(state: State) -> None:
     print(f"  rsyslog rule        : {yn(state.rsyslog_conf_exists)}")
     print(f"  logrotate sistema   : {yn(state.logrotate_sys_exists)}")
     print(f"  /var/log/claude/    : {yn(state.var_log_dir_exists)}")
+    print(f"  grupo claude-audit  : {yn(state.claude_audit_group_exists)}")
+    print(f"  user no grupo       : {yn(state.user_in_claude_audit_group)}")
+    print(f"  tools.log no grupo  : {yn(state.var_log_owned_by_claude_audit)}")
 
 
 def _print_plan(plan: Plan) -> None:

--- a/src/claude_dash/audit/templates/logrotate-system-claude-audit
+++ b/src/claude_dash/audit/templates/logrotate-system-claude-audit
@@ -7,7 +7,7 @@
     notifempty
     dateext
     dateformat -%Y-W%V
-    create 0640 syslog adm
+    create 0640 syslog claude-audit
     postrotate
         /usr/lib/rsyslog/rsyslog-rotate 2>/dev/null || systemctl kill -s HUP rsyslog
     endscript

--- a/src/claude_dash/audit/templates/rsyslog-30-claude-audit.conf
+++ b/src/claude_dash/audit/templates/rsyslog-30-claude-audit.conf
@@ -1,6 +1,6 @@
 # Audit do Claude Code: roteia mensagens com tag "claude-audit"
 # para arquivo dedicado e interrompe o processamento (evita /var/log/syslog).
 if $programname == "claude-audit" or $syslogtag startswith "claude-audit" then {
-    action(type="omfile" file="/var/log/claude/tools.log" fileCreateMode="0640" fileOwner="root" fileGroup="adm")
+    action(type="omfile" file="/var/log/claude/tools.log" fileCreateMode="0640" fileOwner="root" fileGroup="claude-audit")
     stop
 }

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -941,8 +941,10 @@ class DashboardApp(App):
         except PermissionError:
             self._update_audit_detail(Text.from_markup(
                 "[bold yellow]Sem permissao pra ler /var/log/claude/tools.log[/bold yellow]\n"
-                "Adicione seu usuario ao grupo `adm` (re-login depois):\n\n"
-                "  sudo usermod -aG adm $USER\n\n"
+                "Adicione seu usuario ao grupo `claude-audit` (re-login depois):\n\n"
+                "  claude-dash setup-audit            # gera o script root\n"
+                "  sudo bash /tmp/claude-audit-root-setup.sh\n"
+                "  newgrp claude-audit                # (ou re-login)\n\n"
                 f"Ou leia manualmente como root:\n  sudo grep {filter_key} {AUDIT_SYSTEM_LOG}"
             ))
             return

--- a/tests/test_audit_setup.py
+++ b/tests/test_audit_setup.py
@@ -209,7 +209,8 @@ def test_fresh_creates_user_artifacts_and_root_script(tmp_path, monkeypatch, cap
 
     root_script = (tmp_path / "root-setup.sh").read_text()
     assert "mkdir -p /var/log/claude" in root_script
-    assert "chown syslog:adm /var/log/claude" in root_script
+    # #52: chown migrou de syslog:adm pra syslog:claude-audit
+    assert "chown syslog:claude-audit /var/log/claude" in root_script
     assert "/etc/rsyslog.d/30-claude-audit.conf" in root_script
     assert "/etc/logrotate.d/claude-audit" in root_script
     assert "systemctl restart rsyslog" in root_script
@@ -405,3 +406,98 @@ def test_is_compat_shim_helper():
         legacy = td_path / "legacy.sh"
         legacy.write_text("#!/bin/bash\necho old\n")
         assert not au._is_compat_shim(legacy)
+
+
+# ---------------------------------------------------------------------------
+# Grupo claude-audit (#52)
+# ---------------------------------------------------------------------------
+
+def test_claude_audit_group_exists_quando_grupo_resolve(monkeypatch) -> None:
+    """getgrnam retorna struct -> True."""
+    fake_grp = mock.Mock()
+    fake_grp.getgrnam = mock.Mock(return_value=mock.Mock(gr_gid=999))
+    monkeypatch.setattr(
+        "claude_dash.audit.setup._claude_audit_group_exists",
+        lambda: True,
+    )
+    state = au.State()
+    state.claude_audit_group_exists = au._claude_audit_group_exists()
+    # Wrapper re-resolve, monkeypatch acima cobre
+    assert state.claude_audit_group_exists is True
+
+
+def test_claude_audit_group_nao_existe_em_distro_sem_grupo(monkeypatch) -> None:
+    """getgrnam levanta KeyError quando grupo ausente -> False, sem crashar."""
+    import grp as grp_module
+
+    def boom(name: str) -> None:
+        raise KeyError(name)
+
+    monkeypatch.setattr(grp_module, "getgrnam", boom)
+    assert au._claude_audit_group_exists() is False
+    assert au._user_in_claude_audit_group() is False
+
+
+def test_user_in_claude_audit_quando_gid_em_getgroups(monkeypatch) -> None:
+    """getgroups inclui gid do grupo -> True."""
+    import grp as grp_module
+    fake = mock.Mock(gr_gid=4242)
+    monkeypatch.setattr(grp_module, "getgrnam", lambda _name: fake)
+    monkeypatch.setattr(au.os, "getgroups", lambda: [1000, 4242, 27])
+    assert au._user_in_claude_audit_group() is True
+
+
+def test_user_nao_in_claude_audit_quando_gid_fora(monkeypatch) -> None:
+    import grp as grp_module
+    fake = mock.Mock(gr_gid=4242)
+    monkeypatch.setattr(grp_module, "getgrnam", lambda _name: fake)
+    monkeypatch.setattr(au.os, "getgroups", lambda: [1000, 27])
+    assert au._user_in_claude_audit_group() is False
+
+
+def test_var_log_owned_by_claude_audit_false_quando_arquivo_ausente(
+    tmp_path, monkeypatch,
+) -> None:
+    """Sem o arquivo, retorna False sem chamar grp."""
+    monkeypatch.setattr(au, "VAR_LOG_FILE", tmp_path / "missing.log")
+    assert au._var_log_owned_by_claude_audit() is False
+
+
+def test_root_script_inclui_groupadd_e_chown(tmp_path, monkeypatch) -> None:
+    _patch_paths(monkeypatch, tmp_path)
+    body = au._root_setup_script()
+    assert "groupadd -f claude-audit" in body
+    assert "usermod -aG claude-audit" in body
+    assert "chown syslog:claude-audit /var/log/claude" in body
+    assert "chown syslog:claude-audit /var/log/claude/tools.log" in body
+    # Migracao dos rotacionados
+    assert "/var/log/claude/tools.log-*.gz" in body
+    # Aviso sobre re-login
+    assert "newgrp" in body or "re-login" in body
+
+
+def test_print_state_mostra_grupo(tmp_path, monkeypatch, capsys) -> None:
+    """_print_state inclui as 3 linhas novas do grupo."""
+    _patch_paths(monkeypatch, tmp_path)
+    state = au.State()
+    state.claude_audit_group_exists = True
+    state.user_in_claude_audit_group = False
+    state.var_log_owned_by_claude_audit = False
+    au._print_state(state)
+    out = capsys.readouterr().out
+    assert "grupo claude-audit" in out
+    assert "user no grupo" in out
+    assert "tools.log no grupo" in out
+
+
+def test_template_rsyslog_usa_claude_audit() -> None:
+    """Template foi migrado de fileGroup=adm pra fileGroup=claude-audit."""
+    body = au._read_template("rsyslog-30-claude-audit.conf")
+    assert 'fileGroup="claude-audit"' in body
+    assert 'fileGroup="adm"' not in body
+
+
+def test_template_logrotate_usa_claude_audit() -> None:
+    body = au._read_template("logrotate-system-claude-audit")
+    assert "create 0640 syslog claude-audit" in body
+    assert "syslog adm" not in body


### PR DESCRIPTION
Etapa 4 do plano. Substitui o grupo `adm` (default Debian-family pro acesso a logs) por um grupo dedicado `claude-audit` no `/var/log/claude/tools.log`.

## Por quê

- **Cross-distro:** `adm` é convenção Debian-family; Fedora/Arch podem não ter ou ter convenção diferente. `claude-audit` é portável.
- **Menor privilégio:** membership em `claude-audit` dá acesso só ao audit log do Claude, não a `/var/log/` inteiro.
- **Auditabilidade:** `getent group claude-audit` lista exatamente quem tem visibilidade.
- **Revogabilidade:** remover do grupo revoga só o audit, sem afetar outros papéis.

## Mudanças

- **Templates** `rsyslog-30-claude-audit.conf` (`fileGroup="claude-audit"`) e `logrotate-system-claude-audit` (`create 0640 syslog claude-audit`).
- **Script root** ganhou `groupadd -f claude-audit` (idempotente) + `usermod -aG claude-audit "$SUDO_USER"` + `chown syslog:claude-audit /var/log/claude/{,tools.log,tools.log-*.gz}` + `chown` dos rotacionados antigos.
- **State detector** reporta 3 linhas novas no `_print_state`: `grupo claude-audit`, `user no grupo`, `tools.log no grupo`.
- **Helpers** `_claude_audit_group_exists()`, `_user_in_claude_audit_group()`, `_var_log_owned_by_claude_audit()` exportáveis pra teste.
- **Constante** `CLAUDE_AUDIT_GROUP = "claude-audit"`.
- **TUI**: mensagem de `PermissionError` no drill-down (`s` na aba Audit) orienta `setup-audit` + `newgrp claude-audit` em vez de `usermod -aG adm`.

## Migration

Re-rodar `claude-dash setup-audit` após upgrade:

```bash
claude-dash setup-audit
sudo bash /tmp/claude-audit-root-setup.sh
# Re-login obrigatório (ou `newgrp claude-audit` em shell nova).
```

Idempotente — rodar duas vezes produz o mesmo estado. v0.14.x existente continua funcionando até a re-execução; após, a TUI drill-down (`s`) falha com mensagem orientadora até o user entrar no novo grupo.

## Cross-distro

Validado em Debian-family (este host). Fedora/Arch ainda pendente de validação manual — anotado no CHANGELOG. `groupadd`/`usermod` do shadow-utils são ubíquos em distros Linux mainstream, então o risco real é baixo, mas reportar caso encontre problema.

## Validação

- `uv run --extra dev pytest -x -q`: **337 passed, 1 skipped** (era 328; +9 novos).
- Lint limpo nos arquivos tocados.
- Bump `v0.14.7 → v0.15.0` (minor — mudança de grupo é migration path).

## Cobertura

`tests/test_audit_setup.py` ganhou:
- `_claude_audit_group_exists` retorna True/False conforme `getgrnam` resolve.
- `_user_in_claude_audit_group` confere via `os.getgroups()`.
- `_var_log_owned_by_claude_audit` False quando arquivo ausente.
- Root script inclui `groupadd -f claude-audit`, `usermod -aG claude-audit`, `chown syslog:claude-audit`, migração de `.gz` rotacionados, aviso de re-login.
- `_print_state` mostra as 3 linhas do grupo.
- Templates rsyslog/logrotate migrados de `adm` pra `claude-audit`.

Test pré-existente atualizado: assertion do chown migrou de `syslog:adm` pra `syslog:claude-audit`.

## Como testar manualmente

```bash
cd ~/Desenvolvimento/mencoding/claude-dashboard
git checkout feat/audit-claude-audit-group-52
pipx install --force --editable .
claude-dash --version  # 0.15.0
claude-dash setup-audit
# Saída esperada inclui:
#   grupo claude-audit  : nao
#   user no grupo       : nao
#   tools.log no grupo  : nao
sudo bash /tmp/claude-audit-root-setup.sh
# Esperado:
#   "Adicionei 'menzani' ao grupo claude-audit. ATENCAO: efeito so apos re-login..."
#   restart rsyslog
# Re-login (ou `newgrp claude-audit` em shell nova).
claude-dash setup-audit
# Saída esperada agora:
#   grupo claude-audit  : sim
#   user no grupo       : sim
#   tools.log no grupo  : sim
```

Confirma drill-down funcionando depois:

```bash
claude-dash
# 5 → Audit → seleciona linha → s
# Drill-down deve abrir sem PermissionError.
```

## Próxima etapa

#50 (PreToolUse hook real-time) — minor delicado por dobrar volume do log, mexer em formato de entry e exigir update da view pra correlacionar start↔end. Ou #54 (review MCP) se preferir pausa de design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)