### PR TITLE
feat(audit): filtro progressivo de marcação + Esc limpa marcas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.13] - 2026-04-28
+
+### Added
+- TUI: **filtro progressivo de marcação** na aba `Audit`. Quando o usuário marca uma entry com `Space`, **todas as entries da mesma `session_id` somem da tabela** — view fica focada nas sessões ainda não marcadas, ergonomico pra montar comparison cross-session sem precisar caçar SIDs distintos manualmente. Cada Space adicional filtra mais uma sessão. `Esc` limpa todas as marcas e restaura a view completa. Compare via Enter/c também limpa marcas + restaura.
+- TUI: **`Esc` limpa marcas** quando nenhum input prompt está ativo (filter/export/compare). Adiciona um caminho de cancelamento sem precisar dar Enter no compare. Sugestão exibida no status footer: `marked=N (M sessões filtradas; Esc limpa)`.
+- 2 testes novos: `test_marks_filtram_sessao_da_visible_cache` cobre o auto-filter; `test_esc_limpa_marcas_quando_sem_prompt_ativo` cobre o caminho de Esc.
+
+### Changed
+- `action_audit_toggle_mark` voltou a fazer `full_rebuild` (via `_audit_table_signature = None`) — necessário pra filtro progressivo redrawn da tabela. Trade-off com a v0.15.11 (que fazia `update_cell_at` pra preservar scroll): agora a entry recém-marcada some naturalmente, então scroll preservation não é meaningful — a tabela mudou de conteúdo.
+- Linha de atalhos in-tab atualizada: `Spc mark+filter`, `Esc clear marks`.
+
+### Workflow recomendado pra cross-session compare
+
+1. Navegue até qualquer entry de uma sessão A → `Space`. Sessão A some da view.
+2. Navegue até entry de sessão B → `Space`. Sessão B some da view.
+3. (Opcional) marque mais sessões.
+4. `Enter` → comparison lado-a-lado das sessões marcadas.
+5. (Ou) `Esc` → cancela e restaura view.
+
 ## [0.15.12] - 2026-04-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-dashboard"
-version = "0.15.12"
+version = "0.15.13"
 description = "TUI dashboard for Claude Code sessions, tokens, tools and cost"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_dash/views/tui.py
+++ b/src/claude_dash/views/tui.py
@@ -670,6 +670,15 @@ class DashboardApp(App):
                 show_test_sessions=self._audit_show_tests,
                 current_host=current_host,
             )
+            # #67-followup-5: filtro progressivo de marcacao. Quando o
+            # usuario marca uma entry (Space), a tabela esconde TODAS
+            # as entries dessa session_id — o foco vai pras sessoes
+            # ainda nao marcadas, ergonomico pra montar comparison
+            # cross-session sem precisar caçar SIDs distintos. Esc
+            # limpa marcas e restaura a view completa.
+            marked_sids = self._marked_session_ids()
+            if marked_sids:
+                visible = [e for e in visible if e.session_id not in marked_sids]
             # Slice EXATO do que vai aparecer na DataTable. Cache armazena
             # esse slice (NAO a lista cheia) — sem isso, cursor_row da
             # DataTable nao bate com o indice no cache quando filter
@@ -700,11 +709,15 @@ class DashboardApp(App):
                 status_parts.append("host=todos")
             if self._audit_show_tests:
                 status_parts.append("show-tests=on")
-            # #67-followup: contador de marcadas pra usuario saber
-            # quantas estao no batch da proxima Enter/c.
+            # #67-followup-5: contador de marcadas + indicacao de filtro
+            # progressivo. N marcadas = N sessoes escondidas; Esc limpa.
             n_marked = len(self._audit_marked)
             if n_marked > 0:
-                status_parts.append(f"[bold yellow]marked={n_marked}[/]")
+                marked_sids_count = len(self._marked_session_ids())
+                status_parts.append(
+                    f"[bold yellow]marked={n_marked} "
+                    f"({marked_sids_count} sessao(oes) filtrada(s); Esc limpa)[/]"
+                )
             paused = self._is_audit_paused()
             if paused:
                 status_parts.append("[bold yellow]PAUSED — Press End to resume[/]")
@@ -869,10 +882,11 @@ class DashboardApp(App):
             ("t", "window"),
             ("?", "tests"),
             ("h", "host"),
-            ("Spc", "mark"),
-            ("Enter/s", "drill-down"),
+            ("Spc", "mark+filter"),
+            ("Enter/s", "drill/cmp"),
             ("c", "compare"),
             ("e", "export"),
