### PR TITLE
feat(audit): drill-down humano-legível + scroll + split 50/50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.8] - 2026-04-28
+
+### Added
+- TUI: drill-down forense (`s` na aba Audit) agora renderiza cada linha do `tools.log` como **painel humano-legível** com cada campo identificado por label — `Timestamp:`, `Hostname:`, `PID:`, `Event:`, `Session:`, `Tool:`, `Tool use ID:`, `Status:`, `Duration:`, `Permission mode:`, `Input SHA:`, `Input bytes:`, `Output bytes:` + trailing fields tool-específicos: `CWD:`, `Command:` (Bash), `Path:` (Read/Edit/Write), `URL:` (WebFetch), `Query:` (WebSearch), `Skill:`, `Subagent:` + `Description:` (Agent). Status em cores (`red` pra erro, `yellow` pra running, `green` pra success); border do painel vermelho quando entry é erro. Antes mostrava texto bruto RFC 5424 que era ilegível em scan rápido.
+- Novo helper `claude_dash.audit.parser.parse_full_line(line)` — retorna `(AuditEntry, extra_fields)` extraindo cwd/cmd/path/url/query/skill do trailing após o `]`. Esses campos só existem no `/var/log/claude/tools.log` (forense completo), não na `sessions.log` metadata-only.
+- Novo `views/audit.py:render_drill_down_human(line)` — pure function que produz Rich Panel labeled. Testável sem TUI.
+
+### Changed
+- TUI: aba `Audit` agora usa **split 50/50** entre tabela e painel inferior (era 70/30). Drill-down e comparação ganharam espaço útil. `#audit-detail` ganhou `overflow-y: scroll` + `scrollbar-gutter: stable` — barra de rolagem sempre visível, sem layout shift quando o conteúdo cresce.
+
+### Fixed
+- TUI: comparação cross-session (`c`) tinha conteúdo cortado quando 3+ sessões geravam mais linhas do que cabia em ~25% da tela. Agora com 50% de altura + scrollbar dedicado, o conteúdo todo fica acessível via scroll.
+
 ## [0.15.7] - 2026-04-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.15.7"
+version = "0.15.8"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/audit/parser.py
+++ b/src/claude_dash/audit/parser.py
@@ -95,3 +95,42 @@ def parse_line(line: str) -> AuditEntry | None:
         subagent_type=fields.get("subagent_type") or None,
         event=event,
     )
+
+
+# Trailing fields apos o ']' do SD: cwd='...', cmd='...', path='...', etc.
+# Aceita aspas simples (Python repr — formato do hook) ou duplas.
+_TRAILING_RE = re.compile(r"(\w+)=(['\"])(.*?)\2")
+
+
+def parse_full_line(line: str) -> tuple[AuditEntry | None, dict[str, str]]:
+    """Parseia linha + extrai campos trailing (cwd, cmd, path, url, etc.).
+
+    O hook `audit/hook.py:_build_messages` emite, alem do STRUCTURED-DATA
+    canonico, um sufixo informativo:
+
+        ... [audit@iris ...] cwd='/path' cmd='ls -la'
+
+    Esses campos aparecem APENAS no /var/log/claude/tools.log (forense
+    completo), nao no metadata-only sessions.log. O drill-down `s` da
+    aba Audit le esse arquivo e quer renderizar legivel.
+
+    Retorna (entry, extra) — extra e' dict {key: value} com cwd e tool-
+    specific fields conforme `_summarize` no hook.
+
+    Campos cobertos por convencao do hook:
+    - Bash    -> cmd
+    - Read/Edit/Write -> path
+    - WebFetch  -> url
+    - WebSearch -> query
+    - Skill    -> skill
+    - Agent    -> subagent + desc
+    - Sempre  -> cwd (do payload do Claude Code)
+    """
+    entry = parse_line(line)
+    extra: dict[str, str] = {}
+    bracket = line.find("]")
+    if bracket >= 0 and bracket < len(line) - 1:
+        trailing = line[bracket + 1:].strip()
+        for m in _TRAILING_RE.finditer(trailing):
+            extra[m.group(1)] = m.group(3)
+    return entry, extra

