### PR TITLE
feat(audit): comparação cross-session (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.6] - 2026-04-28
+
+### Added
+- TUI: `Audit` tab gained a `c` key for **cross-session comparison** (#38). Opens an inline prompt; user types 2-4 SID prefixes separated by space/comma/semicolon (e.g., `0efd3 a1b2 8f9c`). The audit-detail panel renders parallel columns — one per session — with timestamps, tool calls, and a correlations summary below. Useful when running 3+ Claude Code sessions in parallel and wanting to understand who did what and in what order.
+- Correlation heuristics in new module `claude_dash.views.audit_compare`:
+  - `same_path` / `same_cmd`: same `input_sha` across distinct sessions within ±500ms.
+  - `read_then_edit`: session A read file X at t=0; session B edited X within 5s — classic signal of parallel-refactor race.
+  - All correlations highlighted in `yellow` (or `bold red` for `read_then_edit`) in the comparison view.
+- Pure-function helpers exported: `parse_compare_input(raw)`, `group_by_session(entries, sids)`, `merge_timelines(grouped)`, `find_correlations(grouped, window_ms=500)`. All testable without TUI.
+- 15 new tests in `tests/test_audit_compare.py` covering parsing, grouping, merge ordering, all correlation reasons, edge cases (same session ignored, target-less tools ignored, out-of-window).
+- In-tab key hints line includes `c compare`.
+
 ## [0.15.5] - 2026-04-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.15.5"
+version = "0.15.6"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/views/audit_compare.py
+++ b/src/claude_dash/views/audit_compare.py
@@ -1,0 +1,282 @@
+"""Comparacao cross-session de tool calls (#38).
+
+Pure functions que recebem entries da audit log e produzem timeline
+merged + correlacoes entre sessoes paralelas.
+
+Caso de uso: 3+ sessoes Claude Code rodando simultaneamente; usuario
+quer entender quem fez o que e em que ordem. Ex.: sessao A leu arquivo
+X as 14:30, sessao B editou X as 14:30:03 — pattern read-then-edit
+cross-session que pode indicar trabalho em paralelo no mesmo arquivo.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+from rich.columns import Columns
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from claude_dash.audit.models import AuditEntry
+
+
+@dataclass(slots=True)
+class Correlation:
+    """Par de tool calls cross-session com signal de relacionamento."""
+
+    session_a: str
+    session_b: str
+    entry_a: AuditEntry
+    entry_b: AuditEntry
+    delta_ms: int  # quanto tempo passou entre A -> B (sempre positivo)
+    reason: str  # "same_path" | "same_cmd" | "read_then_edit"
+
+
+def group_by_session(
+    entries: list[AuditEntry],
+    sids: list[str],
+) -> dict[str, list[AuditEntry]]:
+    """Particiona entries por session_id, fazendo prefix-match nos sids dados.
+
+    Retorna dict ``sid -> [entries]`` ordenado por timestamp. Sids sem
+    match viram lista vazia (caller decide como sinalizar).
+    """
+    out: dict[str, list[AuditEntry]] = {sid: [] for sid in sids}
+    for e in entries:
+        for sid in sids:
+            if e.session_id.startswith(sid):
+                out[sid].append(e)
+                break
+    for v in out.values():
+        v.sort(key=lambda x: x.timestamp)
+    return out
+
+
+def merge_timelines(
+    grouped: dict[str, list[AuditEntry]],
+) -> list[tuple[str, AuditEntry]]:
+    """Merge global por timestamp das listas ja-ordenadas (#38).
+
+    Retorna lista ``[(session_id, entry), ...]`` ordenada
+    cronologicamente. Tie-break por session_id (lexicografico) pra
+    determinismo em testes.
+    """
+    flat: list[tuple[str, AuditEntry]] = []
+    for sid, entries in grouped.items():
+        for e in entries:
+            flat.append((sid, e))
+    flat.sort(key=lambda kv: (kv[1].timestamp, kv[0]))
+    return flat
+
+
+def _entry_target(entry: AuditEntry) -> str | None:
+    """Identificador do 'alvo' da tool call pra correlacao.
+
+    Returns:
+        - input_sha truncado pra Bash/WebFetch/WebSearch (mesmo cmd/url/query)
+        - input_sha pra Read/Edit/Write (que codifica o file_path)
+        - None pra tools sem target identificavel (Skill, Agent etc.)
+    """
+    if entry.tool in ("Bash", "Read", "Edit", "Write", "WebFetch", "WebSearch"):
+        return entry.input_sha or None
+    return None
+
+
+def find_correlations(
+    grouped: dict[str, list[AuditEntry]],
+    window_ms: int = 500,
+) -> list[Correlation]:
+    """Detecta tool calls correlacionadas entre sessoes diferentes.
+
+    Heuristicas:
+    1. **same_path / same_cmd**: mesmo input_sha em sessoes distintas
+       dentro da janela ``window_ms``. Bash com mesmo cmd, Read/Edit/Write
+       com mesmo path.
+    2. **read_then_edit**: sessao A faz Read em path X, sessao B faz
+       Edit/Write em mesmo path X em <= 5s. Pattern de "uma sessao leu,
+       outra editou" — sinal classico de race em refactor paralelo.
+
+    Implementacao O(n²) sobre `merged` — caller espera N pequeno
+    (poucas entries em janela curta). Pra escalar, particionar por
+    `_entry_target` e aplicar matching local; fica como otimizacao
+    futura se virar gargalo.
+    """
+    merged = merge_timelines(grouped)
+    out: list[Correlation] = []
+    window = timedelta(milliseconds=window_ms)
+    rte_window = timedelta(seconds=5)
+
+    for i, (sid_a, e_a) in enumerate(merged):
+        target_a = _entry_target(e_a)
+        if target_a is None:
+            continue
+        for sid_b, e_b in merged[i + 1:]:
+            if sid_a == sid_b:
+                continue
+            delta = e_b.timestamp - e_a.timestamp
+            # Optimizacao: lista esta ordenada — assim que delta passa
+            # do maior threshold considerado, podemos parar.
+            if delta > rte_window:
+                break
+            target_b = _entry_target(e_b)
+            if target_b is None:
+                continue
+            delta_ms = int(delta.total_seconds() * 1000)
+            # 1. Mesma assinatura (cmd/path) em sessoes diferentes
+            if target_a == target_b and delta <= window:
+                reason = "same_cmd" if e_a.tool == "Bash" else "same_path"
+                out.append(Correlation(
+                    session_a=sid_a, session_b=sid_b,
+                    entry_a=e_a, entry_b=e_b,
+                    delta_ms=delta_ms, reason=reason,
+                ))
+                continue
+            # 2. read_then_edit: A=Read X, B=Edit/Write X em <=5s
+            if (
+                e_a.tool == "Read"
+                and e_b.tool in ("Edit", "Write")
+                and target_a == target_b
+                and delta <= rte_window
+            ):
+                out.append(Correlation(
+                    session_a=sid_a, session_b=sid_b,
+                    entry_a=e_a, entry_b=e_b,
+                    delta_ms=delta_ms, reason="read_then_edit",
+                ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+_REASON_STYLE = {
+    "same_path": "yellow",
+    "same_cmd": "yellow",
+    "read_then_edit": "bold red",
+}
+
+
+def _short_sid(sid: str) -> str:
+    return sid[:8] if len(sid) > 8 else sid
+
+
+def render_session_column(
+    sid: str,
+    entries: list[AuditEntry],
+    *,
+    correlated_keys: set[str] | None = None,
+    max_rows: int = 30,
+) -> Panel:
+    """Renderiza coluna pra uma sessao na vista de comparacao.
+
+    ``correlated_keys`` e' um set de tool_use_ids cujas linhas devem
+    ser destacadas (entrada esta em alguma Correlation).
+    """
+    correlated_keys = correlated_keys or set()
+    table = Table(
+        show_header=True, header_style="bold cyan",
+        border_style="dim", expand=True, padding=(0, 1),
+    )
+    table.add_column("Hora", width=12)
+    table.add_column("Tool", overflow="fold")
+    table.add_column("dur", justify="right", width=8)
+
+    visible = entries[-max_rows:]
+    for e in visible:
+        ts = e.timestamp.strftime("%H:%M:%S.%f")[:-3]
+        tool_str = e.tool
+        if e.subagent_type:
+            tool_str = f"{e.tool}({e.subagent_type})"
+        is_correlated = e.tool_use_id in correlated_keys
+        row_style = "yellow" if is_correlated else ""
+        dur = "running..." if e.event == "start" else str(e.duration_ms)
+        table.add_row(
+            Text(ts, style=row_style or "cyan"),
+            Text(tool_str, style=row_style),
+            Text(dur, style=row_style, justify="right"),
+        )
+    title = f"{_short_sid(sid)}  ({len(entries)} entries)"
+    return Panel(table, title=title, title_align="left", border_style="dim")
+
+
+def render_comparison(
+    grouped: dict[str, list[AuditEntry]],
+    correlations: list[Correlation],
+    *,
+    max_rows_per_column: int = 30,
+) -> Columns:
+    """Layout em colunas paralelas, uma por sessao."""
+    correlated_tids = set()
+    for c in correlations:
+        if c.entry_a.tool_use_id:
+            correlated_tids.add(c.entry_a.tool_use_id)
+        if c.entry_b.tool_use_id:
+            correlated_tids.add(c.entry_b.tool_use_id)
+
+    panels = [
+        render_session_column(
+            sid, entries,
+            correlated_keys=correlated_tids,
+            max_rows=max_rows_per_column,
+        )
+        for sid, entries in grouped.items()
+    ]
+    return Columns(panels, expand=True, equal=True)
+
+
+def render_correlations_summary(correlations: list[Correlation]) -> Panel:
+    """Painel-resumo das correlacoes detectadas."""
+    if not correlations:
+        return Panel(
+            Text("Nenhuma correlacao detectada nas sessoes selecionadas.",
+                 style="dim"),
+            title="Correlacoes",
+            title_align="left",
+            border_style="dim",
+        )
+    table = Table(
+        show_header=True, header_style="bold cyan",
+        border_style="dim", expand=True, padding=(0, 1),
+    )
+    table.add_column("Sessao A", width=10)
+    table.add_column("Tool A", width=14)
+    table.add_column("Δ (ms)", justify="right", width=8)
+    table.add_column("Sessao B", width=10)
+    table.add_column("Tool B", width=14)
+    table.add_column("Tipo", overflow="fold")
+
+    for c in correlations:
+        style = _REASON_STYLE.get(c.reason, "")
+        table.add_row(
+            Text(_short_sid(c.session_a), style=style),
+            Text(c.entry_a.tool, style=style),
+            Text(str(c.delta_ms), style=style, justify="right"),
+            Text(_short_sid(c.session_b), style=style),
+            Text(c.entry_b.tool, style=style),
+            Text(c.reason, style=style),
+        )
+    return Panel(
+        table,
+        title=f"Correlacoes ({len(correlations)})",
+        title_align="left",
+        border_style="yellow",
+    )
+
+
+def parse_compare_input(raw: str) -> list[str]:
+    """Extrai SIDs do prompt de comparacao.
+
+    Aceita separadores comuns (espaco, virgula, ponto-virgula). Retorna
+    lista de prefixos em ordem; deduplica preservando primeira ocorrencia.
+    """
+    import re
+    tokens = [t for t in re.split(r"[\s,;]+", raw.strip()) if t]
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in tokens:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -66,6 +66,21 @@ from claude_dash.views.audit import (
 from claude_dash.views.audit import (
     render_footer as _audit_render_footer,
 )
+from claude_dash.views.audit_compare import (
+    find_correlations as _compare_find_correlations,
+)
+from claude_dash.views.audit_compare import (
+    group_by_session as _compare_group_by_session,
+)
+from claude_dash.views.audit_compare import (
+    parse_compare_input as _compare_parse_input,
+)
+from claude_dash.views.audit_compare import (
+    render_comparison as _compare_render,
+)
+from claude_dash.views.audit_compare import (
+    render_correlations_summary as _compare_render_summary,
+)
 from claude_dash.views.now import (
     _header as _now_header,
 )
@@ -221,6 +236,15 @@ class DashboardApp(App):
     #audit-export-input.active {
         display: block;
     }
+    #audit-compare-input {
+        dock: bottom;
+        height: 3;
+        display: none;
+        border: solid $accent;
+    }
+    #audit-compare-input.active {
+        display: block;
+    }
     """
 
     BINDINGS: ClassVar[list[Binding]] = [
@@ -249,6 +273,7 @@ class DashboardApp(App):
         Binding("s", "audit_drill_down_root", "Root drill-down", show=False),
         Binding("e", "audit_export_prompt", "Export", show=False),
         Binding("h", "audit_toggle_host", "Toggle host", show=False),
+        Binding("c", "audit_compare_prompt", "Compare", show=False),
         Binding("end", "audit_resume_scroll", "Resume", show=False),
     ]
 
@@ -336,6 +361,13 @@ class DashboardApp(App):
                         "export: caminho .csv ou .json (vazio = default em ~) | Esc cancela"
                     ),
                     id="audit-export-input",
+                )
+                yield Input(
+                    placeholder=(
+                        "compare: 2-3 prefixos de SID separados por espaço "
+                        "(ex.: '0efd3 a1b2 8f9c') | Esc cancela"
+                    ),
+                    id="audit-compare-input",
                 )
         yield Footer()
 
