### PR TITLE
feat(audit): multi-select via Space + Enter contextual + auto-tail fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.9] - 2026-04-28
+
+### Added
+- TUI: aba `Audit` ganhou **multi-select via Space**. Pressionar Space na linha sob o cursor toggla mark — entries marcadas mostram `✓` na nova coluna `Mk` (primeira coluna). Footer status indica `marked=N` quando há marcadas. Pressionar Space numa entry já marcada remove a marca.
+- TUI: tecla **`Enter`** agora dispara ação contextual:
+  - **0-1 marcadas** → drill-down do cursor (mesmo comportamento da tecla `s`).
+  - **2+ marcadas** → comparison cross-session usando os `session_id`s das marcadas (sem precisar do prompt manual de SIDs).
+- TUI: tecla `c` (compare) também aceita marcadas: com 2+ marcadas, compara direto; com 0-1, abre o prompt manual (comportamento antigo).
+- 2 testes novos em `tests/test_audit_view.py` cobrindo `_marked_session_ids` e `_clear_marks_and_refresh`.
+
+### Fixed
+- TUI: bug do auto-tail forçando cursor pra última linha **voltou a aparecer após o split 50/50 da v0.15.8**. O fix anterior dependia exclusivamente do evento `RowHighlighted` do Textual + flag `_audit_cursor_managed`, que tem race condition se o evento chegar atrasado em relação ao próximo tick. Adicionada **segunda linha de defesa determinística**: rastreio de `_audit_last_set_cursor` (posição que setamos no último tick); no tick seguinte, se o cursor está em posição diferente da que registramos, o usuário moveu — marca interação independente de timing de evento. Testes que cobrem o caminho via `pilot.press("up")` continuam verdes.
+
+### Changed
+- DataTable da aba `Audit` agora tem 8 colunas (era 7): nova coluna `Mk` no início, seguida de `time`, `sess`, `host`, `tool`, `dur_ms`, `in`, `out`. `views/audit.py:render_table` (Rich, usado pra rendering shell standalone) permanece com 7 colunas — a `Mk` é exclusiva da TUI.
+- Linha de atalhos in-tab atualizada: `Spc mark`, `Enter/s drill-down`, `c compare`.
+
 ## [0.15.8] - 2026-04-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.15.8"
+version = "0.15.9"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -277,7 +277,9 @@ class DashboardApp(App):
         Binding("s", "audit_drill_down_root", "Root drill-down", show=False),
         Binding("e", "audit_export_prompt", "Export", show=False),
         Binding("h", "audit_toggle_host", "Toggle host", show=False),
-        Binding("c", "audit_compare_prompt", "Compare", show=False),
+        Binding("c", "audit_compare_action", "Compare", show=False),
+        Binding("space", "audit_toggle_mark", "Mark", show=False),
+        Binding("enter", "audit_enter_action", "Drill/Compare", show=False),
         Binding("end", "audit_resume_scroll", "Resume", show=False),
     ]
 
@@ -322,6 +324,16 @@ class DashboardApp(App):
         # ignora um evento e reseta. Qualquer evento subsequente sem
         # flag significa interacao do usuario -> marca pausa.
         self._audit_cursor_managed: bool = False
+        # Segunda linha de defesa pro auto-tail bug: rastreia o cursor_row
+        # que setamos programaticamente. Se no proximo tick o cursor
+        # estiver em posicao diferente sem nossa autorizacao, usuario
+        # moveu — marca interacao deterministicamente (sem depender de
+        # timing do evento RowHighlighted que pode chegar atrasado).
+        self._audit_last_set_cursor: int = -1
+        # Multi-select via Space: tool_use_ids das entries marcadas.
+        # Enter ou tecla `c` agem sobre essas: 2+ -> comparacao,
+        # 0-1 -> drill-down do cursor.
+        self._audit_marked: set[str] = set()
         # Render incremental: tracking pra evitar full rebuild a cada tick.
         # Signature do filtro (filter+window+show_tests): se mudar, rebuild.
         self._audit_table_signature: tuple | None = None
@@ -685,6 +697,11 @@ class DashboardApp(App):
                 status_parts.append("host=todos")
             if self._audit_show_tests:
                 status_parts.append("show-tests=on")
+            # #67-followup: contador de marcadas pra usuario saber
+            # quantas estao no batch da proxima Enter/c.
+            n_marked = len(self._audit_marked)
+            if n_marked > 0:
+                status_parts.append(f"[bold yellow]marked={n_marked}[/]")
             paused = self._is_audit_paused()
             if paused:
                 status_parts.append("[bold yellow]PAUSED — Press End to resume[/]")
