### PR TITLE
feat(audit): PreToolUse hook real-time tool tracking (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-04-28
+
+### Added
+- **PreToolUse hook (real-time tool tracking).** The `claude-dash-audit-hook` binary now distinguishes `PreToolUse` vs `PostToolUse` via `payload["hook_event_name"]`. PreToolUse emits a syslog line with msgid `TOOLSTART` and `event="start"` *before* the tool executes — before only PostToolUse emitted, so long-running tools (multi-minute Bash, Agent, slow WebFetch) appeared as silence on the Audit tab until they completed. Now they show up immediately as "running" italic-dim rows. When the matching `TOOLCALL` arrives, the row is replaced in-place with the real `dur_ms`/`output_bytes`/`status`. Closes #50.
+- `AuditEntry.event: Literal["start","end"]` field (default `"end"` for backward compatibility with logs predating #50).
+- `views/audit.py:correlate_start_end(entries)` pure function: collapses `start`+`end` pairs by `tool_use_id`, preserving orphan starts (tools still running) and entries without `tool_use_id`.
+- TUI `_populate_audit_table` renders running rows with `italic dim` style + `dur_ms="running..."` + `out="—"`.
+- Filter `status=error` now ignores `event="start"` entries (they have `status="running"` so wouldn't match anyway, but documented explicitly).
+- `setup-audit` wires both `PreToolUse` and `PostToolUse` blocks in `~/.claude/settings.json` (idempotent — re-run to add `PreToolUse` to existing v0.15.x installs).
+
+### Changed
+- Audit log entries now include an explicit `event="end"` field in the STRUCTURED-DATA when emitted by the new hook (was implicit/absent before). Old logs continue to parse correctly — parser defaults `event` to `"end"` when absent.
+- **Volume of audit log doubles.** Each tool call now produces 2 lines (start + end) instead of 1. Logrotate continues at 26-week retention; if you have very high tool throughput, you may want to revisit the rotation policy. Standard usage shouldn't notice.
+
+### Migration
+
+Re-run `claude-dash setup-audit` to wire the `PreToolUse` block (idempotent — won't disturb existing config). New sessions started after the re-run begin emitting both events; old sessions continue with PostToolUse only via cached settings until restarted.
+
 ## [0.15.1] - 2026-04-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.15.1"
+version = "0.15.2"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/hook.py
+++ b/src/claude_dash/audit/hook.py
@@ -1,9 +1,13 @@
-"""Hook PostToolUse: registra cada tool call do Claude Code.
+"""Hook PostToolUse + PreToolUse: registra cada tool call do Claude Code.
 
 Entry point ``claude-dash-audit-hook``. Substitui 1:1 o bash legado
-``~/.claude/iris/hooks/audit-tool.sh``. A saida emitida (linha syslog RFC 5424
-no logger e linha de metadata no LOCAL_LOG) e **byte-identica** a do bash
-para o mesmo payload — mudar formato exige mudar o teste de equivalencia.
+``~/.claude/iris/hooks/audit-tool.sh``.
+
+Distingue PreToolUse vs PostToolUse via ``payload["hook_event_name"]`` (#50):
+- ``PreToolUse`` -> linha com msgid ``TOOLSTART`` e ``event="start"``;
+  duration_ms/output_bytes/status sao 0/0/"running" (dado nao existe ainda).
+- ``PostToolUse`` -> linha com msgid ``TOOLCALL`` e ``event="end"`` —
+  byte-identico ao formato classico pra retrocompat.
 
 Fail-silent: qualquer excecao -> ``sys.exit(0)``. Critical: hook NUNCA pode
 quebrar a sessao Claude. Trade-off consciente — prefere-se perder um log a
@@ -81,6 +85,10 @@ def _build_messages(payload: dict) -> tuple[str, str]:
     Retorna ``(full_msg, meta_msg)`` — meta_msg ja inclui o ``\\n`` final
     para append direto no LOCAL_LOG. full_msg vai como argumento do
     ``logger`` (sem trailing newline; logger adiciona).
+
+    PreToolUse (#50): payload["hook_event_name"] == "PreToolUse" ->
+    msgid TOOLSTART + event="start" + status="running" + duration_ms=0
+    + output_bytes=0. Demais campos identicos.
     """
     session_id = payload.get("session_id", "")
     tool_name = payload.get("tool_name", "?")
@@ -91,18 +99,32 @@ def _build_messages(payload: dict) -> tuple[str, str]:
     duration_ms = payload.get("duration_ms", 0)
     perm_mode = payload.get("permission_mode", "")
 
+    # #50: distingue Pre vs Post pela hook_event_name
+    is_pre = payload.get("hook_event_name") == "PreToolUse"
+    msgid = "TOOLSTART" if is_pre else "TOOLCALL"
+    event = "start" if is_pre else "end"
+
     input_serialized = json.dumps(tool_input, sort_keys=True, ensure_ascii=False)
     input_bytes = len(input_serialized.encode("utf-8"))
     input_sha = hashlib.sha256(input_serialized.encode("utf-8")).hexdigest()[:16]
 
-    status = "success"
-    if isinstance(tool_resp, dict) and (tool_resp.get("is_error") or tool_resp.get("error")):
-        status = "error"
-
-    try:
-        output_bytes = len(json.dumps(tool_resp, ensure_ascii=False).encode("utf-8"))
-    except Exception:
+    if is_pre:
+        # PreToolUse nao tem response ainda — campos default.
+        status = "running"
         output_bytes = 0
+        duration_ms = 0
+    else:
+        status = "success"
+        if isinstance(tool_resp, dict) and (
+            tool_resp.get("is_error") or tool_resp.get("error")
+        ):
+            status = "error"
+        try:
+            output_bytes = len(
+                json.dumps(tool_resp, ensure_ascii=False).encode("utf-8"),
+            )
+        except Exception:
+            output_bytes = 0
 
     summary = _summarize(tool_name, tool_input)
     if len(summary.encode("utf-8")) > MAX_INPUT:
@@ -122,6 +144,7 @@ def _build_messages(payload: dict) -> tuple[str, str]:
         f'input_sha="{input_sha}"',
         f'input_bytes="{input_bytes}"',
         f'output_bytes="{output_bytes}"',
+        f'event="{event}"',
     ]
     if tool_name == "Agent":
         subagent_type = (tool_input.get("subagent_type") or "").replace('"', "'")
@@ -130,10 +153,10 @@ def _build_messages(payload: dict) -> tuple[str, str]:
     sd = "[audit@iris " + " ".join(sd_parts) + "]"
 
     full_msg = (
-        f"<134>1 {ts} {hostname} claude-code {pid} TOOLCALL {sd} "
+        f"<134>1 {ts} {hostname} claude-code {pid} {msgid} {sd} "
         f"cwd={cwd!r} {summary}"
     )
-    meta_msg = f"<134>1 {ts} {hostname} claude-code {pid} TOOLCALL {sd}\n"
+    meta_msg = f"<134>1 {ts} {hostname} claude-code {pid} {msgid} {sd}\n"
     return full_msg, meta_msg
 
 

--- a/src/claude_dash/audit/models.py
+++ b/src/claude_dash/audit/models.py
@@ -9,16 +9,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 
 
 @dataclass(slots=True)
 class AuditEntry:
-    """Uma chamada de tool registrada pelo hook PostToolUse.
+    """Uma chamada de tool registrada pelo hook (Pre/PostToolUse).
 
     Atributos correspondem aos campos STRUCTURED-DATA emitidos pelo
     hook (`[audit@iris ...]`) mais o cabecalho RFC 5424 (timestamp,
     hostname). Tipos sao normalizados: ``timestamp`` vira datetime,
     contadores numericos viram int.
+
+    Campo ``event`` (#50): "start" para PreToolUse (sem duration_ms,
+    output_bytes, status validos — esses dados ainda nao existem),
+    "end" para PostToolUse (formato classico). Default "end" preserva
+    compat com logs pre-#50.
     """
 
     timestamp: datetime
@@ -26,7 +32,7 @@ class AuditEntry:
     session_id: str
     tool: str
     tool_use_id: str
-    status: str  # "success" | "error"
+    status: str  # "success" | "error" (ou "running" pra event=start)
     duration_ms: int
     perm_mode: str
     input_sha: str
@@ -36,3 +42,6 @@ class AuditEntry:
     # PID do processo Claude Code que disparou a tool. Util para
     # correlacionar com transcripts mas nao e exibido na tabela.
     pid: str = ""
+    # #50: evento que originou a entry. "start" e' PreToolUse,
+    # "end" e' PostToolUse. Default "end" mantem retrocompat.
+    event: Literal["start", "end"] = "end"

--- a/src/claude_dash/audit/parser.py
+++ b/src/claude_dash/audit/parser.py
@@ -5,6 +5,10 @@ Le linhas do formato emitido pelo ``audit/hook.py``:
     <134>1 2026-04-28T00:00:29.223-03:00 Predator-PH315-54 claude-code \\
       135727 TOOLCALL [audit@iris session="..." tool="..." status="..." ...]
 
+Tokens de message-id (#50):
+- ``TOOLCALL``: PostToolUse (event="end", classico)
+- ``TOOLSTART``: PreToolUse (event="start", sem duration_ms/output_bytes/status validos)
+
 Linhas malformadas retornam ``None`` (skip silencioso) — isso e
 deliberado: o tail incremental nao deve crashar em logs corrompidos
 ou de versoes antigas do hook.
@@ -18,9 +22,9 @@ from claude_dash.audit.models import AuditEntry
 
 # Cabecalho ate antes do STRUCTURED-DATA. Captura: prio (descartado),
 # version (descartado), timestamp, hostname, app (descartado), pid,
-# msgid (descartado).
+# msgid (TOOLCALL ou TOOLSTART pra distinguir end vs start).
 _HEADER_RE = re.compile(
-    r"^<\d+>\d+\s+(\S+)\s+(\S+)\s+\S+\s+(\S+)\s+\S+\s+\[audit@iris\s+(.*?)\]"
+    r"^<\d+>\d+\s+(\S+)\s+(\S+)\s+\S+\s+(\S+)\s+(\S+)\s+\[audit@iris\s+(.*?)\]"
 )
 
 # Pares chave="valor" dentro do STRUCTURED-DATA. Aceita aspas duplas
@@ -50,7 +54,9 @@ def parse_line(line: str) -> AuditEntry | None:
     if not m:
         return None
 
-    ts_str, hostname, pid, sd_inner = m.group(1), m.group(2), m.group(3), m.group(4)
+    ts_str, hostname, pid, msgid, sd_inner = (
+        m.group(1), m.group(2), m.group(3), m.group(4), m.group(5),
+    )
 
     try:
         ts = datetime.fromisoformat(ts_str)
@@ -65,6 +71,14 @@ def parse_line(line: str) -> AuditEntry | None:
     if "session" not in fields or "tool" not in fields:
         return None
 
+    # Determina event pelo msgid (TOOLSTART/TOOLCALL) ou campo explicito
+    # (mais defensivo). Default "end" pra logs pre-#50.
+    event_field = fields.get("event", "")
+    event = "start" if event_field == "start" or msgid == "TOOLSTART" else "end"
+
+    # Pra entries de start, status default = "running" (vs "success" do end).
+    default_status = "running" if event == "start" else "success"
+
     return AuditEntry(
         timestamp=ts,
         hostname=hostname,
@@ -72,11 +86,12 @@ def parse_line(line: str) -> AuditEntry | None:
         session_id=fields.get("session", ""),
         tool=fields.get("tool", ""),
         tool_use_id=fields.get("tool_use_id", ""),
-        status=fields.get("status", "success"),
+        status=fields.get("status", default_status),
         duration_ms=_to_int(fields.get("duration_ms", "0")),
         perm_mode=fields.get("perm_mode", ""),
         input_sha=fields.get("input_sha", ""),
         input_bytes=_to_int(fields.get("input_bytes", "0")),
         output_bytes=_to_int(fields.get("output_bytes", "0")),
         subagent_type=fields.get("subagent_type") or None,
+        event=event,
     )

--- a/src/claude_dash/audit/setup.py
+++ b/src/claude_dash/audit/setup.py
@@ -395,6 +395,10 @@ def _wire_settings(plan: Plan, dry_run: bool, mode: str) -> None:
     Em ``fresh``/``partial``: garante que existe uma entry PostToolUse
     matcher ``.*`` apontando para ``claude-dash-audit-hook``, sem mexer
     nas outras.
+
+    #50: tambem garante uma entry PreToolUse equivalente — mesmo binario
+    `claude-dash-audit-hook` distingue Pre vs Post via hook_event_name no
+    payload. Adicao idempotente.
     """
     settings = _load_settings()
     if not isinstance(settings, dict):
@@ -403,6 +407,7 @@ def _wire_settings(plan: Plan, dry_run: bool, mode: str) -> None:
 
     hooks = settings.setdefault("hooks", {})
     pt = hooks.setdefault("PostToolUse", [])
+    pre = hooks.setdefault("PreToolUse", [])
 
     changed = False
     found_new = False
@@ -428,8 +433,27 @@ def _wire_settings(plan: Plan, dry_run: bool, mode: str) -> None:
         })
         changed = True
 
+    # #50: PreToolUse tambem deve apontar pro entry point novo. Idempotente.
+    pre_has_new = any(
+        NEW_HOOK_CMD in (h.get("command", "") or "")
+        for entry in pre
+        for h in (entry.get("hooks") or [])
+    )
+    if not pre_has_new:
+        pre.append({
+            "matcher": ".*",
+            "hooks": [{
+                "type": "command",
+                "command": NEW_HOOK_CMD,
+                "timeout": 5,
+            }],
+        })
+        changed = True
+
     if not changed:
-        plan.actions.append("settings.json: ja wired para claude-dash-audit-hook")
+        plan.actions.append(
+            "settings.json: ja wired para claude-dash-audit-hook (Pre+Post)"
+        )
         return
 
     bak_label = "settings.json.bak.<ts>"

--- a/src/claude_dash/views/audit.py
+++ b/src/claude_dash/views/audit.py
@@ -125,6 +125,10 @@ def filter_entries(
         else:
             now = datetime.now().astimezone()
 
+    # #50: status="error" so se aplica a entries event="end" — start nao
+    # tem status valido (sempre "running"). Documentado no docstring.
+    error_filter = filters.get("status") == "error"
+
     out: list[AuditEntry] = []
     for e in entries:
         if not show_test_sessions and _is_test_session(e.session_id):
@@ -135,6 +139,11 @@ def filter_entries(
             continue
         if "status" in filters and e.status != filters["status"]:
             continue
+        # #50: filtro por status="error" exclui implicitamente entries
+        # de start (essas tem status="running" default — nao seriam
+        # "error" mas tambem nao queremos mostrar como pending no filtro).
+        if error_filter and e.event == "start":
+            continue
         if "session_prefix" in filters and not e.session_id.startswith(
             filters["session_prefix"]
         ):
@@ -144,6 +153,40 @@ def filter_entries(
         if current_host is not None and e.hostname and e.hostname != current_host:
             continue
         out.append(e)
+    return out
+
+
+def correlate_start_end(entries: list[AuditEntry]) -> list[AuditEntry]:
+    """Colapsa pares start↔end pelo mesmo tool_use_id (#50).
+
+    Entries com event="end" prevalecem sobre suas correspondentes
+    event="start": o end ja contem duration_ms/output_bytes/status reais,
+    enquanto o start so era util enquanto a tool estava em execucao.
+
+    Entries de start sem end correspondente (tools ainda rodando) sao
+    preservadas — caller tipicamente exibe com indicador "running".
+
+    Implementacao: passada unica O(n). Usa dict tool_use_id->idx do
+    start; quando o end chega, descarta o start. Entries sem
+    tool_use_id (ex.: Agent legacy) passam direto sem correlacao.
+    """
+    # idx do start no array out (pra remocao quando o end chega)
+    start_idx_by_tuid: dict[str, int] = {}
+    out: list[AuditEntry] = []
+    for e in entries:
+        if not e.tool_use_id:
+            out.append(e)
+            continue
+        if e.event == "end":
+            # Se ha start correspondente, marca pra remover
+            si = start_idx_by_tuid.pop(e.tool_use_id, None)
+            if si is not None:
+                out[si] = e  # substitui in-place
+            else:
+                out.append(e)
+        else:  # event == "start"
+            start_idx_by_tuid[e.tool_use_id] = len(out)
+            out.append(e)
     return out
 
 

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -49,6 +49,9 @@ from claude_dash.discover import (
     subagents_of,
 )
 from claude_dash.views.audit import (
+    correlate_start_end as _audit_correlate,
+)
+from claude_dash.views.audit import (
     default_export_path as _audit_default_export_path,
 )
 from claude_dash.views.audit import (
@@ -596,6 +599,10 @@ class DashboardApp(App):
     def _refresh_audit(self) -> None:
         try:
             all_entries = list(self._audit_entries)
+            # #50: correlaciona start↔end ANTES do filter — quando ambos
+            # existem pra mesmo tool_use_id, end vence (tem dado real).
+            # Entries de start sem end ainda mostram (tool em execucao).
+            all_entries = _audit_correlate(all_entries)
             # Filtro explicito `/host=` tem precedencia sobre o implicit
             # "so este host" (do contrario o usuario nao conseguiria ver
             # outro host sem fazer toggle a cada vez).
@@ -729,14 +736,21 @@ class DashboardApp(App):
             tool_str = e.tool
             if e.subagent_type:
                 tool_str = f"{e.tool}({e.subagent_type})"
+            # #50: tool ainda em execucao — duration_ms invalido,
+            # output_bytes ainda zero. Indica visualmente.
+            is_running = e.event == "start"
+            if is_running:
+                style = "italic dim"
+            dur_str = "running..." if is_running else str(e.duration_ms)
+            out_str = "—" if is_running else _fmt_bytes(e.output_bytes)
             cells = [
-                Text(time_str, style="cyan" if not host_other else "dim"),
+                Text(time_str, style="cyan" if not (host_other or is_running) else "dim"),
                 Text(sess_str, style=style),
                 Text(host_str, style=style),
                 Text(tool_str, style=style),
-                Text(str(e.duration_ms), style=style, justify="right"),
+                Text(dur_str, style=style, justify="right"),
                 Text(_fmt_bytes(e.input_bytes), style=style, justify="right"),
-                Text(_fmt_bytes(e.output_bytes), style=style, justify="right"),
+                Text(out_str, style=style, justify="right"),
             ]
             dt.add_row(*cells)
 

--- a/tests/test_audit_hook.py
+++ b/tests/test_audit_hook.py
@@ -374,6 +374,53 @@ def test_byte_identical_to_legacy_bash(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# PreToolUse / TOOLSTART (#50)
+# ---------------------------------------------------------------------------
+
+
+def test_pretooluse_emite_msgid_toolstart() -> None:
+    """Payload com hook_event_name=PreToolUse -> msgid TOOLSTART."""
+    payload = {**BASH_PAYLOAD, "hook_event_name": "PreToolUse"}
+    full, meta = _build(payload)
+    assert " TOOLSTART " in full
+    assert " TOOLSTART " in meta
+    assert " TOOLCALL " not in full
+
+
+def test_pretooluse_inclui_event_start_no_sd() -> None:
+    payload = {**BASH_PAYLOAD, "hook_event_name": "PreToolUse"}
+    full, _ = _build(payload)
+    kv = _kv(_sd(full))
+    assert kv["event"] == "start"
+    assert kv["status"] == "running"
+    assert kv["duration_ms"] == "0"
+    assert kv["output_bytes"] == "0"
+
+
+def test_posttooluse_explicito_emite_toolcall_event_end() -> None:
+    """Payload com hook_event_name=PostToolUse -> TOOLCALL + event=end."""
+    payload = {**BASH_PAYLOAD, "hook_event_name": "PostToolUse"}
+    full, _ = _build(payload)
+    assert " TOOLCALL " in full
+    kv = _kv(_sd(full))
+    assert kv["event"] == "end"
+    assert kv["status"] == "success"
+
+
+def test_pretooluse_input_sha_estavel_com_posttooluse() -> None:
+    """input_sha do start deve bater com o do end (mesmo tool_input)."""
+    pre_payload = {**BASH_PAYLOAD, "hook_event_name": "PreToolUse"}
+    post_payload = {**BASH_PAYLOAD, "hook_event_name": "PostToolUse"}
+    pre_full, _ = _build(pre_payload)
+    post_full, _ = _build(post_payload)
+    pre_kv = _kv(_sd(pre_full))
+    post_kv = _kv(_sd(post_full))
+    assert pre_kv["input_sha"] == post_kv["input_sha"]
+    # tool_use_id permite correlacionar Pre↔Post
+    assert pre_kv["tool_use_id"] == post_kv["tool_use_id"]
+
+
+# ---------------------------------------------------------------------------
 # Util de fixture
 # ---------------------------------------------------------------------------
 

--- a/tests/test_audit_parser.py
+++ b/tests/test_audit_parser.py
@@ -90,3 +90,46 @@ def test_timestamp_parseado_para_datetime() -> None:
     assert e.timestamp.month == 4
     assert e.timestamp.day == 28
     assert e.timestamp.tzinfo is not None
+
+
+# ---- PreToolUse / TOOLSTART (#50) -----------------------------------
+
+
+def test_toolstart_parseado_como_event_start() -> None:
+    """Linha com msgid TOOLSTART -> event=start."""
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLSTART '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="running" '
+        'duration_ms="0" perm_mode="auto" input_sha="0" input_bytes="10" '
+        'output_bytes="0" event="start"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.event == "start"
+    assert e.status == "running"
+
+
+def test_toolcall_default_event_end() -> None:
+    """Linha TOOLCALL sem campo event explicito -> event=end (retrocompat)."""
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="success" '
+        'duration_ms="100" perm_mode="auto" input_sha="0" input_bytes="0" '
+        'output_bytes="0"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.event == "end"
+
+
+def test_toolcall_com_event_explicito_end() -> None:
+    """Linha TOOLCALL com event=end (formato novo) -> event=end."""
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="success" '
+        'duration_ms="100" perm_mode="auto" input_sha="0" input_bytes="0" '
+        'output_bytes="0" event="end"]'
+    )
+    e = parse_line(line)
+    assert e is not None
+    assert e.event == "end"

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -13,6 +13,7 @@ from claude_dash.views.audit import (
     _EXPORT_FIELDS,
     _color_for,
     _is_test_session,
+    correlate_start_end,
     default_export_path,
     export_entries,
     filter_entries,
@@ -470,6 +471,70 @@ def test_render_table_inclui_coluna_host() -> None:
     # host esta na coluna idx 2
     cell = next(iter(table.columns[2].cells))
     assert "PREDATOR" in cell
+
+
+# ---- correlate_start_end (#50) --------------------------------------
+
+
+def _entry_event(
+    *,
+    event: str = "end",
+    tool_use_id: str = "x",
+    delta_seconds: float = 0,
+    status: str = "success",
+) -> AuditEntry:
+    base = datetime(2026, 4, 28, 0, 0, 0, tzinfo=timezone(timedelta(hours=-3)))
+    return AuditEntry(
+        timestamp=base + timedelta(seconds=delta_seconds),
+        hostname="host", pid="1",
+        session_id="0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+        tool="Bash", tool_use_id=tool_use_id, status=status,
+        duration_ms=100 if event == "end" else 0,
+        perm_mode="auto", input_sha="0", input_bytes=10,
+        output_bytes=20 if event == "end" else 0,
+        event=event,  # type: ignore[arg-type]
+    )
+
+
+def test_correlate_start_seguido_de_end_substitui_in_place() -> None:
+    s = _entry_event(event="start", tool_use_id="A", delta_seconds=0)
+    e = _entry_event(event="end", tool_use_id="A", delta_seconds=2)
+    out = correlate_start_end([s, e])
+    assert len(out) == 1
+    assert out[0].event == "end"
+    assert out[0].duration_ms == 100
+
+
+def test_correlate_start_sem_end_preservado_como_running() -> None:
+    """Tool ainda em execucao — start fica no array."""
+    s = _entry_event(event="start", tool_use_id="B")
+    out = correlate_start_end([s])
+    assert len(out) == 1
+    assert out[0].event == "start"
+
+
+def test_correlate_multiplos_pares_e_um_orfao() -> None:
+    s1 = _entry_event(event="start", tool_use_id="A", delta_seconds=0)
+    e1 = _entry_event(event="end", tool_use_id="A", delta_seconds=1)
+    s2 = _entry_event(event="start", tool_use_id="B", delta_seconds=2)
+    s3 = _entry_event(event="start", tool_use_id="C", delta_seconds=3)
+    e3 = _entry_event(event="end", tool_use_id="C", delta_seconds=4)
+    out = correlate_start_end([s1, e1, s2, s3, e3])
+    # A: collapse pra end, B: stays start, C: collapse pra end
+    tool_use_ids_e_events = [(o.tool_use_id, o.event) for o in out]
+    assert tool_use_ids_e_events == [
+        ("A", "end"),
+        ("B", "start"),
+        ("C", "end"),
+    ]
+
+
+def test_correlate_entries_sem_tool_use_id_passam_direto() -> None:
+    """Agent legacy sem tool_use_id — sem chave de correlacao."""
+    e1 = _entry_event(event="end", tool_use_id="")
+    e2 = _entry_event(event="end", tool_use_id="")
+    out = correlate_start_end([e1, e2])
+    assert len(out) == 2
 
 
 def test_render_table_dim_para_outro_host() -> None:


### PR DESCRIPTION
Etapa 7. Tools longas agora aparecem imediatamente como linhas 'running' italic-dim na aba Audit, em vez de silêncio até completar.

## Mudanças
- AuditEntry.event field (start/end)
- Parser aceita TOOLSTART + TOOLCALL
- Hook distingue Pre/Post via hook_event_name
- correlate_start_end() colapsa pares por tool_use_id
- TUI renderiza running em italic dim
- setup-audit wira PreToolUse + PostToolUse

## Validação
355 passed (+11), lint limpo, bump v0.15.1 → v0.15.2.

## Migration
Re-rodar `claude-dash setup-audit` pra adicionar PreToolUse no settings.json. Idempotente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)