+            ("Esc", "clear marks"),
             ("End", "resume"),
         ]
         parts = "  ".join(
@@ -960,11 +974,15 @@ class DashboardApp(App):
             pass
 
     def action_audit_toggle_mark(self) -> None:
-        """Tecla `Space`: toggla marca da entry no cursor (#67-followup).
+        """Tecla `Space`: marca entry no cursor + filtra a sessao (#67-followup-5).
 
-        Atualiza apenas a celula Mk via update_cell_at — sem rebuild,
-        sem perda de scroll position, sem perda de cursor. Antes
-        forcava full_rebuild que zerava scroll (bug reportado).
+        Ao marcar uma entry, TODAS as entries da mesma session_id somem
+        da tabela — a view fica focada em sessoes ainda nao marcadas,
+        facilitando montar comparison cross-session. Esc limpa marcas
+        e restaura view completa.
+
+        Marcar uma entry ja-marcada (mas invisivel pelo filtro) nao e'
+        possivel via cursor; user usa Esc pra limpar tudo e remarcar.
         """
         if not self._audit_active():
             return
@@ -981,28 +999,18 @@ class DashboardApp(App):
         key = entry.tool_use_id or entry.session_id
         if not key:
             return
+        # Toggle: se ja marcada (improvavel pela auto-filtragem mas
+        # possivel se entry ainda nao foi escondida), unmark. Caso
+        # contrario, mark.
         if key in self._audit_marked:
             self._audit_marked.discard(key)
-            new_mark = " "
         else:
             self._audit_marked.add(key)
-            new_mark = "✓"
-        # Update in-place da celula Mk (coluna 0). Preserva scroll +
-        # cursor sem precisar do _audit_table_signature reset.
-        try:
-            from textual.coordinate import Coordinate
-            dt.update_cell_at(
-                Coordinate(cursor_row, 0),
-                Text(new_mark, style="bold yellow", justify="center"),
-            )
-        except Exception:
-            # Fallback se update_cell_at indisponivel: tick proximo
-            # vai sincronizar via _audit_marked state.
-            pass
-        # Atualiza apenas o status line (contador de marcadas).
-        self._update_audit_status_only()
-        # Garante que DataTable mantem foco — necessario pra que Enter
-        # subsequente dispare RowSelected -> on_data_table_row_selected.
+        # Filtro mudou (sessao das marcadas afeta visibilidade). Forca
+        # rebuild zerando signature + chama refresh.
+        self._audit_table_signature = None
+        self._refresh_audit()
+        # Re-foco defensivo da DataTable pra Enter subsequente.
         with contextlib.suppress(Exception):
             dt.focus()
 
@@ -1452,6 +1460,12 @@ class DashboardApp(App):
                     return
             except Exception:
                 pass
+            # Esc na aba Audit sem prompts ativos: limpa marcas (#67-followup-5).
+            # Util pra cancelar montagem de comparison ou desfiltrar a tabela.
+            if self._audit_active() and self._audit_marked:
+                self._clear_marks_and_refresh()
+                event.stop()
+                return
         # Marca interacao do usuario na aba Audit pra pausar auto-scroll.
         # Tecla End tem action propria de retomar — nao trata como pausa.
         if self._audit_active() and event.key not in {"end"}:

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -398,6 +398,83 @@ def test_enter_com_2plus_marcadas_dispara_compare() -> None:
     _run(run())
 
 
+def test_marks_filtram_sessao_da_visible_cache() -> None:
+    """#67-followup-5: ao marcar entry, a sessao toda some da view."""
+    async def run():
+        from datetime import datetime as _dt
+        from datetime import timedelta as _td
+        from datetime import timezone as _tz
+
+        from claude_dash.audit.models import AuditEntry
+
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            await pilot.press("5")
+            await pilot.pause(0.3)
+
+            # Limpa buffer de entries reais pra teste deterministico
+            app._audit_entries.clear()
+            # Desativa filtro de host atual pra entries syntheticas (hostname='host')
+            # passarem; senao serao excluidas por nao baterem com CURRENT_HOSTNAME.
+            app._audit_host_only_current = False
+
+            # Usa timestamp recente pra cair na janela default 24h
+            base = _dt.now(tz=_tz(_td(hours=-3))) - _td(minutes=5)
+            # UUIDs v4 validos (pos 14 == 4, pos 19 in {8,9,a,b})
+            sid_a = "0efd3cf4-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+            sid_b = "a1b2cccc-cccc-4ccc-8ccc-cccccccccccc"
+            for i in range(4):
+                app._audit_entries.append(AuditEntry(
+                    timestamp=base + _td(seconds=i),
+                    hostname="host", pid="1",
+                    session_id=sid_a if i < 2 else sid_b,
+                    tool="Bash", tool_use_id=f"synthetic-tu-{i}",
+                    status="success", duration_ms=10, perm_mode="auto",
+                    input_sha="0", input_bytes=10, output_bytes=20,
+                ))
+            app._refresh_audit()
+            await pilot.pause(0.2)
+
+            # Antes da marca: ambas as sessoes visiveis
+            sids_in_view = {e.session_id for e in app._audit_visible_cache}
+            assert sid_a in sids_in_view
+            assert sid_b in sids_in_view
+
+            # Marca uma entry de sid_a manualmente (simula Space)
+            app._audit_marked.add("synthetic-tu-0")
+            app._audit_table_signature = None
+            app._refresh_audit()
+            await pilot.pause(0.2)
+
+            # Verifica que NENHUMA entry de sid_a aparece na cache visivel
+            sids_in_view = {e.session_id for e in app._audit_visible_cache}
+            assert sid_a not in sids_in_view
+            # sid_b ainda visivel (nao foi marcado)
+            assert sid_b in sids_in_view
+    _run(run())
+
+
+def test_esc_limpa_marcas_quando_sem_prompt_ativo() -> None:
+    """#67-followup-5: Esc na aba Audit sem prompts ativos limpa marcas."""
+    async def run():
+        app = DashboardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause(0.3)
+            await pilot.press("5")
+            await pilot.pause(0.3)
+
+            app._audit_marked.add("any-key-1")
+            app._audit_marked.add("any-key-2")
+            assert len(app._audit_marked) == 2
+
+            await pilot.press("escape")
+            await pilot.pause(0.2)
+
+            assert len(app._audit_marked) == 0
+    _run(run())
+
+
 def test_clear_marks_and_refresh() -> None:
     """_clear_marks_and_refresh esvazia o set."""
     async def run():


### PR DESCRIPTION
Quando user marca entry com Space, sessão toda some da view → workflow cross-session compare fica trivial. Esc cancela e restaura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)