@@ -723,8 +740,18 @@ class DashboardApp(App):
         """
         from claude_dash.views.audit import _color_for, _fmt_bytes
 
+        # Detecta movimento de cursor pelo usuario entre ticks
+        # (deterministico, nao depende de timing de evento). Se o cursor
+        # esta diferente do que setamos da ultima vez, usuario moveu.
+        if (
+            dt.row_count > 0
+            and self._audit_last_set_cursor >= 0
+            and dt.cursor_row != self._audit_last_set_cursor
+        ):
+            self._mark_audit_user_action()
+
         if not dt.columns:
-            dt.add_columns("time", "sess", "host", "tool", "dur_ms", "in", "out")
+            dt.add_columns("Mk", "time", "sess", "host", "tool", "dur_ms", "in", "out")
 
         # `visible` ja vem capeado pelo chamador (_refresh_audit) em
         # AUDIT_TABLE_MAX_ROWS. Nao re-slicear pra manter cache alinhado.
@@ -779,7 +806,12 @@ class DashboardApp(App):
                 style = "italic dim"
             dur_str = "running..." if is_running else str(e.duration_ms)
             out_str = "—" if is_running else _fmt_bytes(e.output_bytes)
+            # Multi-select via Space (#67-followup): celula `Mk` mostra ✓
+            # quando entry esta marcada pra comparison batch.
+            mark_key = e.tool_use_id or e.session_id
+            mark_str = "✓" if mark_key in self._audit_marked else " "
             cells = [
+                Text(mark_str, style="bold yellow", justify="center"),
                 Text(time_str, style="cyan" if not (host_other or is_running) else "dim"),
                 Text(sess_str, style=style),
                 Text(host_str, style=style),
@@ -806,6 +838,11 @@ class DashboardApp(App):
         ):
             self._audit_cursor_managed = True
             dt.move_cursor(row=dt.row_count - 1, animate=False)
+        # Atualiza tracker pro proximo tick comparar (#67-followup).
+        # Independente de termos movido, registramos onde o cursor
+        # esta agora — proximo tick deteta diff = movimento do usuario.
+        if dt.row_count > 0:
+            self._audit_last_set_cursor = dt.cursor_row
 
     def _populate_audit_keys(self) -> None:
         """Renderiza linha de atalhos da aba Audit no widget #audit-keys.
@@ -821,9 +858,10 @@ class DashboardApp(App):
             ("t", "window"),
             ("?", "tests"),
             ("h", "host"),
-            ("s", "drill-down"),
-            ("e", "export"),
+            ("Spc", "mark"),
+            ("Enter/s", "drill-down"),
             ("c", "compare"),