--- a/src/claude_dash/views/audit.py
+++ b/src/claude_dash/views/audit.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
+from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
@@ -154,6 +155,80 @@ def filter_entries(
             continue
         out.append(e)
     return out
+
+
+def render_drill_down_human(line: str) -> Panel:
+    """Renderiza uma linha bruta do tools.log como Panel labeled (#67-followup).
+
+    Substitui a saida raw RFC 5424 por painel com cada campo identificado:
+    Timestamp, Hostname, PID, Event, Session, Tool, Tool use ID, Status,
+    Duration, Permission mode, Input SHA, Input bytes, Output bytes,
+    plus trailing fields (CWD + tool-specific: cmd/path/url/query/skill).
+
+    Linhas malformadas viram painel red com a linha original — nao crasha.
+    """
+    from claude_dash.audit.parser import parse_full_line
+
+    entry, extra = parse_full_line(line)
+    if entry is None:
+        return Panel(
+            Text(line.rstrip(), style="red"),
+            title="Linha invalida",
+            title_align="left",
+            border_style="red",
+        )
+
+    txt = Text()
+
+    def field(label: str, value: str, *, value_style: str = "") -> None:
+        txt.append(f"  {label:<18}", style="dim")
+        txt.append(f"{value}\n", style=value_style)
+
+    field("Timestamp:", entry.timestamp.isoformat())
+    field("Hostname:", entry.hostname)
+    field("PID:", entry.pid or "—")
+    event_style = "bold cyan" if entry.event == "start" else "bold"
+    field("Event:", entry.event, value_style=event_style)
+    field("Session:", entry.session_id)
+    field("Tool:", entry.tool, value_style="bold")
+    if entry.subagent_type:
+        field("Subagent:", entry.subagent_type)
+    field("Tool use ID:", entry.tool_use_id or "—")
+    status_style = (
+        "red" if entry.status == "error"
+        else ("yellow" if entry.status == "running" else "green")
+    )
+    field("Status:", entry.status, value_style=status_style)
+    field("Duration:", f"{entry.duration_ms} ms")
+    field("Permission mode:", entry.perm_mode or "—")
+    field("Input SHA:", entry.input_sha or "—")
+    field("Input bytes:", str(entry.input_bytes))
+    field("Output bytes:", str(entry.output_bytes))
+
+    # Trailing — separa visualmente
+    if extra:
+        txt.append("\n")
+        if "cwd" in extra:
+            field("CWD:", extra["cwd"])
+        # Tool-specific summaries do hook _summarize()
+        for key, label in (
+            ("cmd", "Command:"),
+            ("path", "Path:"),
+            ("url", "URL:"),
+            ("query", "Query:"),
+            ("skill", "Skill:"),
+            ("subagent", "Subagent input:"),
+            ("desc", "Description:"),
+        ):
+            if key in extra:
+                field(label, extra[key])
+
+    ts_str = entry.timestamp.strftime("%H:%M:%S.%f")[:-3]
+    title = f"{entry.tool} @ {ts_str}"
+    if entry.subagent_type:
+        title = f"{entry.tool}({entry.subagent_type}) @ {ts_str}"
+    border = "red" if entry.status == "error" else "cyan"
+    return Panel(txt, title=title, title_align="left", border_style=border)
 
 
 def correlate_start_end(entries: list[AuditEntry]) -> list[AuditEntry]:

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -196,15 +196,19 @@ class DashboardApp(App):
         margin: 0 0 1 0;
     }
     /* Aba Audit: tabela em cima, detail painel embaixo, status 1 linha,
-       prompt de filtro docked-bottom (so visivel quando ativo). */
+       prompt de filtro docked-bottom (so visivel quando ativo).
+       Split ~50/50 entre tabela e detail (era 70/30) — drill-down e
+       comparison precisam de espaco. overflow-y:scroll forca a barra
+       de rolagem aparecer mesmo quando o conteudo cabe (UX previsivel). */
     #audit-table {
         border: solid $primary;
-        height: 70%;
+        height: 50%;
     }
     #audit-detail {
         height: 1fr;
         border: solid $primary;
-        overflow-y: auto;
+        overflow-y: scroll;
+        scrollbar-gutter: stable;
     }
     #audit-status {
         height: 1;
@@ -1027,19 +1031,21 @@ class DashboardApp(App):
         truncated = len(matching) > max_lines
         shown = matching[-max_lines:]
         # Header informa qual chave foi usada e o contexto da entry.
+        from claude_dash.views.audit import render_drill_down_human
+
         ts = entry.timestamp.strftime("%H:%M:%S")
