### PR TITLE
fix(audit): tolerar PermissionError em _detect_state apos usermod -aG

### DIFF
--- a/src/claude_dash/audit/setup.py
+++ b/src/claude_dash/audit/setup.py
@@ -218,7 +218,7 @@ def _detect_state() -> State:
     s.rsyslog_conf_exists = RSYSLOG_CONF.is_file()
     s.logrotate_sys_exists = LOGROTATE_SYS_CONF.is_file()
     s.var_log_dir_exists = VAR_LOG_DIR.is_dir()
-    s.var_log_file_exists = VAR_LOG_FILE.is_file()
+    s.var_log_file_exists = _safe_is_file(VAR_LOG_FILE)
 
     # #52: estado do grupo claude-audit
     s.claude_audit_group_exists = _claude_audit_group_exists()
@@ -257,18 +257,38 @@ def _user_in_claude_audit_group() -> bool:
         return False
 
 
+def _safe_is_file(path: Path) -> bool:
+    """is_file() tolerante a PermissionError no diretorio pai.
+
+    Necessario porque setup-audit roda *justamente* na transicao em que
+    o usuario foi adicionado ao grupo `claude-audit` mas a sessao ainda
+    nao carregou o grupo (usermod -aG so afeta novas sessoes). Sem isso,
+    stat() em /var/log/claude/tools.log falha com EACCES (parent dir
+    tem o-x=---) e o detector de estado crasha — deadlock: a ferramenta
+    que diagnosticaria o problema nao roda porque o problema existe.
+    Trata permission denied como "estado desconhecido = False": no pior
+    caso, setup-audit re-executa acoes idempotentes.
+    """
+    try:
+        return path.is_file()
+    except PermissionError:
+        return False
+
+
 def _var_log_owned_by_claude_audit() -> bool:
     """True se /var/log/claude/tools.log tem grupo `claude-audit`.
 
     Permite distinguir cenario "post-migration completo" de "ainda em adm
     porque rsyslog nao foi reiniciado" e similar. False quando arquivo
-    nao existe ainda.
+    nao existe ainda OU quando nao temos permissao para statar (mesma
+    motivacao de _safe_is_file).
     """
-    if not VAR_LOG_FILE.is_file():
+    try:
+        st = VAR_LOG_FILE.stat()
+    except (FileNotFoundError, PermissionError):
         return False
     try:
         import grp
-        st = VAR_LOG_FILE.stat()
         return grp.getgrgid(st.st_gid).gr_name == CLAUDE_AUDIT_GROUP
     except (KeyError, OSError, ImportError):
         return False

--- a/tests/test_audit_setup.py
+++ b/tests/test_audit_setup.py
@@ -509,6 +509,43 @@ def test_var_log_owned_by_claude_audit_false_quando_arquivo_ausente(
     assert au._var_log_owned_by_claude_audit() is False
 
 
+def test_detect_state_tolera_permission_error_em_var_log_file(
+    tmp_path, monkeypatch,
+) -> None:
+    """Regression: setup-audit nao deve crashar quando /var/log/claude/tools.log
+    existe mas a sessao do usuario ainda nao carregou o grupo claude-audit
+    (parent dir tem o-x=---). Esse e justamente o cenario em que `setup-audit`
+    precisa rodar para orientar o usuario a fazer `newgrp claude-audit`."""
+    _patch_paths(monkeypatch, tmp_path)
+
+    class _StubPath:
+        def is_file(self):
+            raise PermissionError(13, "Permission denied")
+        def stat(self):
+            raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(au, "VAR_LOG_FILE", _StubPath())
+    state = au._detect_state()
+    assert state.var_log_file_exists is False
+    assert state.var_log_owned_by_claude_audit is False
+
+
+def test_safe_is_file_retorna_false_em_permission_error(tmp_path) -> None:
+    """_safe_is_file engole PermissionError (parent dir sem x para o usuario)."""
+    class _StubPath:
+        def is_file(self):
+            raise PermissionError(13, "Permission denied")
+    assert au._safe_is_file(_StubPath()) is False
+
+
+def test_safe_is_file_propaga_para_paths_normais(tmp_path) -> None:
+    """_safe_is_file delega para is_file() quando nao ha permission error."""
+    f = tmp_path / "x"
+    f.touch()
+    assert au._safe_is_file(f) is True
+    assert au._safe_is_file(tmp_path / "missing") is False
+
+
 def test_root_script_inclui_groupadd_e_chown(tmp_path, monkeypatch) -> None:
     _patch_paths(monkeypatch, tmp_path)
     body = au._root_setup_script()


### PR DESCRIPTION
## Summary

- `setup-audit` crashava com `PermissionError` em `/var/log/claude/tools.log` quando o usuário já tinha sido adicionado ao grupo `claude-audit` mas a sessão de shell ainda não havia recarregado os grupos suplementares (`usermod -aG` só afeta novas sessões).
- Esse é justamente o cenário em que `setup-audit` precisa rodar para orientar o próximo passo (`newgrp claude-audit`) — deadlock: a ferramenta de diagnóstico não roda porque o problema existe.
- Helper novo `_safe_is_file()` + ajuste em `_var_log_owned_by_claude_audit()` engolem `PermissionError` e tratam como "estado desconhecido = False". Sem regressão: no pior caso `setup-audit` re-executa ações idempotentes do plano `partial`.

## Repro

Em RET-DTI-601048 (Linux), com `claude-audit` já criado mas sessão antiga:

```
$ claude-dash setup-audit
PermissionError: [Errno 13] Permission denied: '/var/log/claude/tools.log'
  at setup.py:221  (VAR_LOG_FILE.is_file())
```

`/var/log/claude` tinha perms `rwxr-x---` (owner=`syslog`, group=`claude-audit`, other=`---`); sessão atual ainda sem o grupo carregado em `os.getgroups()`.

## Test plan

- [x] `uv run pytest tests/test_audit_setup.py` — 29 passing (3 testes novos)
- [x] `uv run pytest -q` — 408 passing
- [x] `uv run ruff check` — clean
- [x] Smoke test em RET-DTI-601048: `claude-dash setup-audit --dry-run` agora reporta `Modo: PARTIAL` corretamente em vez de crashar; mostra `user no grupo: nao` orientando ao próximo passo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)