### PR TITLE
feat(audit): feedback explícito quando Enter não consegue compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.12] - 2026-04-28
+
+### Changed
+- TUI: `action_audit_enter_action` agora distingue 3 casos de marcadas em vez de cair silenciosamente em drill-down quando comparison não é possível:
+  1. **2+ marcadas em 2+ sessões distintas** → comparison (caminho normal).
+  2. **2+ marcadas mas todas da mesma sessão** → mensagem amarela explicando: `"N entries marcadas, mas todas da mesma sessao (sid_short…). Comparison exige 2+ sessoes DISTINTAS."`
+  3. **2+ marcadas mas nenhuma no buffer atual** (rotacionaram para fora) → mensagem amarela explicando: `"N entries marcadas, mas nenhuma encontrada no buffer atual (podem ter rotacionado)."`
+  4. **0-1 marcadas** → drill-down do cursor (= tecla `s`, comportamento padrão).
+- Mensagens informativas no painel `#audit-detail` permitem diagnosticar rapidamente quando Enter "não abre compare" — antes caía silenciosamente em drill-down sem indicação do motivo.
+
 ## [0.15.11] - 2026-04-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.15.11"
+version = "0.15.12"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -1060,17 +1060,41 @@ class DashboardApp(App):
         """Tecla `Enter`: drill-down ou comparison conforme marcadas (#67-followup).
 
         Comportamento:
-        - 2+ entries marcadas -> compara as session_ids.
-        - 0-1 marcadas -> drill-down do cursor (= tecla `s`).
+        - 2+ marcadas em 2+ sessoes distintas -> comparison
+        - 2+ marcadas mas todas da mesma sessao -> feedback claro
+        - 0-1 marcadas -> drill-down do cursor (= tecla `s`)
+        - 1+ marcadas mas sem casar com buffer -> drill-down (silenciosa)
         """
         if not self._audit_active():
             return
         self._mark_audit_user_action()
 
+        n_marked = len(self._audit_marked)
         marked_sids = self._marked_session_ids()
-        if len(marked_sids) >= 2:
+
+        if n_marked >= 2 and len(marked_sids) >= 2:
+            # Caminho normal: comparison entre sessoes distintas
             self._handle_audit_compare(" ".join(sorted(marked_sids)))
             self._clear_marks_and_refresh()
+            return
+
+        if n_marked >= 2 and len(marked_sids) < 2:
+            # User marcou 2+ entries mas o resultado nao da pra comparar.
+            # Distingue 2 casos pra feedback util.
+            if len(marked_sids) == 0:
+                msg = (
+                    f"{n_marked} entries marcadas, mas nenhuma encontrada "
+                    "no buffer atual (podem ter rotacionado). Marque "
+                    "(Space) entries visiveis e tente Enter de novo."
+                )
+            else:
+                sid_short = next(iter(marked_sids))[:8]
+                msg = (
+                    f"{n_marked} entries marcadas, mas todas da mesma "
+                    f"sessao ({sid_short}…). Comparison exige 2+ sessoes "
+                    "DISTINTAS. Marque entries de sessoes diferentes."
+                )
+            self._update_audit_detail(Text(msg, style="yellow"))
             return
 
         # Default: drill-down do cursor (mesmo que `s`)


### PR DESCRIPTION
Antes Enter com 2+ marcadas da mesma sessão caía em drill-down silencioso. Agora mostra mensagem amarela explicando o motivo — comparison exige 2+ sessões distintas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)