-        header = (
+        header_markup = (
             f"[bold]{ts} {entry.tool}[/bold]  "
             f"[dim]session={entry.session_id[:8]}…[/dim]\n"
             f"[bold]grep {filter_key} {AUDIT_SYSTEM_LOG}[/bold]  "
-            f"({len(matching)} linhas"
-            f"{', ultimas ' + str(max_lines) if truncated else ''})\n\n"
+            f"({len(matching)} linha(s)"
+            f"{', mostrando ultimas ' + str(max_lines) if truncated else ''})\n"
         )
-        # Text.from_markup interpretaria colchetes do log como markup;
-        # constrói Text manual: header em markup, body como texto plano.
-        text_obj = Text.from_markup(header)
-        text_obj.append("".join(shown))
-        self._update_audit_detail(text_obj)
+        # Renderiza cada linha como Panel humano-legivel (#67-followup).
+        # Antes mostravamos texto bruto RFC 5424; agora cada campo do log
+        # vem identificado por label.
+        panels = [render_drill_down_human(line) for line in shown]
+        self._update_audit_detail(Group(Text.from_markup(header_markup), *panels))
 
     def _update_audit_detail(self, content) -> None:
         with contextlib.suppress(Exception):

--- a/tests/test_audit_parser.py
+++ b/tests/test_audit_parser.py
@@ -1,7 +1,7 @@
 """Testes do parser de linhas RFC 5424 do audit log."""
 from __future__ import annotations
 
-from claude_dash.audit.parser import parse_line
+from claude_dash.audit.parser import parse_full_line, parse_line
 
 
 def test_linha_valida_basica() -> None:
@@ -133,3 +133,64 @@ def test_toolcall_com_event_explicito_end() -> None:
     e = parse_line(line)
     assert e is not None
     assert e.event == "end"
+
+
+# ---- parse_full_line: extrai trailing fields (#67-followup) ---------
+
+
+def test_full_line_extrai_cwd_e_cmd_de_bash() -> None:
+    """Linha do tools.log inclui cwd + cmd no trailing apos o ']'."""
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="success" '
+        'duration_ms="100" perm_mode="auto" input_sha="0" input_bytes="0" '
+        "output_bytes=\"0\"] cwd='/home/menzani' cmd='ls -la /tmp'"
+    )
+    entry, extra = parse_full_line(line)
+    assert entry is not None
+    assert entry.tool == "Bash"
+    assert extra["cwd"] == "/home/menzani"
+    assert extra["cmd"] == "ls -la /tmp"
+
+
+def test_full_line_extrai_path_de_read() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Read" tool_use_id="x" status="success" '
+        'duration_ms="100" perm_mode="auto" input_sha="0" input_bytes="0" '
+        "output_bytes=\"0\"] cwd='/tmp' path='/etc/hostname'"
+    )
+    entry, extra = parse_full_line(line)
+    assert entry is not None
+    assert extra["path"] == "/etc/hostname"
+
+
+def test_full_line_extrai_url_de_webfetch() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="WebFetch" tool_use_id="x" status="success" '
+        'duration_ms="100" perm_mode="auto" input_sha="0" input_bytes="0" '
+        "output_bytes=\"0\"] cwd='/tmp' url='https://example.com/'"
+    )
+    entry, extra = parse_full_line(line)
+    assert entry is not None
+    assert extra["url"] == "https://example.com/"
+
+
+def test_full_line_sem_trailing_retorna_extra_vazio() -> None:
+    """Linha so com SD, sem campos depois — extra vazio mas entry valido."""
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="success" '
+        'duration_ms="100" perm_mode="auto" input_sha="0" input_bytes="0" '
+        'output_bytes="0"]'
+    )
+    entry, extra = parse_full_line(line)
+    assert entry is not None
+    assert extra == {}
+
+
+def test_full_line_invalida_retorna_none_e_dict_vazio() -> None:
+    entry, extra = parse_full_line("lixo nao parseavel")
+    assert entry is None
+    assert extra == {}

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -18,6 +18,7 @@ from claude_dash.views.audit import (
     export_entries,
     filter_entries,
     parse_filter_input,
+    render_drill_down_human,
     render_footer,
     render_table,
 )
@@ -548,3 +549,105 @@ def test_render_table_dim_para_outro_host() -> None:
     # row.style ou cells inheritados — Rich mantem _row_styles na Table.
     # Mais simples: checamos que a Table tem pelo menos uma row com style dim.
     assert any("dim" in str(getattr(row, "style", "")) for row in rendered)