+            ("e", "export"),
             ("End", "resume"),
         ]
         parts = "  ".join(
@@ -883,11 +921,25 @@ class DashboardApp(App):
         except Exception:
             pass
 
-    def action_audit_compare_prompt(self) -> None:
-        """Tecla `c`: prompt pra comparar 2-3 sessoes lado-a-lado (#38)."""
+    def action_audit_compare_action(self) -> None:
+        """Tecla `c`: comparar sessoes (#38 + #67-followup).
+
+        Comportamento:
+        - 2+ entries marcadas (Space) -> compara as session_ids unicas.
+        - 0-1 marcadas -> abre prompt manual (comportamento antigo).
+        """
         if not self._audit_active():
             return
         self._mark_audit_user_action()
+
+        marked_sids = self._marked_session_ids()
+        if len(marked_sids) >= 2:
+            # Usa session_ids das marcadas direto, sem prompt.
+            self._handle_audit_compare(" ".join(sorted(marked_sids)))
+            self._clear_marks_and_refresh()
+            return
+
+        # Fallback: prompt manual de SIDs
         try:
             inp = self.query_one("#audit-compare-input", Input)
             inp.value = ""
@@ -895,6 +947,76 @@ class DashboardApp(App):
             inp.focus()
         except Exception:
             pass
+
+    def action_audit_toggle_mark(self) -> None:
+        """Tecla `Space`: toggla marca da entry no cursor (#67-followup).
+
+        Marcadas ficam destacadas com ✓ na coluna Mk. Tecla Enter (ou c)
+        com 2+ marcadas dispara comparison; com 0-1 dispara drill-down.
+        """
+        if not self._audit_active():
+            return
+        self._mark_audit_user_action()
+        try:
+            dt = self.query_one("#audit-table", DataTable)
+        except Exception:
+            return
+        visible = list(getattr(self, "_audit_visible_cache", []))
+        cursor_row = dt.cursor_row
+        if not visible or cursor_row < 0 or cursor_row >= len(visible):
+            return
+        entry = visible[cursor_row]
+        key = entry.tool_use_id or entry.session_id
+        if not key:
+            return
+        if key in self._audit_marked:
+            self._audit_marked.discard(key)
+        else:
+            self._audit_marked.add(key)
+        # Re-render pra atualizar a celula Mk. _audit_table_signature
+        # nao depende de _audit_marked, entao append-only manteria a
+        # tabela velha; forca rebuild zerando a signature.
+        self._audit_table_signature = None
+        self._refresh_audit()
+
+    def action_audit_enter_action(self) -> None:
+        """Tecla `Enter`: drill-down ou comparison conforme marcadas (#67-followup).
+
+        Comportamento:
+        - 2+ entries marcadas -> compara as session_ids.
+        - 0-1 marcadas -> drill-down do cursor (= tecla `s`).
+        """
+        if not self._audit_active():
+            return
+        self._mark_audit_user_action()
+
+        marked_sids = self._marked_session_ids()
+        if len(marked_sids) >= 2:
+            self._handle_audit_compare(" ".join(sorted(marked_sids)))
+            self._clear_marks_and_refresh()
+            return
+
+        # Default: drill-down do cursor (mesmo que `s`)
+        self.action_audit_drill_down_root()
+
+    def _marked_session_ids(self) -> set[str]:
+        """Resolve session_ids unicas a partir do set de tool_use_ids marcados."""
+        if not self._audit_marked:
+            return set()
+        sids: set[str] = set()
+        # Itera pelo buffer atual; marca pode ter sido feita em entry
+        # que ja saiu do ring buffer — nesse caso nao acha e descarta.
+        for entry in self._audit_entries:
+            key = entry.tool_use_id or entry.session_id
+            if key in self._audit_marked and entry.session_id:
+                sids.add(entry.session_id)
+        return sids
+
+    def _clear_marks_and_refresh(self) -> None:
+        """Limpa todas as marcas e forca re-render da tabela."""
+        self._audit_marked.clear()
+        self._audit_table_signature = None
+        self._refresh_audit()
 
     def action_audit_toggle_host(self) -> None:
         """Tecla `h`: toggle entre `host=<atual>` e `host=todos` (#55).

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -271,6 +271,58 @@ def test_tecla_question_toggle_test_sessions() -> None:
     _run(run())
 
 
+def test_marked_session_ids_resolve_de_tool_use_ids_no_buffer() -> None:
+    """#67-followup: _marked_session_ids resolve sids unicos do conjunto marcado."""
+    async def run():
+        from datetime import datetime as _dt
+        from datetime import timedelta as _td
+        from datetime import timezone as _tz
+
+        from claude_dash.audit.models import AuditEntry
+
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+
+            # 3 entries de 2 sessoes diferentes (independente do buffer real)
+            base = _dt(2026, 4, 28, 0, 0, 0, tzinfo=_tz(_td(hours=-3)))
+            sid_a = "0efd3cf4-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+            sid_b = "a1b2cccc-cccc-cccc-cccc-cccccccccccc"
+            for i in range(3):
+                app._audit_entries.append(AuditEntry(
+                    timestamp=base + _td(seconds=i),
+                    hostname="host", pid="1",
+                    session_id=sid_a if i < 2 else sid_b,
+                    tool="Bash", tool_use_id=f"synthetic-tu-{i}", status="success",
+                    duration_ms=10, perm_mode="auto", input_sha="0",
+                    input_bytes=10, output_bytes=20,
+                ))
+
+            # Marca tool_use_ids manualmente (simula o que action_audit_toggle_mark
+            # faria via Space) — uma de cada session
+            app._audit_marked.add("synthetic-tu-0")  # sid_a
+            app._audit_marked.add("synthetic-tu-2")  # sid_b
+
+            sids = app._marked_session_ids()
+            assert sid_a in sids
+            assert sid_b in sids
+    _run(run())
+
+
+def test_clear_marks_and_refresh() -> None:
+    """_clear_marks_and_refresh esvazia o set."""
+    async def run():
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            app._audit_marked.add("any-key")
+            app._audit_marked.add("other-key")
+            assert len(app._audit_marked) == 2
+            app._clear_marks_and_refresh()
+            assert len(app._audit_marked) == 0
+    _run(run())
+
+
 def test_cursor_user_pausa_auto_tail() -> None:
     """Movimento de cursor pelo usuario deve pausar o auto-tail.
 


### PR DESCRIPTION
3 melhorias na aba Audit:

## Mudanças
1. **Multi-select via Space** — nova coluna Mk com ✓; status 'marked=N'.
2. **Enter contextual** — 0-1 marks: drill-down. 2+ marks: comparison direta com session_ids das marcadas. Tecla 'c' idem.
3. **Auto-tail bug fix robusto** — segunda linha de defesa determinística via `_audit_last_set_cursor`. Sem race condition de evento.

## Validação
400 passed (+2), lint limpo, bump v0.15.8 → v0.15.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)