@@ -787,6 +819,7 @@ class DashboardApp(App):
             ("h", "host"),
             ("s", "drill-down"),
             ("e", "export"),
+            ("c", "compare"),
             ("End", "resume"),
         ]
         parts = "  ".join(
@@ -840,6 +873,19 @@ class DashboardApp(App):
         self._mark_audit_user_action()
         try:
             inp = self.query_one("#audit-filter-input", Input)
+            inp.value = ""
+            inp.add_class("active")
+            inp.focus()
+        except Exception:
+            pass
+
+    def action_audit_compare_prompt(self) -> None:
+        """Tecla `c`: prompt pra comparar 2-3 sessoes lado-a-lado (#38)."""
+        if not self._audit_active():
+            return
+        self._mark_audit_user_action()
+        try:
+            inp = self.query_one("#audit-compare-input", Input)
             inp.value = ""
             inp.add_class("active")
             inp.focus()
@@ -1048,6 +1094,52 @@ class DashboardApp(App):
             with contextlib.suppress(Exception):
                 self.query_one("#audit-table", Static).focus()
             return
+        if event.input.id == "audit-compare-input":
+            self._handle_audit_compare(event.value.strip())
+            event.input.remove_class("active")
+            event.input.value = ""
+            with contextlib.suppress(Exception):
+                self.query_one("#audit-table", Static).focus()
+            return
+
+    def _handle_audit_compare(self, raw: str) -> None:
+        """Processa prompt de comparacao: parsea SIDs e renderiza colunas (#38)."""
+        sids = _compare_parse_input(raw)
+        if len(sids) < 2:
+            self._update_audit_detail(Text(
+                "Compare exige ao menos 2 prefixos de SID (max 3 recomendado).",
+                style="yellow",
+            ))
+            return
+        if len(sids) > 4:
+            self._update_audit_detail(Text(
+                "Compare aceita ate 4 sessoes — prompt teve mais; truncando.",
+                style="yellow",
+            ))
+            sids = sids[:4]
+
+        all_entries = list(self._audit_entries)
+        all_entries = _audit_correlate(all_entries)
+        # Aplica janela temporal corrente (do toggle `t`); host filter NAO
+        # — comparar cross-device pode ser util.
+        all_entries = _audit_filter_entries(
+            all_entries,
+            window_hours=self._audit_window_hours,
+            show_test_sessions=self._audit_show_tests,
+        )
+
+        grouped = _compare_group_by_session(all_entries, sids)
+        if all(len(v) == 0 for v in grouped.values()):
+            self._update_audit_detail(Text(
+                f"Nenhuma entry casou com os prefixos {sids} na janela atual.",
+                style="yellow",
+            ))
+            return
+
+        correlations = _compare_find_correlations(grouped)
+        comparison = _compare_render(grouped, correlations)
+        summary = _compare_render_summary(correlations)
+        self._update_audit_detail(Group(comparison, summary))
 
     def _handle_audit_export(self, raw_path: str) -> None:
         """Resolve path + formato, exporta conjunto filtrado atual.
@@ -1098,6 +1190,15 @@ class DashboardApp(App):
                 pass
             try:
                 inp = self.query_one("#audit-export-input", Input)
+                if inp.has_class("active"):
+                    inp.remove_class("active")
+                    inp.value = ""
+                    event.stop()
+                    return
+            except Exception:
+                pass
+            try:
+                inp = self.query_one("#audit-compare-input", Input)
                 if inp.has_class("active"):
                     inp.remove_class("active")
                     inp.value = ""

--- a/tests/test_audit_compare.py
+++ b/tests/test_audit_compare.py
@@ -1,0 +1,174 @@
+"""Testes da comparacao cross-session (#38)."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from claude_dash.audit.models import AuditEntry
+from claude_dash.views.audit_compare import (
+    Correlation,
+    find_correlations,
+    group_by_session,
+    merge_timelines,
+    parse_compare_input,
+)
+
+
+def _e(
+    *,
+    sid: str = "0efd3cf4-96ef-41b7-9d41-f91ec539becd",
+    tool: str = "Bash",
+    delta_seconds: float = 0,
+    input_sha: str = "aaaaaa",
+    tool_use_id: str = "x",
+) -> AuditEntry:
+    base = datetime(2026, 4, 28, 10, 0, 0, tzinfo=UTC)
+    return AuditEntry(
+        timestamp=base + timedelta(seconds=delta_seconds),
+        hostname="host", pid="1",
+        session_id=sid, tool=tool, tool_use_id=tool_use_id,
+        status="success", duration_ms=10, perm_mode="auto",
+        input_sha=input_sha, input_bytes=10, output_bytes=20,
+    )
+
+
+# ---- parse_compare_input --------------------------------------------
+
+
+def test_parse_compare_input_separadores_diversos() -> None:
+    assert parse_compare_input("0efd3 a1b2 8f9c") == ["0efd3", "a1b2", "8f9c"]
+    assert parse_compare_input("0efd3,a1b2,8f9c") == ["0efd3", "a1b2", "8f9c"]
+    assert parse_compare_input("0efd3; a1b2;8f9c") == ["0efd3", "a1b2", "8f9c"]
+    assert parse_compare_input("  0efd3   a1b2  ") == ["0efd3", "a1b2"]
+
+
+def test_parse_compare_input_dedup_preservando_ordem() -> None:
+    assert parse_compare_input("a b a c b") == ["a", "b", "c"]
+
+
+def test_parse_compare_input_vazio() -> None:
+    assert parse_compare_input("") == []
+    assert parse_compare_input("   ") == []
+
+
+# ---- group_by_session -----------------------------------------------
+
+
+def test_group_prefix_match_basico() -> None:
+    a = _e(sid="0efd3cf4-aaaa-aaaa-aaaa-aaaaaaaaaaaa", tool="Bash")
+    b = _e(sid="a1b2cccc-cccc-cccc-cccc-cccccccccccc", tool="Read")
+    out = group_by_session([a, b], ["0efd3", "a1b2"])
+    assert out["0efd3"] == [a]
+    assert out["a1b2"] == [b]
+
+
+def test_group_sid_sem_match_vira_lista_vazia() -> None:
+    a = _e(sid="0efd3cf4-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    out = group_by_session([a], ["0efd3", "ffffff"])
+    assert out["0efd3"] == [a]
+    assert out["ffffff"] == []
+
+
+def test_group_ordena_por_timestamp_dentro_da_sessao() -> None:
+    e1 = _e(sid="0efd3cf4", delta_seconds=5)
+    e2 = _e(sid="0efd3cf4", delta_seconds=0)
+    e3 = _e(sid="0efd3cf4", delta_seconds=10)
+    out = group_by_session([e1, e2, e3], ["0efd3"])
+    assert [x.timestamp for x in out["0efd3"]] == sorted(
+        [e1.timestamp, e2.timestamp, e3.timestamp],
+    )
+
+
+# ---- merge_timelines ------------------------------------------------
+
+
+def test_merge_timelines_global() -> None:
+    """Merge respeita ordem global por timestamp + tie-break por sid."""
+    grouped = {
+        "A": [_e(sid="A", delta_seconds=0), _e(sid="A", delta_seconds=10)],
+        "B": [_e(sid="B", delta_seconds=5), _e(sid="B", delta_seconds=15)],
+    }
+    out = merge_timelines(grouped)
+    sids_em_ordem = [sid for sid, _ in out]
+    assert sids_em_ordem == ["A", "B", "A", "B"]
+
+
+def test_merge_timelines_tiebreak_por_sid_lexico() -> None:
+    grouped = {
+        "B": [_e(sid="B", delta_seconds=0)],
+        "A": [_e(sid="A", delta_seconds=0)],
+    }
+    out = merge_timelines(grouped)
+    assert [sid for sid, _ in out] == ["A", "B"]
+
+
+# ---- find_correlations ----------------------------------------------
+
+
+def test_correlate_same_path_em_janela_curta() -> None:
+    """Mesmo input_sha em sessoes diferentes < 500ms -> same_path."""
+    a = _e(sid="A", tool="Read", input_sha="path-X", delta_seconds=0,
+           tool_use_id="ta")
+    b = _e(sid="B", tool="Read", input_sha="path-X", delta_seconds=0.3,
+           tool_use_id="tb")
+    out = find_correlations({"A": [a], "B": [b]})
+    assert len(out) == 1
+    assert out[0].reason == "same_path"
+    assert out[0].delta_ms == 300
+
+
+def test_correlate_same_cmd_para_bash() -> None:
+    a = _e(sid="A", tool="Bash", input_sha="cmd-X", tool_use_id="ta")
+    b = _e(sid="B", tool="Bash", input_sha="cmd-X", delta_seconds=0.1,
+           tool_use_id="tb")
+    out = find_correlations({"A": [a], "B": [b]})
+    assert len(out) == 1
+    assert out[0].reason == "same_cmd"
+
+
+def test_correlate_read_then_edit_em_5s() -> None:
+    """A=Read X em t=0; B=Edit X em t=2 -> read_then_edit."""
+    read = _e(sid="A", tool="Read", input_sha="file-X", delta_seconds=0,
+              tool_use_id="r1")
+    edit = _e(sid="B", tool="Edit", input_sha="file-X", delta_seconds=2,
+              tool_use_id="e1")
+    out = find_correlations({"A": [read], "B": [edit]})
+    assert len(out) == 1
+    assert out[0].reason == "read_then_edit"
+    assert out[0].delta_ms == 2000
+
+
+def test_correlate_ignora_mesma_sessao() -> None:
+    a = _e(sid="A", tool="Read", input_sha="X", tool_use_id="t1")
+    b = _e(sid="A", tool="Read", input_sha="X", delta_seconds=0.1,
+           tool_use_id="t2")
+    out = find_correlations({"A": [a, b]})
+    assert out == []
+
+
+def test_correlate_ignora_alvo_invalido() -> None:
+    """Skill/Agent nao tem _entry_target -> nunca correlaciona."""
+    a = _e(sid="A", tool="Skill", input_sha="X", tool_use_id="t1")
+    b = _e(sid="B", tool="Skill", input_sha="X", delta_seconds=0.1,
+           tool_use_id="t2")
+    out = find_correlations({"A": [a], "B": [b]})
+    assert out == []
+
+
+def test_correlate_fora_da_janela_nao_pareia() -> None:
+    """Mesmo input_sha mas delta > rte_window (5s) -> sem correlacao."""
+    a = _e(sid="A", tool="Read", input_sha="X", delta_seconds=0)
+    b = _e(sid="B", tool="Read", input_sha="X", delta_seconds=10)
+    out = find_correlations({"A": [a], "B": [b]})
+    assert out == []
+
+
+def test_correlate_retorna_correlation_dataclass() -> None:
+    a = _e(sid="A", tool="Bash", input_sha="X", tool_use_id="t1")
+    b = _e(sid="B", tool="Bash", input_sha="X", delta_seconds=0.05,
+           tool_use_id="t2")
+    out = find_correlations({"A": [a], "B": [b]})
+    assert isinstance(out[0], Correlation)
+    assert out[0].session_a == "A"
+    assert out[0].session_b == "B"
+    assert out[0].entry_a is a
+    assert out[0].entry_b is b


### PR DESCRIPTION
Etapa 11. Tecla 'c' compara 2-4 sessões lado-a-lado com detecção de correlações (same_path/same_cmd em ±500ms, read_then_edit em ≤5s).

## Mudanças
- Novo módulo views/audit_compare com pure functions
- Tecla 'c' + Input prompt no TUI
- Render em colunas paralelas + summary de correlações
- 15 testes novos

## Validação
384 passed (+15), lint limpo, bump v0.15.5 → v0.15.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)