+
+
+# ---- render_drill_down_human (#67-followup) -------------------------
+
+
+def _human_text(panel) -> str:
+    """Extrai conteudo plain text de um Rich Panel pra assertions."""
+    from rich.console import Console
+    console = Console(record=True, width=200)
+    console.print(panel)
+    return console.export_text()
+
+
+def test_drill_down_human_inclui_todos_os_labels_principais() -> None:
+    line = (
+        '<134>1 2026-04-28T17:55:38.278-03:00 ret-dti-601048 claude-code 99999 '
+        'TOOLCALL [audit@iris session="0efd3cf4-96ef-41b7-9d41-f91ec539becd" '
+        'tool="Bash" tool_use_id="toolu_test" status="success" '
+        'duration_ms="42" perm_mode="auto" input_sha="abc123" '
+        "input_bytes=\"50\" output_bytes=\"100\"] cwd='/home/menzani' cmd='ls -la'"
+    )
+    panel = render_drill_down_human(line)
+    txt = _human_text(panel)
+    # Cabecalho do Panel inclui tool + horario
+    assert "Bash" in txt
+    # Labels canonicos
+    for label in (
+        "Timestamp:", "Hostname:", "PID:", "Event:", "Session:", "Tool:",
+        "Tool use ID:", "Status:", "Duration:", "Permission mode:",
+        "Input SHA:", "Input bytes:", "Output bytes:",
+    ):
+        assert label in txt, f"label ausente: {label}"
+    # Valores
+    assert "ret-dti-601048" in txt
+    assert "0efd3cf4-96ef-41b7-9d41-f91ec539becd" in txt
+    assert "toolu_test" in txt
+    assert "42 ms" in txt
+    # Trailing fields
+    assert "CWD:" in txt
+    assert "/home/menzani" in txt
+    assert "Command:" in txt
+    assert "ls -la" in txt
+
+
+def test_drill_down_human_status_error_em_red() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="error" '
+        'duration_ms="50" perm_mode="auto" input_sha="0" input_bytes="0" '
+        'output_bytes="0"]'
+    )
+    panel = render_drill_down_human(line)
+    # Border do Panel vira red quando status=error
+    assert panel.border_style == "red"
+
+
+def test_drill_down_human_event_start_destacado() -> None:
+    """PreToolUse/TOOLSTART -> Event: start em estilo destacado."""
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLSTART '
+        '[audit@iris session="abc" tool="Bash" tool_use_id="x" status="running" '
+        'duration_ms="0" perm_mode="auto" input_sha="0" input_bytes="0" '
+        'output_bytes="0" event="start"]'
+    )
+    panel = render_drill_down_human(line)
+    txt = _human_text(panel)
+    assert "Event:" in txt
+    assert "start" in txt
+    assert "running" in txt
+
+
+def test_drill_down_human_linha_invalida_nao_crasha() -> None:
+    panel = render_drill_down_human("texto qualquer nao parseavel")
+    assert panel.border_style == "red"
+    txt = _human_text(panel)
+    assert "Linha invalida" in txt or "invalida" in txt
+
+
+def test_drill_down_human_path_de_read() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Read" tool_use_id="x" status="success" '
+        'duration_ms="10" perm_mode="auto" input_sha="0" input_bytes="0" '
+        "output_bytes=\"0\"] cwd='/tmp' path='/etc/hostname'"
+    )
+    panel = render_drill_down_human(line)
+    txt = _human_text(panel)
+    assert "Path:" in txt
+    assert "/etc/hostname" in txt
+
+
+def test_drill_down_human_subagent_em_agent() -> None:
+    line = (
+        '<134>1 2026-04-28T00:00:29.223-03:00 host claude-code 1 TOOLCALL '
+        '[audit@iris session="abc" tool="Agent" tool_use_id="x" status="success" '
+        'duration_ms="5000" perm_mode="auto" input_sha="0" input_bytes="0" '
+        'output_bytes="0" subagent_type="general-purpose"]'
+    )
+    panel = render_drill_down_human(line)
+    txt = _human_text(panel)
+    assert "Subagent:" in txt
+    assert "general-purpose" in txt


### PR DESCRIPTION
3 melhorias UX na aba Audit:

## Mudanças
1. **Drill-down humano-legível** — cada linha do tools.log vira painel labeled (Timestamp, Hostname, PID, Event, Session, Tool, Tool use ID, Status, Duration, Permission mode, Input SHA, Input/Output bytes, CWD + tool-specific Command/Path/URL/Query/Skill/Subagent). Status em cor.
2. **Split 50/50** — `#audit-table` 70%→50%, dá espaço pra drill-down e comparison.
3. **Scrollbar garantido** — `#audit-detail` overflow-y: scroll + scrollbar-gutter: stable. Sem layout shift.

## Validação
398 passed (+12), lint limpo (RUF001/RUF002 em account.py pré-existentes), bump v0.15.7 → v0.15.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)